### PR TITLE
Fixed \r\n from appearing in logs.

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -30,7 +30,7 @@ logger.dump_logs = function () {
 }
 
 logger.log = function (level, data) {
-    data = data.replace(/\n?$/, "");
+    data = data.replace(/\r?\n/, "");
     // todo - just buffer these up (defer) until plugins are loaded
     if (plugins.plugin_list) {
         while (deferred_logs.length > 0) {


### PR DESCRIPTION
This is the fix for all logging to strip \r\n from anywhere in the string we talked about.
