### PR TITLE
Fix clamd send_data infinite loop on linux

### DIFF
--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -73,30 +73,41 @@ exports.hook_data_post = function (next, connection) {
         return len;
     }
 
-    var data_marker = 0;
-    var in_data = false;
-    var close_pending = true;
-
+    var data_marker = 0; ///< The current line number we're sending to clamd
+    var in_data = false; ///< We're sending data, but not done yet
+    var data_line = "";  ///< The current line we're sending to clamd
+    
     var send_data = function () {
         in_data = true;
         var wrote_all = true;
         while (wrote_all && (data_marker < transaction.data_lines.length)) {
-            var line = transaction.data_lines[data_marker];
-            var len = pack_len(Buffer.byteLength(line));
-            wrote_all = socket.write(len, function() {
-                socket.write(line);
+            if (data_line) {
+                // If the current line is not empty, we haven't sent it yet
                 data_marker++;
-            });
-            if (!wrote_all) return;
+                wrote_all = socket.write(data_line);
+                data_line = "";
+                if (!wrote_all) {
+                    return;
+                }
+            }
+            if (data_marker < transaction.data_lines.length) {
+                // If we a line yet to write, encode the length and send it
+                data_line = transaction.data_lines[data_marker];
+                var len = Buffer.byteLength(data_line);
+                var buf = pack_len(len);
+                connection.logdata(plugin, "C{len=" + len + "}: " + data_line);
+                wrote_all = socket.write(buf);
+            }
         }
-        if (close_pending) {
-            close_pending = false;
+        if (wrote_all) {
+            // We're at the end of the data_lines - send a zero length line
+            in_data = false; // We don't need to be called by socket.on('drain' ...
             socket.end(pack_len(0));
         }
     };
 
     socket.on('drain', function () {
-        if (close_pending && in_data) {
+        if (in_data) {
             process.nextTick(function () { send_data() });
         }
     });


### PR DESCRIPTION
Before 9147e00b, clamd.js would cause haraka to give up due to exceeding
maximum stack depth. After it, haraka appears to infinite loop and somehow
get killed.

The problem is that socket.write's callback is not called immediately.
According to http://nodejs.org/docs/v0.4.9/api/net.html#socket.write, there
is no requirement that it is called immediately. Thus, what happens is
socket.write(len,...) returns true, but data_marker is not incremented and
send_data simply infinite loops.

Note that socket.write is apparently called immediately on my Lion OS X
system. It simply is not called immediately on my Debian squeeze 6.0.2
kernel 2.6.32-5 x86_64 system running node v0.6.8 installed from source.

Note that I modeled the send_data clamd.js on the one in smtp_proxy.js.
It does not use socket.write callbacks at all (& thus avoids any assumption
about whether they happen immediately or not).

---

Note: I added some logging to the current clamd.js to verify that socket.write was returning true but not calling its callback immediately -- the behavior difference on OS X versus linux & the fact that nobody has reported this problem was a bit hard to believe. The logging, however, bore out the problem. I logged once "send_data 1" at the top of the loop and once "send_data 2" at the bottom of the loop counting (cnt) the number of times "send_data 2" was called. Clearly the callback was not getting called because data_marker never got incremented. Works fine on OS X.

[DEBUG] [F0DC651E-84EC-452D-AE07-F67CB529AB3B.1] [clamd] send_data 1 data_marker: 0
[DEBUG] [F0DC651E-84EC-452D-AE07-F67CB529AB3B.1] [clamd] send_data 2 cnt 1 data_marker: 0 wrote_all: true
[DEBUG] [F0DC651E-84EC-452D-AE07-F67CB529AB3B.1] [clamd] send_data 1 data_marker: 0
[DEBUG] [F0DC651E-84EC-452D-AE07-F67CB529AB3B.1] [clamd] send_data 2 cnt 2 data_marker: 0 wrote_all: true
[DEBUG] [F0DC651E-84EC-452D-AE07-F67CB529AB3B.1] [clamd] send_data 1 data_marker: 0
[DEBUG] [F0DC651E-84EC-452D-AE07-F67CB529AB3B.1] [clamd] send_data 2 cnt 3 data_marker: 0 wrote_all: true
[DEBUG] [F0DC651E-84EC-452D-AE07-F67CB529AB3B.1] [clamd] send_data 1 data_marker: 0
[DEBUG] [F0DC651E-84EC-452D-AE07-F67CB529AB3B.1] [clamd] send_data 2 cnt 4 data_marker: 0 wrote_all: true
