### PR TITLE
Under normal operation these to loginfo() lines log too much.

### DIFF
--- a/plugins/lookup_rdns.strict.js
+++ b/plugins/lookup_rdns.strict.js
@@ -29,7 +29,7 @@ function _in_whitelist(connection, plugin, address) {
     var host_list_regex =
         plugin.config.get('lookup_rdns.strict.whitelist_regex', 'list');
     
-    connection.loginfo(plugin, "Checking if " + address + " is in the " +
+    connection.logdebug(plugin, "Checking if " + address + " is in the " +
         "lookup_rdns.strict.whitelist files");
 
     var i;

--- a/plugins/rcpt_to.in_host_list.js
+++ b/plugins/rcpt_to.in_host_list.js
@@ -7,7 +7,7 @@ exports.hook_rcpt = function(next, connection, params) {
         return next();
     }
     
-    connection.loginfo(this, "Checking if " + rcpt + " host is in host_lists");
+    connection.logdebug(this, "Checking if " + rcpt + " host is in host_lists");
     
     var domain          = rcpt.host.toLowerCase();
     var host_list       = this.config.get('host_list', 'list');


### PR DESCRIPTION
Just a fix to make these only log under logdebug().
