### PR TITLE
Add Ubuntu Upstart init file

### DIFF
--- a/contrib/haraka.conf
+++ b/contrib/haraka.conf
@@ -2,6 +2,9 @@
 #
 # Ubuntu Upstart script (place in /etc/init and run "initctl start haraka")
 # (Assumes running w/the daemonize plugin)
+#
+# Contributed by "David Weekly" <david@weekly.org>
+#
 
 description	  "Haraka Email Server"
 
@@ -21,4 +24,4 @@ end script
 
 expect fork
 
-exec /usr/bin/haraka -c /root/haraka_fwdmx
+exec /usr/bin/haraka -c /var/haraka/fwdmx


### PR DESCRIPTION
Useful for anyone running Haraka on an Ubuntu server. Just drop this into /etc/init and it will start automatically on boot, etc.
