### PR TITLE
Cleanup receiver line, populate authentification info

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -633,8 +633,8 @@ Connection.prototype.received_line = function() {
     var smtp = this.greeting === 'EHLO' ? 'ESMTP' : 'SMTP';
     // TODO - populate authheader and sslheader - see qpsmtpd for how to.
     return  "from " + this.remote_info
-           +" (HELO " + this.hello_host + ") ("+this.remote_ip
-           +")\n  " + (this.authheader || '') + "  by " + config.get('me', 'nolog')
+           +" (" + this.hello_host + " ["+this.remote_ip
+           +"])\n  " + (this.authheader || '') + "  by " + config.get('me', 'nolog')
            +" (Haraka/" + version
            +") with " + (this.sslheader || '') + smtp + "; "
            + _date_to_str(new Date());

--- a/plugins/auth/flat_file.js
+++ b/plugins/auth/flat_file.js
@@ -49,6 +49,7 @@ exports.check_user = function (next, connection, credentials) {
     if (hmac_pw === credentials[1]) {
         connection.relaying = 1;
         connection.respond(235, "Authentication successful");
+        connection.authheader = "(authenticated bits=0)\n";
     }
     else {
         connection.respond(535, "Authentication failed");


### PR DESCRIPTION
Compared "Receiver" line from Hanaka, Googlemail and sendmail. Changed it to be more similare in ehlo info.

Also added auth info population to it.
