### PR TITLE
Fix connection.respond when messages is an array

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -183,7 +183,7 @@ Connection.prototype.respond = function(code, messages) {
         code = messages.code;
         messages = messages.reply;
     }
-    if (!(typeof messages === 'object' && messages.constructor === Array)) {
+    if (!(typeof messages === 'object' && messages.constructor.name === 'Array')) {
         // messages not an array, make it so:
         messages = [ '' + messages ];
     }


### PR DESCRIPTION
Currently - this will not work as expected:

var output = [];  # or var output = new Array;
output.push('foo');
output.push('bar');
connection.respond(220, output);
return next(OK);

This would return:
220 foo,bar

After this patch:
220-foo
220 bar
