### PR TITLE
Massive bug fix for the smtp_proxy bug that fails to relay 5xx errors

### DIFF
--- a/plugins/queue/smtp_proxy.js
+++ b/plugins/queue/smtp_proxy.js
@@ -248,6 +248,7 @@ exports.hook_mail = function (next, connection, params) {
                     smtp_proxy.command = 'helo';
                 }
                 else if (code.match(/^[45]/)) {
+                    var response_array = smtp_proxy.response.slice();
                     if (smtp_proxy.command !== 'rcpt') {
                         // errors are OK for rcpt, but nothing else
                         // this can also happen if the destination server
@@ -256,7 +257,7 @@ exports.hook_mail = function (next, connection, params) {
                         smtp_proxy.socket.send_command('RSET');
                     }
                     return smtp_proxy.next(code.match(/^4/) ?
-                        DENYSOFT : DENY, smtp_proxy.response);
+                        DENYSOFT : DENY, response_array);
                 }
                 switch (smtp_proxy.command) {
                     case 'xclient':


### PR DESCRIPTION
Massive bug fix for the smtp_proxy bug that fails to relay 5xx errors onto the connected client.  This was a result of the smtp_proxy.response array getting cleared on socket.send_command().  Clients would see the connection simply hang and eventually timeout.
