### PR TITLE
This should make it easier to install Haraka on production boxes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "generic-pool"  : ">= 1.0.9",
     "node-syslog"   : ">= 1.1.2",
     "iconv"         : ">= 1.1.3"
+  },
   "optionalDependencies": {
     "nodeunit"      : "https://github.com/godsflaw/nodeunit/tarball/master"
   },


### PR DESCRIPTION
Replaced nodeunit link from git to https.
