### PR TITLE
Initial IPv6 compatibility

### DIFF
--- a/config/smtp.ini
+++ b/config/smtp.ini
@@ -1,7 +1,8 @@
 ; port to listen on
 port=2525
 
-; address to listen on (default: all addresses)
+; address to listen on (default: all IPv4 addresses)
+; set this to ::0 to listen on IPv6 and IPv4 (not all OSes)
 ;listen_host=0.0.0.0
 
 ; Time in seconds to let sockets be idle with no activity

--- a/connection.js
+++ b/connection.js
@@ -13,6 +13,7 @@ var Address     = require('./address').Address;
 var uuid        = require('./utils').uuid;
 var outbound    = require('./outbound');
 var date_to_str = require('./utils').date_to_str;
+var ipaddr      = require('ipaddr.js');
 
 var version  = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'))).version;
 
@@ -43,7 +44,7 @@ for (var key in logger) {
 }
 
 function setupClient(self) {
-    self.remote_ip = self.client.remoteAddress;
+    self.remote_ip = ipaddr.process(self.client.remoteAddress).toString();
     self.lognotice("connect ip=" + self.remote_ip);
 
     self.client.on('end', function() {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "nopt"          : ">= 1.0.5",
     "generic-pool"  : ">= 1.0.9",
     "node-syslog"   : ">= 1.1.2",
-    "iconv"         : ">= 1.1.3"
+    "iconv"         : ">= 1.1.3",
+    "ipaddr.js"     : ">= 0.1.1"
   },
   "optionalDependencies": {
     "nodeunit"      : "https://github.com/godsflaw/nodeunit/tarball/master"

--- a/server.js
+++ b/server.js
@@ -94,8 +94,7 @@ Server.createServer = function (params) {
             }
         }
 
-        c.set('host', config_data.main.listen_host);
-        c.listen(parseInt(config_data.main.port));
+        c.listen(parseInt(config_data.main.port), config_data.main.listen_host);
         c.on('listening', listening);
         Server.cluster = c;
         if (c.isMaster) {


### PR DESCRIPTION
These patches ensure that things don't break horribly when IPv6 interfaces are used.  There is still more work to be done (mainly in the plugins).
- Make sure connection.remote_ip is either an IPv4 or IPv6 address only (e.g. translate IPv4-mapped addresses like ::ffff:1.2.3.4 addresses back to IPv4 representations using ipaddr.js) so things like rDNS lookup do not fail.
- Fix bug in cluster support which meant Haraka wasn't honouring the listen_address supplied in smtp.ini and therefore would not listen on ::0
