### PR TITLE
Add missing on('end') event to server socket

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -38,20 +38,25 @@ for (var key in logger) {
     }
 }
 
-
 function setupClient(self) {
     self.remote_ip = self.client.remoteAddress;
     self.lognotice("got connection from: " + self.remote_ip);
-    
+
+    self.client.on('end', function () {
+        if (!self.disconnected) {
+            self.fail("client (" + self.remote_ip + ") closed connection");
+        }
+    });
+
     self.client.on('error', function (err) {
         if (!self.disconnected) {
-            self.fail("client closed with err: " + err);
+            self.fail("client (" + self.remote_ip + ") closed with err: " + err);
         }
     });
     
     self.client.on('timeout', function () {
         if (!self.disconnected) {
-            self.fail("client (" + self.client.fd + ") timed out");
+            self.fail("client (" + self.remote_ip + ") timed out");
         }
     });
     


### PR DESCRIPTION
I've been working on a 'stats' plugin that tracks each connected client and I noticed that if the remote host drops the connection without sending QUIT, Haraka never notices the disconnect.

I've also changed self.client.fd to self.remote_ip in the logged output of the other events as since the TLS changes self.client.fd is undefined.
