### PR TITLE
Gracefully handle connection events where socket.remoteAddress returns undefined

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -44,8 +44,16 @@ for (var key in logger) {
 }
 
 function setupClient(self) {
-    self.remote_ip = ipaddr.process(self.client.remoteAddress).toString();
-    self.lognotice("connect ip=" + self.remote_ip);
+    var ip = self.client.remoteAddress;
+    if (!ip) {
+        self.logdebug('setupClient got no IP address for this connection!');
+        self.client.destroy();
+        return;
+    }
+
+    self.remote_ip = ipaddr.process(ip).toString();
+    self.remote_port = self.client.remotePort;
+    self.lognotice("connect ip=" + self.remote_ip + ' port=' + self.remote_port);
 
     self.client.on('end', function() {
         if (!self.disconnected) {


### PR DESCRIPTION
Since updating to node.js 0.6/0.8 - I see a handful of connections per day that when setupClient() runs no IP address is returned by socket.remoteAddress.   I've no idea what causes this and I've been unable to replicate it manually - but this patch handles this case gracefully.
