### PR TITLE
custom plugin dependencies

### DIFF
--- a/bin/haraka
+++ b/bin/haraka
@@ -154,6 +154,7 @@ else if (parsed.help) {
 else if (parsed['configs']) {
     
     process.env.HARAKA = parsed['configs'];
+    require.paths.unshift(path.join(process.env.HARAKA, 'node_modules'));
     
     var logger = require(path.join(base, 'logger'))
         server = require(path.join(base, 'server'));


### PR DESCRIPTION
i'm writing some custom plugins but they have dependencies on packages i don't want to install globally ( i don't think they should be ). unfortunately, this means node can't find them ( them being the deps i'm requiring ). i'd like to just put a `package.json` inside the folder i installed haraka's configs / plugins to and `npm install` them to a `node_modules` beside `plugins` and `config`.

this seems to work and keeps things clean. it was the best i could come up with according to the way modules are resolved:
http://nodejs.org/docs/v0.3.1/api/modules.html#module_Resolving

of course, i could just add this line at the top of each of my plugins, but i thought it might become something canonical. other people will hopefully be writing custom plugins as well one day. what do you think?
