### PR TITLE
Bug fix for clamd plugin when using unix socket

### DIFF
--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -122,8 +122,11 @@ exports.hook_data_post = function (next, connection) {
         return next(DENYSOFT,'Error connecting to virus scanner');
     });
     socket.on('connect', function () {
-        var hp = socket.address();
-        connection.loginfo(plugin, 'connected to host: ' + hp.address + ':' + hp.port);
+        var hp = socket.address(),
+          addressInfo = hp === null ? '' : ' ' + hp.address + ':' + hp.port;
+
+        connection.loginfo(plugin, 'connected to host' + addressInfo);
+
         socket.write("zINSTREAM\0", function () {
             send_data();
         });


### PR DESCRIPTION
System:
Ubuntu 11.10
clamav-daemon: default conf with unix socket 
node: v0.6.13

In the socket connect event, the call to loginfo fails because address object is null.  Added a null check for address info.

-Ardie
