### PR TITLE
Change listen_asdress to listen_host config parameter

### DIFF
--- a/config/smtp.ini
+++ b/config/smtp.ini
@@ -2,7 +2,7 @@
 port=25
 
 ; address to listen on (default: all addresses)
-;listen_address=0.0.0.0
+;listen_host=0.0.0.0
 
 ; Time in seconds to let sockets be idle with no activity
 ;inactivity_timeout=300


### PR DESCRIPTION
Small fix for listening host parameter in the smtp.ini
Current one is ignored if uncommented und changed.
