### PR TITLE
smtp_forward plugin fixes/enhancements

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -819,6 +819,7 @@ Connection.prototype.queue_outbound_respond = function(retval, msg) {
 Connection.prototype.queue_respond = function(retval, msg) {
     switch (retval) {
         case constants.ok:
+                this.respond(250, msg || "Message Queued");
                 plugins.run_hooks("queue_ok", this);
                 break;
         case constants.deny:
@@ -842,5 +843,4 @@ Connection.prototype.queue_respond = function(retval, msg) {
 
 Connection.prototype.queue_ok_respond = function (retval, msg) {
     this.reset_transaction();
-    this.respond(250, msg || "Message Queued");
 };

--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -28,6 +28,6 @@ Configuration
 
   Both values are required.
 
-  * disable_tls=[true|1]
+  * enable_tls=[true|yes|1]
 
-    Disables the use of TLS
+    Enable TLS with the forward host (if supported)


### PR DESCRIPTION
1)  Add fixes similar to smtp_proxy to address the on drain handler from making the client/server go out of sync.  This was less of a problem here than with smtp_proxy (e.g. it still worked), however it caused the client and server to go out of sync and the 'data' command handler would never run.

2)  Move the response to the client from queue_ok_respond back to queue_respond handler; this is so that a queue plugin can return a message back to the client.   I have changed smtp_forward to return the accept line back from the forward host and added our own transaction.uuid to the end of the string to aid debugging as both identifiers will be present in the senders logs. e.g.:

250 2.0.0 p9ILsnYM028628 Message accepted for delivery (10174387-4C51-44F9-BA40-086CD4F2F015.2)

3)  Invert the TLS logic as per smtp_proxy and change documentation to match.
