### PR TITLE
This plugin will evaluate the remote IP address and the remote rDNS hostname.

### DIFF
--- a/config/connect.rdns_access.blacklist
+++ b/config/connect.rdns_access.blacklist
@@ -1,0 +1,1 @@
+# Hostnames and IPs are matched exactly as written on each line.

--- a/config/connect.rdns_access.blacklist_regex
+++ b/config/connect.rdns_access.blacklist_regex
@@ -1,0 +1,5 @@
+# Does the same thing as the blacklist file, but each line is a regex.
+# Each line is also anchored for you, meaning '^' + regex + '$' is added for
+# you.  If you need to get around this restriction, you may use a '.*' at
+# either the start or the end of your regex.  This should help prevent people
+# from writing overly permissive rules on accident.

--- a/config/connect.rdns_access.ini
+++ b/config/connect.rdns_access.ini
@@ -1,0 +1,2 @@
+[general]
+deny_msg=Connection rejected.

--- a/config/connect.rdns_access.whitelist
+++ b/config/connect.rdns_access.whitelist
@@ -1,0 +1,1 @@
+# Hostnames and IPs are matched exactly as written on each line.

--- a/config/connect.rdns_access.whitelist_regex
+++ b/config/connect.rdns_access.whitelist_regex
@@ -1,0 +1,5 @@
+# Does the same thing as the whitelist file, but each line is a regex.
+# Each line is also anchored for you, meaning '^' + regex + '$' is added for
+# you.  If you need to get around this restriction, you may use a '.*' at
+# either the start or the end of your regex.  This should help prevent people
+# from writing overly permissive rules on accident.

--- a/docs/plugins/connect.rdns_access.md
+++ b/docs/plugins/connect.rdns_access.md
@@ -1,0 +1,55 @@
+connect.rdns_access
+===================
+
+This plugin will evaluate the remote IP address and the remote rDNS hostname
+against a set of white and black lists.  The lists are applied in the following
+way:
+
+connect.rdns_access.whitelist         (pass)
+connect.rdns_access.whitelist_regex   (pass)
+connect.rdns_access.blacklist         (block)
+connect.rdns_access.blacklist_regex   (block)
+
+Configuration connect.rdns_access.ini
+-------------------------------------
+
+General configuration file for this plugin.
+
+* connect.rdns_access.general.deny_msg
+
+  Text to send the user on reject (text).
+
+
+Configuration connect.rdns_access.whitelist
+-------------------------------------------
+
+The whitelist is mostly to counter blacklist entries that match more than
+what one would want.  This file should be used for a specific IP address
+or rDNS hostnames, one per line, that should bypass blacklist checks.
+NOTE: We heavily suggest tailoring blacklist entries to be as accurate as
+possible and never using whitelists.  Nevertheless, if you need whitelists,
+here they are.
+
+Configuration connect.rdns_access.whitelist_regex
+-------------------------------------------------
+
+Does the same thing as the whitelist file, but each line is a regex.
+Each line is also anchored for you, meaning '^' + regex + '$' is added for
+you.  If you need to get around this restriction, you may use a '.*' at
+either the start or the end of your regex.  This should help prevent people
+from writing overly permissive rules on accident.
+
+Configuration connect.rdns_access.blacklist
+-------------------------------------------
+
+This file should be used for a specific IP address or rDNS hostnames, one
+per line, that should fail on connect.
+
+Configuration connect.rdns_access.blacklist_regex
+-------------------------------------------------
+
+Does the same thing as the blacklist file, but each line is a regex.
+Each line is also anchored for you, meaning '^' + regex + '$' is added for
+you.  If you need to get around this restriction, you may use a '.*' at
+either the start or the end of your regex.  This should help prevent people
+from writing overly permissive rules on accident.

--- a/plugins/connect.rdns_access.js
+++ b/plugins/connect.rdns_access.js
@@ -1,0 +1,112 @@
+// connect.rdns_access plugin
+
+exports.register = function() {
+    var config       = this.config.get('connect.rdns_access.ini', 'ini');
+    this.wl = this.config.get('connect.rdns_access.whitelist', 'list');
+    this.bl = this.config.get('connect.rdns_access.blacklist', 'list');
+    this.wlregex =
+      this.config.get('connect.rdns_access.whitelist_regex', 'list');
+    this.blregex =
+      this.config.get('connect.rdns_access.blacklist_regex', 'list');
+    this.deny_msg    = config.general && (config.general['deny_msg'] ||
+      'Connection rejected.');
+
+
+    this.register_hook('connect', 'rdns_access');
+}
+
+exports.rdns_access = function(next, connection) {
+    var plugin = this;
+
+    // IP whitelist checks
+    if (connection.remote_ip) {
+        plugin.logdebug('checking ' + connection.remote_ip +
+            ' against connect.rdns_access.whitelist');
+
+        if (_in_whitelist(plugin, connection.remote_ip.toLowerCase())) {
+            plugin.logdebug("Allowing " + connection.remote_ip);
+            return next();
+        }
+    }
+
+    // hostname whitelist checks
+    if (connection.remote_host) {
+        plugin.logdebug('checking ' + connection.remote_host +
+            ' against connect.rdns_access.whitelist');
+
+        if (_in_whitelist(plugin, connection.remote_host.toLowerCase())) {
+            plugin.logdebug("Allowing " + connection.remote_host);
+            return next();
+        }
+    }
+
+    // IP blacklist checks
+    if (connection.remote_ip) {
+        plugin.logdebug('checking ' + connection.remote_ip +
+            ' against connect.rdns_access.blacklist');
+
+        if (_in_blacklist(plugin, connection.remote_ip.toLowerCase())) {
+            plugin.logdebug("Rejecting " + connection.remote_ip);
+            return next(DENY, plugin.deny_msg);
+        }
+    }
+
+    // hostname blacklist checks
+    if (connection.remote_host) {
+        plugin.logdebug('checking ' + connection.remote_host +
+            ' against connect.rdns_access.blacklist');
+
+        if (_in_blacklist(plugin, connection.remote_host.toLowerCase())) {
+            plugin.logdebug("Rejecting " + connection.remote_host);
+            return next(DENY, plugin.deny_msg);
+        }
+    }
+}
+
+function _in_whitelist(plugin, host) {
+    var i;
+    for (i in plugin.wl) {
+        plugin.logdebug("checking " + host + " against " + plugin.wl[i]);
+
+        if (plugin.wl[i].toLowerCase() === host) {
+            return 1;
+        }
+    }
+
+    for (i in plugin.wlregex) {
+        plugin.logdebug("checking " + host + " against " +
+            plugin.wlregex[i]);
+
+        var regex = new RegExp ('^' + plugin.wlregex[i] + '$', 'i');
+
+        if (host.match(regex)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+function _in_blacklist(plugin, host) {
+    var i;
+    for (i in plugin.bl) {
+        plugin.logdebug("checking " + host + " against " + plugin.bl[i]);
+
+        if (plugin.bl[i].toLowerCase() === host) {
+            return 1;
+        }
+    }
+
+    for (i in plugin.blregex) {
+        plugin.logdebug("checking " + host + " against " +
+            plugin.blregex[i]);
+
+        var regex = new RegExp ('^' + plugin.blregex[i] + '$', 'i');
+
+        if (host.match(regex)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This plugin will evaluate the remote IP address and the remote rDNS hostname
against a set of white and black lists.  The lists are applied in the following
way:

connect.rdns_access.whitelist         (pass)
connect.rdns_access.whitelist_regex   (pass)
connect.rdns_access.blacklist         (block)
connect.rdns_access.blacklist_regex   (block)

Squashed commit of the following:

commit 53e04b08d9af07473cdb34ddbebda3320d735c03
Author: Christopher Mooney chris@dod.net
Date:   Tue Oct 4 16:03:54 2011 -0700

```
Custom DENY message.
```

commit 78462f6c82324217aae280784941375b642303dc
Author: Christopher Mooney chris@dod.net
Date:   Tue Oct 4 15:25:14 2011 -0700

```
The documentation for connect.rdns_access.
```

commit 8843af9239d9ded46a09be53e61399cc3c7c5c1a
Merge: cc40d24 d298cf7
Author: Christopher Mooney chris@dod.net
Date:   Tue Oct 4 13:17:35 2011 -0700

```
Merge remote branch 'origin/master' into godsflaw
```

commit cc40d24715743ee11ae78df8e890d4750169d386
Author: Christopher Mooney chris@dod.net
Date:   Tue Sep 27 17:40:09 2011 -0700

```
the start of the connect.rdns_access plugin.
```
