### PR TITLE
Make plugins that end in .mod.js be loaded as modules instead of through 

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -113,10 +113,11 @@ plugins.load_plugin = function(name) {
     
     var plugin = new Plugin(name);
     var fp = plugin.full_paths,
-        rf, last_err;
+        rf, last_err, plugin_file;
     for (var i=0, j=fp.length; i<j; i++) {
         try {
             rf = fs.readFileSync(fp[i]);
+            plugin_file = fp[i];
             break;
         }
         catch (err) {
@@ -143,7 +144,13 @@ plugins.load_plugin = function(name) {
         Buffer: Buffer
     };
     try {
-        vm.runInNewContext(code, sandbox, name);
+        if (/\.mod$/.test(name)) {
+            var pluginModule = require(plugin_file);
+            for (var k in pluginModule) if (pluginModule.hasOwnProperty(k)) plugin[k] = pluginModule[k];
+        }
+        else {
+            vm.runInNewContext(code, sandbox, name);
+        }
     }
     catch (err) {
         if (config.get('smtp.ini', 'nolog', 'ini').main.ignore_bad_plugins) {


### PR DESCRIPTION
This patch makes it so that if you create a module that ends in .mod.js then it is loaded through require() instead of through the vm. Loading through require has many advantages, notably if your plugin needs to require() its own dependencies, and is less surprising. It has the downside that a few things such as the constants are not predefined for you.

I would have suggested to move everything to using require(), but this would break essentially every plugin written to date. The idea behind this patch is to create a convention that allows for both approaches to live side by side.
