### PR TITLE
Enable configuring auth users with login like email

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -5,7 +5,7 @@ var fs = require('fs');
 // for "ini" type files
 var regex = {
     section: /^\s*\[\s*([^\]]*)\s*\]\s*$/,
-    param:   /^\s*(\w+)\s*=\s*(.*)\s*$/,
+    param:   /^\s*([\w@\._]+)\s*=\s*(.*)\s*$/,
     comment: /^\s*[;#].*$/,
     line:    /^\s*(.*)\s*$/,
     blank:   /^\s*$/


### PR DESCRIPTION
Current ini config file parser doesnt allow email like user logins to be set.

```
 [users]
 test@domain.com=password
```
