### PR TITLE
Utility to make constants importable into a given context

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -7,3 +7,11 @@ exports.denysoft        = 903;
 exports.denydisconnect  = 904;
 exports.disconnect      = 905;
 exports.ok              = 906;
+
+exports.import = function (object) {
+    for (var k in exports) {
+        if (exports.hasOwnProperty(k) && k !== "import") {
+            object[k.toUpperCase()] = exports[k];
+        }
+    }
+}

--- a/plugins.js
+++ b/plugins.js
@@ -103,11 +103,6 @@ plugins.load_plugins = function () {
     plugins.plugin_list = plugin_list.map(plugins.load_plugin);
 };
 
-var constants_str = "";
-for (var con in constants) {
-    constants_str += "var " + con.toUpperCase() + " = " + constants[con] + "; ";
-}
-
 plugins.load_plugin = function(name) {
     logger.loginfo("Loading plugin: " + name);
     
@@ -131,7 +126,7 @@ plugins.load_plugin = function(name) {
         }
         throw "Loading plugin " + name + " failed: " + last_err;
     }
-    var code = constants_str + rf;
+    var code = rf;
     var sandbox = { 
         require: require,
         exports: plugin,
@@ -142,6 +137,7 @@ plugins.load_plugin = function(name) {
         process: process,
         Buffer: Buffer
     };
+    constants.import(sandbox);
     try {
         vm.runInNewContext(code, sandbox, name);
     }


### PR DESCRIPTION
Utility to make constants importable into a given context; application of said utility to loading the constants in plugin context.

This is slightly cleaner than code generation for plugins done in the old way, but more usefully it means that properly required plugins can call require("Haraka/constants").import(global) and get the same constants.
