### PR TITLE
Make the console global object available in the plugin context to bring t

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -140,6 +140,7 @@ plugins.load_plugin = function(name) {
         setInterval: setInterval,
         clearInterval: clearInterval,
         process: process,
+        console: console
         Buffer: Buffer
     };
     try {


### PR DESCRIPTION
Make the console global object available in the plugin context to bring them closer to looking like modules.
