### PR TITLE
Need Math in the sandbox in order to have the reseed_rng plugin modify its functions

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -126,6 +126,7 @@ plugins._load_and_compile_plugin = function(name) {
         clearInterval: clearInterval,
         process: process,
         Buffer: Buffer,
+        Math: Math,
     };
     constants.import(sandbox);
     try {


### PR DESCRIPTION
Need Math in the sandbox in order to have the reseed_rng plugin modify its functions.  Exposing global Math to the plugins may not be ideal, but for now this is the only way we can see a plugin having influence over the core server's use of Math.random().
