### PR TITLE
Content-transfer-encoding header -> decode_function fix.

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -79,7 +79,7 @@ Body.prototype.parse_start = function (line) {
         enc = '8bit';
     }
     enc = enc.replace(/^quoted-printable$/i, 'qp');
-    enc = enc.toLowerCase();
+    enc = enc.toLowerCase().split("\n").pop().trim();
     
     this.decode_function = this["decode_" + enc];
     this.ct = ct;


### PR DESCRIPTION
Another small fix here. In my production application, I was occasionally getting some critical errors from `mailbody.js` saying that the `decode_function` was not a function. After doing some digging, I discovered that, for some edge-case emails, the `content-transfer-encoding` header was getting stored in `mailheader.js` twice. For example, some weird emails would store the `content-transfer-encoding` as `["base64", "base64"]`. Then, later on in line 74 of `mailbody.js`,

`var enc = this.header.get_decoded('content-transfer-encoding') || '8bit';`

when the header was fetched, it was returning `"base64\nbase64"`, due to the way the way the `get_decoded` function joins an array of values for a header with `\n`. So when `mailbody.js` tried to assign the `decode_function` for the body, it would attempt to assign it to `this.decode_base64\nbase64` or `this.decode_bin_base64\nbase64`, which obviously don't exist. So this small change normalizes the case where there might be multiple values stored for a `content-transfer-encoding`.
