### PR TITLE
Loggingchanges

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -25,7 +25,7 @@ for (var key in logger) {
     if (key.match(/^log\w/)) {
         Connection.prototype[key] = (function (key) {
             return function () {
-                var args = [ (this.transaction ? this.transaction.uuid : this.uuid) + " " ];
+                var args = [ "[" + (this.transaction ? this.transaction.uuid : this.uuid) + "] " ];
                 var start = 0;
                 if (arguments.length && arguments[0] instanceof plugins.Plugin) {
                     start = 1;

--- a/logger.js
+++ b/logger.js
@@ -86,17 +86,34 @@ for (key in logger) {
                 return function() {
                     if (loglevel < logger[key])
                         return;
-                    var str = "[" + level + "] ";
+                    var levelstr = "[" + level + "]";
+                    var str = "";
+                    var uuidstr = "[no_connection]";
+                    var pluginstr = "[haraka_core]";
                     for (var i = 0; i < arguments.length; i++) {
                         var data = arguments[i];
                         if (typeof(data) === 'object') {
-                            str += util.inspect(data);
+                            // if the object is a connection, we wish to add
+                            // the connection id
+                            if (("uuid" in data) && ("tran_count" in data)) {
+                                // this looks like a connection
+                                uuidstr = "[" + data.uuid;
+                                if (data.tran_count > 0) {
+                                  uuidstr += "." + data.tran_count;
+                                }
+                                uuidstr += "]";
+                            } else if (("name" in data) && ("full_paths" in data)) {
+                                // lame attempt to sniff this object as a plugin.
+                                pluginstr = "[" + data.name + "]"; 
+                            } else {
+                                str += util.inspect(data);
+                            }
                         }
                         else {
                             str += data;
                         }
                     }
-                    logger.log(level, str);
+                    logger.log(level, [levelstr, uuidstr, pluginstr, str].join(" "));
                 }
             })(level, key);
         }

--- a/plugins.js
+++ b/plugins.js
@@ -60,7 +60,7 @@ for (var key in logger) {
         // console.log("adding Plugin." + key + " method");
         Plugin.prototype[key] = (function (key) {
             return function () {
-                var args = ["[" + this.name + "] "];
+                var args = [this];
                 for (var i=0, l=arguments.length; i<l; i++) {
                     args.push(arguments[i]);
                 }

--- a/plugins/connect.rdns_access.js
+++ b/plugins/connect.rdns_access.js
@@ -29,10 +29,10 @@ exports.rdns_access = function(next, connection) {
     // IP whitelist checks
     if (connection.remote_ip) {
         plugin.logdebug('checking ' + connection.remote_ip +
-            ' against connect.rdns_access.whitelist');
+            ' against connect.rdns_access.whitelist', connection);
 
-        if (_in_whitelist(plugin, connection.remote_ip)) {
-            plugin.logdebug("Allowing " + connection.remote_ip);
+        if (_in_whitelist(plugin, connection.remote_ip, connection)) {
+            plugin.logdebug("Allowing " + connection.remote_ip, connection);
             return next();
         }
     }
@@ -40,10 +40,11 @@ exports.rdns_access = function(next, connection) {
     // hostname whitelist checks
     if (connection.remote_host) {
         plugin.logdebug('checking ' + connection.remote_host +
-            ' against connect.rdns_access.whitelist');
+            ' against connect.rdns_access.whitelist', connection);
 
-        if (_in_whitelist(plugin, connection.remote_host.toLowerCase())) {
-            plugin.logdebug("Allowing " + connection.remote_host);
+        if (_in_whitelist(plugin, connection.remote_host.toLowerCase(),
+            connection)) {
+            plugin.logdebug("Allowing " + connection.remote_host, connection);
             return next();
         }
     }
@@ -51,10 +52,11 @@ exports.rdns_access = function(next, connection) {
     // IP blacklist checks
     if (connection.remote_ip) {
         plugin.logdebug('checking ' + connection.remote_ip +
-            ' against connect.rdns_access.blacklist');
+            ' against connect.rdns_access.blacklist', connection);
 
         if (_in_blacklist(plugin, connection.remote_ip)) {
-            plugin.logdebug("Rejecting, matched: " + connection.remote_ip);
+            plugin.logdebug("Rejecting, matched: " + connection.remote_ip,
+                connection);
             return next(DENY, connection.remote_host.toLowerCase() + ' [' +
                 connection.remote_ip + '] ' + plugin.deny_msg);
         }
@@ -63,10 +65,11 @@ exports.rdns_access = function(next, connection) {
     // hostname blacklist checks
     if (connection.remote_host) {
         plugin.logdebug('checking ' + connection.remote_host +
-            ' against connect.rdns_access.blacklist');
+            ' against connect.rdns_access.blacklist', connection);
 
         if (_in_blacklist(plugin, connection.remote_host.toLowerCase())) {
-            plugin.logdebug("Rejecting, matched: " + connection.remote_host);
+            plugin.logdebug("Rejecting, matched: " + connection.remote_host,
+                connection);
             return next(DENY, connection.remote_host.toLowerCase() + ' [' +
                 connection.remote_ip + '] ' + plugin.deny_msg);
         }
@@ -75,10 +78,11 @@ exports.rdns_access = function(next, connection) {
     return next();
 }
 
-function _in_whitelist(plugin, host) {
+function _in_whitelist(plugin, host, connection) {
     var i;
     for (i in plugin.wl) {
-        plugin.logdebug('checking ' + host + ' against ' + plugin.wl[i]);
+        plugin.logdebug('checking ' + host + ' against ' +
+            plugin.wl[i], connection);
 
         if (plugin.wl[i].toLowerCase() === host) {
             return 1;
@@ -87,7 +91,7 @@ function _in_whitelist(plugin, host) {
 
     if (plugin.wlregex) {
         plugin.logdebug('checking ' + host + ' against ' +
-            plugin.wlregex.source);
+            plugin.wlregex.source, connection);
 
         if (host.match(plugin.wlregex)) {
             return 1;
@@ -97,10 +101,11 @@ function _in_whitelist(plugin, host) {
     return 0;
 }
 
-function _in_blacklist(plugin, host) {
+function _in_blacklist(plugin, host, connection) {
     var i;
     for (i in plugin.bl) {
-        plugin.logdebug('checking ' + host + ' against ' + plugin.bl[i]);
+        plugin.logdebug('checking ' + host + ' against ' +
+            plugin.bl[i], connection);
 
         if (plugin.bl[i].toLowerCase() === host) {
             return 1;
@@ -109,7 +114,7 @@ function _in_blacklist(plugin, host) {
 
     if (plugin.blregex) {
         plugin.logdebug('checking ' + host + ' against ' +
-            plugin.blregex.source);
+            plugin.blregex.source, connection);
 
         if (host.match(plugin.blregex)) {
             return 1;

--- a/plugins/dnsbl.js
+++ b/plugins/dnsbl.js
@@ -8,13 +8,13 @@ exports.register = function() {
 }
 
 exports.check_ip = function(next, connection) {
-    this.logdebug("check_ip: " + connection.remote_ip);
+    this.logdebug("check_ip: " + connection.remote_ip, connection);
     
     var ip = new String(connection.remote_ip);
     var reverse_ip = ip.split('.').reverse().join('.');
     
     if (!this.zones || !this.zones.length) {
-        this.logerror("No zones");
+        this.logerror("No zones", connection);
         return next();
     }
     
@@ -22,7 +22,7 @@ exports.check_ip = function(next, connection) {
     
     var self = this;
     this.zones.forEach(function(zone) {
-        self.logdebug("Querying: " + reverse_ip + "." + zone);
+        self.logdebug("Querying: " + reverse_ip + "." + zone, connection);
         dns.resolve(reverse_ip + "." + zone, "TXT", function (err, value) {
             if (!remaining_zones.length) return;
             remaining_zones.pop(); // we don't care about order really
@@ -33,7 +33,7 @@ exports.check_ip = function(next, connection) {
                     case 'ENOTFOUND':
                                         break;
                     default:
-                        self.loginfo("DNS error: " + err);
+                        self.loginfo("DNS error: " + err, connection);
                 }
                 if (remaining_zones.length === 0) {
                     // only call declined if no more results are pending

--- a/plugins/mail_from.is_resolvable.js
+++ b/plugins/mail_from.is_resolvable.js
@@ -21,7 +21,7 @@ exports.hook_mail = function(next, connection, params) {
     // Just in case DNS never comes back (UDP), we should DENYSOFT.
     timeout_id = setTimeout(function () {
         plugin.loginfo('timed out when looking up ' + domain +
-            '\'s MX record. Disconnecting.');
+            '\'s MX record. Disconnecting.'), connection;
         called_next++;
         return next(DENYSOFT, timeout_msg);
     }, timeout * 1000);
@@ -34,7 +34,7 @@ exports.hook_mail = function(next, connection, params) {
             return;
         }
         if (err && err.code != dns.NXDOMAIN && err.code != 'ENOTFOUND') {
-            plugin.logerror("DNS Error: " + err);
+            plugin.logerror("DNS Error: " + err, connection);
             clearTimeout(timeout_id);
             return next(DENYSOFT, "Temporary resolver error");
         }


### PR DESCRIPTION
   changes the way logging works.
   logline will always always be in the form:

```
 [level] [connection uuid] [origin] message
```

   where origin is "haraka_core" or the name of the plugin which
   triggered the message, and "connection uuid" is the ID of the
   connection associated with the message.

   when calling a log method on logger, you should provide the
   plugin object and the connection object anywhere in the arguments
   to the log method.

```
 logger.logdebug("i like turtles", plugin, connection);
```

   will yield, for example,

```
 [DEBUG] [7F1C820F-DC79-4192-9AA6-5307354B20A6] [dnsbl] i like turtles
```

   if you call the log method on the connection object, you can
   forego the connection as argument:

```
 connection.logdebug("turtles all the way down", plugin);
```

   and similarly for the log methods on the plugin object:

```
 plugin.logdebug("he just really likes turtles", connection);
```

   failing to provide a connection and/or plugin object will leave
   the default values in the log (currently "haraka_core" and
   "no_connection").

   currently this is implemented by testing for argument type in
   the logger.js log\* method. objects-as-arguments are then sniffed
   to try to determine if they're a connection or plugin instance.
