### PR TITLE
Always send SIZE capability

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -377,9 +377,7 @@ Connection.prototype.ehlo_respond = function(retval, msg) {
                                 ];
                 
                 var databytes = config.get('databytes', 'nolog');
-                if (databytes) {
-                    response.push("SIZE " + databytes);
-                }
+                response.push("SIZE " + databytes || 0);
                 
                 this.capabilities = response;
                 


### PR DESCRIPTION
Real trivial patch to send 'SIZE 0' if databytes is not set.

This is useful if you want to allow for per-domain/per-recipient message size limits as RFC1653 states:

A parameter value of 0 (zero) indicates that no fixed maximum message size is in force.

This will cause capable clients to send MAIL FROM:<...> SIZE=... which can then be checked against the limits in hook_rcpt.
