### PR TITLE
Various updates to connection methods

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,15 +1,16 @@
 "use strict";
 // Constants
 
-exports.cont            = 900;
-exports.stop            = 901;
-exports.deny            = 902;
-exports.denysoft        = 903;
-exports.denydisconnect  = 904;
-exports.disconnect      = 905;
-exports.ok              = 906;
-exports.next_hook       = 907;
-exports.delay           = 908;
+exports.cont               = 900;
+exports.stop               = 901;
+exports.deny               = 902;
+exports.denysoft           = 903;
+exports.denydisconnect     = 904;
+exports.disconnect         = 905;
+exports.ok                 = 906;
+exports.next_hook          = 907;
+exports.delay              = 908;
+exports.denysoftdisconnect = 909;
 
 exports.import = function (object) {
     for (var k in exports) {


### PR DESCRIPTION
- Add a 'loop' state and loop_respond method; used in rdns_respond and connection_respond methods, so that if anything other than OK or CONT are returned, no other commands can be sent and the session does not progress (QUIT is allowed though).
- Changed the default response codes in rdns_respond and connect_respond to be more RFC compliant
- Changed the EHLO/HELO response not to output connection.remote_host if it isn't set or is NXDOMAIN or DNSERROR.
- Check for command arguments to RSET, DATA and QUIT as per the RFC.
