### PR TITLE
This should put the UUID on every line of the response.

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -181,6 +181,8 @@ Connection.prototype.current_line = function() {
 };
 
 Connection.prototype.respond = function(code, messages) {
+    var uuid = '';
+
     if (this.disconnected) {
         return;
     }
@@ -196,13 +198,14 @@ Connection.prototype.respond = function(code, messages) {
     }
 
     if (code >= 400 && this.deny_includes_uuid) {
-        messages.push("for support please provide uuid:" + (this.transaction || this).uuid);
+        uuid = (this.transaction || this).uuid;
     }
     
     var msg;
     var buf = '';
     while (msg = messages.shift()) {
-        var line = code + (messages.length ? "-" : " ") + msg;
+        var line = code + (messages.length ? "-" : " ") + 
+            (uuid ? '[' + uuid + '] ' : '' ) + msg;
         this.logprotocol("S: " + line);
         buf = buf + line + "\r\n";
     }


### PR DESCRIPTION
Since some MTAs are not so smart when it comes to reject messages, this should make it so both our message and the UUID is included on certain errors.
