### PR TITLE
Fixed for plain text attachments being treated as mail bodies

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -72,6 +72,7 @@ Body.prototype.parse_headers = function (line) {
 Body.prototype.parse_start = function (line) {
     var ct = this.header.get_decoded('content-type') || 'text/plain';
     var enc = this.header.get_decoded('content-transfer-encoding') || '8bit';
+    var cd = this.header.get_decoded('content-disposition') || '';
     
     if (!enc.match(/^base64|quoted-printable|[78]bit$/i)) {
         logger.logerror("Invalid CTE on email: " + enc + ", using 8bit");
@@ -83,7 +84,7 @@ Body.prototype.parse_start = function (line) {
     this.decode_function = this["decode_" + enc];
     this.ct = ct;
     
-    if (/^text\//i.test(ct)) {
+    if (/^text\//i.test(ct) && !/^attachment/i.test(cd) ) {
         this.state = 'body';
     }
     else if (/^multipart\//i.test(ct)) {
@@ -92,7 +93,6 @@ Body.prototype.parse_start = function (line) {
         this.state = 'multipart_preamble';
     }
     else {
-        var cd = this.header.get_decoded('content-disposition') || '';
         var match = cd.match(/name\s*=\s*["']?([^'";]+)["']?/i);
         if (!match) {
             match = ct.match(/name\s*=\s*["']?([^'";]+)["']?/i);


### PR DESCRIPTION
I had some complaints that some users of my email attachment service were unable to process `.txt` and `.csv` files. This is because the `content-type` header on these files in `text/plain`, and that was the only check used to determine if something was a `body` as opposed to an `attachment`. This is a fix that ensures a body is only treated as such if the `content-disposition` header is not `attachment`.
