### PR TITLE
Allow plugins to optionally supply an SMTP reply code

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -15,7 +15,7 @@ var outbound    = require('./outbound');
 var version  = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'))).version;
 
 var line_regexp = /^([^\n]*\n)/;
-var msg_regexp = /^(\d{3})\s+(.+)$/;
+var msg_regexp = /^([245]\d{2})\s+(.+)$/;
 
 var connection = exports;
 


### PR DESCRIPTION
Hi Matt,

Thanks for Haraka - I've just started playing with it and really like it so far.

This pull request is for a trivial patch to allow a plugin to optionally specify an SMTP reply code to be used instead of the default.  e.g. return next(DENY, '502 EHLO not allowed from your host');

Useful for some plug-ins e.g. greylisting where the original papers proved that 451 is better handled than 450 at RCPT (gawd knows why!!...).

Cheers,
Steve.
