### PR TITLE
This is a change to the smtp_proxy plugin that implements back-end

### DIFF
--- a/config/smtp_proxy.ini
+++ b/config/smtp_proxy.ini
@@ -1,2 +1,3 @@
 host=localhost
 port=2555
+timeout=30

--- a/docs/plugins/queue/smtp_proxy.md
+++ b/docs/plugins/queue/smtp_proxy.md
@@ -27,5 +27,11 @@ Configuration
     
     The port to connect to.
 
+  * timeout=SECONDS
+    
+    The amount of seconds to let a backend connection live idle in the
+    proxy pool.  This should always be less than the global plugin timeout,
+    which should in turn be less than the connection timeout.
+
   Both values are required.
   

--- a/plugins/queue/smtp_proxy.js
+++ b/plugins/queue/smtp_proxy.js
@@ -7,22 +7,136 @@ var sock = require('./line_socket');
 
 var smtp_regexp = /^([0-9]{3})([ -])(.*)/;
 
+// Local function to get an smtp_proxy connection.
+// This function will either choose one from the pool or make new one.
+function _get_smtp_proxy(self, next, connection) {
+    var smtp_proxy = {};
+
+    if (connection.server.notes.smtp_proxy_pool &&
+        connection.server.notes.smtp_proxy_pool.length) {
+        self.logdebug("using connection from the pool: (" +
+            connection.server.notes.smtp_proxy_pool.length + ")");
+
+        smtp_proxy = connection.server.notes.smtp_proxy_pool.shift();
+
+        // We should just reset these things when we shift a connection off
+        // since we have to setup stuff based on _this_ connection.
+        smtp_proxy.response = [];
+        smtp_proxy.recipient_marker = 0;
+        smtp_proxy.pool_connection = 1;
+        connection.notes.smtp_proxy = smtp_proxy;
+        smtp_proxy.next = next;
+
+        // Cleanup all old event listeners
+        // Note, if new ones are added in the mail from handler,
+        // please remove them here.
+        smtp_proxy.socket.removeAllListeners('error');
+        smtp_proxy.socket.removeAllListeners('timeout');
+        smtp_proxy.socket.removeAllListeners('close');
+        smtp_proxy.socket.removeAllListeners('connect');
+        smtp_proxy.socket.removeAllListeners('line');
+        smtp_proxy.socket.removeAllListeners('drain');
+    } else {
+        smtp_proxy.config = self.config.get('smtp_proxy.ini', 'ini');
+        smtp_proxy.socket = new sock.Socket();
+        smtp_proxy.socket.connect(smtp_proxy.config.main.port,
+            smtp_proxy.config.main.host);
+        smtp_proxy.socket.setTimeout((smtp_proxy.config.main.timeout) ?
+            (smtp_proxy.config.main.timeout * 1000) : (300 * 1000));
+        smtp_proxy.command = 'connect';
+        smtp_proxy.response = [];
+        smtp_proxy.recipient_marker = 0;
+        smtp_proxy.pool_connection = 0;
+        connection.notes.smtp_proxy = smtp_proxy;
+        smtp_proxy.next = next;
+    }
+
+    if (connection.server.notes.active_proxy_conections >= 0) {
+        connection.server.notes.active_proxy_conections++;
+    } else {
+        connection.server.notes.active_proxy_conections = 1;
+    }
+
+    self.logdebug("active proxy connections: (" +
+        connection.server.notes.active_proxy_conections + ")");
+
+    return smtp_proxy;
+}
+
+// function will destroy an smtp_proxy and pull it out of the idle array
+function _destroy_smtp_proxy(self, connection, smtp_proxy) {
+    var reset_active_connections = 0;
+    var index;
+
+    if (smtp_proxy && smtp_proxy.socket) {
+        self.logdebug("destroying proxy connection");
+        smtp_proxy.socket.destroySoon();
+        smtp_proxy.socket = 0;
+        reset_active_connections = 1;
+    }
+
+    // Unlink the connection from the proxy just in case we got here
+    // without that happening already.
+    if (connection && connection.notes.smtp_proxy) {
+        delete connection.notes.smtp_proxy;
+    }
+
+    if (connection.server.notes.smtp_proxy_pool) {
+        // Pull that smtp_proxy from the proxy pool.
+        // Note we do not do this operation that often.
+        index = connection.server.notes.smtp_proxy_pool.indexOf(smtp_proxy);
+        if (index != -1) {
+            connection.server.notes.smtp_proxy_pool.splice(index, 1);
+            self.logdebug("pulling dead proxy connection from pool: (" +
+                connection.server.notes.smtp_proxy_pool.length + ")");
+        }
+    }
+
+    if (reset_active_connections) {
+        connection.server.notes.active_proxy_conections--;
+        self.logdebug("active proxy connections: (" +
+            connection.server.notes.active_proxy_conections + ")");
+    }
+
+    return;
+}
+
+function _smtp_proxy_idle(self, connection) {
+    var smtp_proxy = connection.notes.smtp_proxy;
+
+    if (!(smtp_proxy)) {
+        return;
+    }
+
+    if (connection.server.notes.smtp_proxy_pool) {
+        connection.server.notes.smtp_proxy_pool.push(smtp_proxy);
+    } else {
+        connection.server.notes.smtp_proxy_pool = [ smtp_proxy ];
+    }
+
+    connection.server.notes.active_proxy_conections--;
+
+    self.logdebug("putting proxy connection back in pool: (" +
+        connection.server.notes.smtp_proxy_pool.length + ")");
+    self.logdebug("active proxy connections: (" +
+        connection.server.notes.active_proxy_conections + ")");
+
+    // Unlink this connection from the proxy now that it is back
+    // in the pool.
+    if (connection && connection.notes.smtp_proxy) {
+        delete connection.notes.smtp_proxy;
+    }
+
+    return;
+}
+
 exports.hook_mail = function (next, connection, params) {
     this.loginfo("smtp proxying");
-    var mail_from = params[0];
-    var smtp_proxy = {};
-    smtp_proxy.config = this.config.get('smtp_proxy.ini', 'ini');
-    smtp_proxy.socket = new sock.Socket();
-    smtp_proxy.socket.connect(smtp_proxy.config.main.port, smtp_proxy.config.main.host);
-    smtp_proxy.socket.setTimeout(300 * 1000); // 5m timeout
     var self = this;
-    smtp_proxy.command = 'connect';
-    smtp_proxy.response = [];
+    var mail_from = params[0];
     var data_marker = 0;
-    smtp_proxy.recipient_marker = 0;
-    connection.transaction.notes.smtp_proxy = smtp_proxy;
-    smtp_proxy.next = next;
-    
+    var smtp_proxy = _get_smtp_proxy(self, next, connection);
+
     smtp_proxy.send_data = function () {
         if (data_marker < connection.transaction.data_lines.length) {
             var wrote_all = smtp_proxy.socket.write(connection.transaction.data_lines[data_marker].replace(/^\./, '..').replace(/\r?\n/g, '\r\n'));
@@ -35,24 +149,25 @@ exports.hook_mail = function (next, connection, params) {
             smtp_proxy.socket.send_command('dot');
         }
     }
-    
+
+    // Add socket event listeners.    
+    // Note, if new ones are added here, please remove them in _get_smtp_proxy.
+
     smtp_proxy.socket.on('error', function (err) {
-        self.logerror("Ongoing connection failed: " + err);
-        smtp_proxy.socket.destroy();
-        if (connection.transaction)
-            delete connection.transaction.notes.smtp_proxy;
-        // we don't deny on error - maybe another plugin can deliver
-        smtp_proxy.next();
+        self.logdebug("Ongoing connection failed: " + err);
+        _destroy_smtp_proxy(self, connection, smtp_proxy);
     });
 
     smtp_proxy.socket.on('timeout', function () {
-        self.logerror("Ongoing connection timed out");
-        smtp_proxy.socket.destroy();
-        if (connection.transaction)
-            delete connection.transaction.notes.smtp_proxy;
-        smtp_proxy.next();
+        self.logdebug("Ongoing connection timed out");
+        _destroy_smtp_proxy(self, connection, smtp_proxy);
     });
     
+    smtp_proxy.socket.on('close', function (had_error) {
+        self.logdebug("Ongoing connection closed");
+        _destroy_smtp_proxy(self, connection, smtp_proxy);
+    });
+
     smtp_proxy.socket.on('connect', function () {});
     
     smtp_proxy.socket.send_command = function (cmd, data) {
@@ -77,30 +192,43 @@ exports.hook_mail = function (next, connection, params) {
                 if (code.match(/^[45]/)) {
                     if (smtp_proxy.command !== 'rcpt') {
                         // errors are OK for rcpt, but nothing else
-                        smtp_proxy.socket.send_command('QUIT');
-                        smtp_proxy.command = 'quit';
+                        // this can also happen if the destination server
+                        // times out, but that is okay.
+                        smtp_proxy.socket.send_command('RSET');
                     }
-                    return smtp_proxy.next(code.match(/^4/) ? DENYSOFT : DENY, smtp_proxy.response);
+                    return smtp_proxy.next(code.match(/^4/) ?
+                        DENYSOFT : DENY, smtp_proxy.response);
                 }
-                smtp_proxy.response = []; // reset the response now we're done with it
+
+                smtp_proxy.response = []; // reset the response
+
                 switch (smtp_proxy.command) {
                     case 'connect':
-                        smtp_proxy.socket.send_command('HELO', self.config.get('me'));
+                        smtp_proxy.socket.send_command('HELO',
+                            self.config.get('me'));
                         break;
                     case 'helo':
-                        smtp_proxy.socket.send_command('MAIL', 'FROM:' + mail_from);
+                        smtp_proxy.socket.send_command('MAIL',
+                            'FROM:' + mail_from);
                         break;
                     case 'mail':
-                        return smtp_proxy.next();
+                        smtp_proxy.next();
+                        break;
                     case 'rcpt':
-                        return smtp_proxy.next();
+                        smtp_proxy.next();
+                        break;
                     case 'data':
-                        return smtp_proxy.next();
+                        smtp_proxy.next();
+                        break;
                     case 'dot':
-                        smtp_proxy.socket.send_command('QUIT');
-                        return smtp_proxy.next(OK);
-                    case 'quit':
-                        smtp_proxy.socket.destroySoon();
+                        smtp_proxy.socket.send_command('RSET');
+                        smtp_proxy.next(OK);
+                        break;
+                    case 'rset':
+                        _smtp_proxy_idle(self, connection);
+                        // We do not call next() here because many paths
+                        // lead to this conclusion, and next() is called
+                        // on a case-by-case basis.
                         break;
                     default:
                         throw "Unknown command: " + smtp_proxy.command;
@@ -110,36 +238,49 @@ exports.hook_mail = function (next, connection, params) {
         else {
             // Unrecognised response.
             self.logerror("Unrecognised response from upstream server: " + line);
-            smtp_proxy.socket.destroy();
+            smtp_proxy.socket.send_command('RSET');
             return smtp_proxy.next(DENYSOFT);
         }
     });
+
     smtp_proxy.socket.on('drain', function() {
         self.logprotocol("Drained");
         if (smtp_proxy.command === 'dot') {
             smtp_proxy.send_data();
         }
     });
+
+    if (smtp_proxy.pool_connection) {
+        smtp_proxy.socket.send_command('MAIL', 'FROM:' + mail_from);
+    }
 };
 
 exports.hook_rcpt_ok = function (next, connection, recipient) {
-    if (!connection.transaction.notes.smtp_proxy) return next();
-    var smtp_proxy = connection.transaction.notes.smtp_proxy;
+    if (!connection.notes.smtp_proxy) return next();
+    var smtp_proxy = connection.notes.smtp_proxy;
     smtp_proxy.next = next;
     smtp_proxy.socket.send_command('RCPT', 'TO:' + recipient);
 };
 
 exports.hook_data = function (next, connection) {
-    if (!connection.transaction.notes.smtp_proxy) return next();
-    var smtp_proxy = connection.transaction.notes.smtp_proxy;
+    if (!connection.notes.smtp_proxy) return next();
+    var smtp_proxy = connection.notes.smtp_proxy;
     smtp_proxy.next = next;
     smtp_proxy.socket.send_command("DATA");
 };
 
 exports.hook_queue = function (next, connection) {
-    if (!connection.transaction.notes.smtp_proxy) return next();
-    var smtp_proxy = connection.transaction.notes.smtp_proxy;
+    if (!connection.notes.smtp_proxy) return next();
+    var smtp_proxy = connection.notes.smtp_proxy;
     smtp_proxy.command = 'dot';
     smtp_proxy.next = next;
     smtp_proxy.send_data();
+};
+
+exports.hook_quit = function (next, connection) {
+    if (!connection.notes.smtp_proxy) return next();
+    var smtp_proxy = connection.notes.smtp_proxy;
+    smtp_proxy.next = next;
+    smtp_proxy.socket.send_command("RSET");
+    smtp_proxy.next(OK);
 };


### PR DESCRIPTION
connection pooling to the destination server.  It has been running in
production for two weeks on dod.net, and does appear to be stable.

Squashed commit of the following:

commit a7a23e9ff9ab5f8314fb062acb3d0ec7b36d899e
Merge: 1d91f0e 8a4e623
Author: Christopher Mooney chris@dod.net
Date:   Wed Sep 7 11:30:41 2011 -0700

```
Merge remote branch 'upstream/master' into queue_smtp_proxy
```

commit 1d91f0edbeed712e9244db3202cc81eb1bd9ecd4
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 18:31:02 2011 -0700

```
This is the better way to print this.
```

commit 379938bfd4587585c442d1db379f8ad9048aea6f
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 18:28:40 2011 -0700

```
Make the pool tracking a bit better.
```

commit a33bc63758254ae69ac5c87d6dfbfab67632a602
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 18:18:47 2011 -0700

```
just making the timeout documentation more clear.
```

commit 913f1dbb965ba2c0780abbda7f2299cf22e809d1
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 18:16:55 2011 -0700

```
better active proxy connection tracking.
```

commit 4f2ea9d1480a758d8f178d615e1ee1f42a07bb46
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 17:25:48 2011 -0700

```
making the proxy connection print the same.
```

commit 1ee07a86ed77f494fc10b40189f39d34ff7be09d
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 15:51:56 2011 -0700

```
need to learn to count.
```

commit b3c545b1f5075b27d644c1539a7a620ba9d09e55
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 15:50:11 2011 -0700

```
on destroy, if we are pulling something from the pool, we need to
decrement the active connection counter.
```

commit 3071fec5b6720dc54e52e9840dcecb1d7ee7d2f3
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 15:40:40 2011 -0700

```
this should prime our active connections value a bit better.
```

commit 45bb482e6455566352deb2191cc9c1f5dbfaf4a2
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 15:27:27 2011 -0700

```
syntax error.
```

commit 4d3b1e8b7be4ee50a68ec5cc7c63118e898d1fd7
Merge: d6bba20 953ff1b
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 15:21:00 2011 -0700

```
Merge remote branch 'upstream/master' into queue_smtp_proxy
```

commit d6bba207b3b619c904789430735695f88cc4311e
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 31 15:20:29 2011 -0700

```
A little better logging.
```

commit 1b6e514cd9076d1ad21d2bbcf550f713ff808eaf
Author: Christopher Mooney chris@dod.net
Date:   Tue Aug 30 16:59:16 2011 -0700

```
adding some docs around the timeout value.
```

commit 779c041b100f457585a3118f619863e6f0dce8ab
Author: Christopher Mooney chris@dod.net
Date:   Tue Aug 30 16:47:11 2011 -0700

```
just being more clear about why we do not call next() here.
```

commit 148de77c44ebd363795ae246c31563e5e2625839
Author: Christopher Mooney chris@dod.net
Date:   Tue Aug 30 16:31:11 2011 -0700

```
This should solve the no next() in the case where the user sends the
QUIT.
```

commit 402b052665bc773ced24052b9087361728ebffcb
Merge: 81fb34d 4cc77df
Author: Christopher Mooney chris@dod.net
Date:   Tue Aug 30 11:46:53 2011 -0700

```
Merge remote branch 'upstream/master' into queue_smtp_proxy
```

commit 81fb34df2ea7dc0cc243ccd8d5538057daf85206
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 17:27:54 2011 -0700

```
I just want to see the pool size in the logs.
```

commit edb84d7717f3b6000692beec1cfaed4cde23214b
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 16:16:20 2011 -0700

```
Seems to make more sense for this to destroySoon() and flush write buffer.
```

commit 3874cbefa02ecba0f807345c0e7df8f0dd830579
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 15:54:39 2011 -0700

```
Okay, this should make debug output easier to read.
```

commit f34264b9ab1da8686ec87ce875f9ceab53772db7
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 15:45:45 2011 -0700

```
There may still be a few bugs, but this is almost the final state of
smtp proxy pooling.  Time to test.
```

commit 1b96a051e8200c806e9f877ab4460155cd5c409e
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 15:12:12 2011 -0700

```
This should make destruction from the pool much better.
It will also make pulling a new connection from the pool much cleaner.
```

commit ca4a1e9b2b341c9f14e9ea131c36e032907b7ae6
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 14:24:38 2011 -0700

```
This should cleanup some logging of ERROR.
```

commit e89f80bd1227e2e868528fd030eaea2088ad01fb
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 14:07:22 2011 -0700

```
remove old listeners for pooled connections.
```

commit dec0b00d5bfff6142fbde283e06102008edbb37d
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 13:50:29 2011 -0700

```
If we use a connection from the pool, we will need to send the mail from
command ourselves, since the pooled connection cannot be set off from
a banner.
```

commit ec89f47f05ab672b3db286c304ea134111d12b67
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 11:49:19 2011 -0700

```
Need to pass self for debug log.
```

commit 95b7cfaaa1a630cd1e78e40f690ff91251e43eac
Author: Christopher Mooney chris@dod.net
Date:   Fri Aug 26 11:46:01 2011 -0700

```
Fixed a bug in destroy connection, and put in some debugging.
```

commit 45166752835b71f48909f8dd6330d5723d31524b
Author: Christopher Mooney chris@dod.net
Date:   Thu Aug 25 11:18:40 2011 -0700

```
Fixed some syntax errors.
```

commit 3bd1e04fb2cb532d3ea941fe6f3cfe73f08a62f1
Author: Christopher Mooney chris@dod.net
Date:   Thu Aug 25 11:10:23 2011 -0700

```
one of the objects was still named the old name.
```

commit a89e7d0c9b135882b4b3084ca1e72897eff29de1
Author: Christopher Mooney chris@dod.net
Date:   Wed Aug 24 18:54:58 2011 -0700

```
First pass at pooled proxy connections.
```
