### PR TITLE
Add TLS cipher information to log output and received header

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -1031,8 +1031,12 @@ Connection.prototype.received_line = function() {
     // Implement RFC3848
     if (this.using_tls)  smtp = smtp + 'S';
     if (this.authheader) smtp = smtp + 'A';
-    // TODO - populate authheader and sslheader - see qpsmtpd for how to.
-    // sslheader is not possible with TLS support in node yet.
+    // sslheader only populated with node.js >= 0.8
+    if (this.notes.tls && this.notes.tls.cipher) {
+        var sslheader = '(version=' + this.notes.tls.cipher.version + 
+            ' cipher=' + this.notes.tls.cipher.name + 
+            ' verify=' + ((this.notes.tls.authorized) ? 'OK' : 'FAIL') + ')';
+    }
     return [
         'from ',
             // If no rDNS then use an IP literal here
@@ -1043,9 +1047,9 @@ Connection.prototype.received_line = function() {
             'by ', config.get('me'), ' (Haraka/', version, ') with ', smtp, 
             ' id ', this.transaction.uuid, 
         "\n\t",
-            '(envelope-from ', this.transaction.mail_from.format(), ')',
-            // ((this.sslheader) ? ' ' + this.sslheader.replace(/\r?\n\t?$/,'') : ''), 
+            'envelope-from ', this.transaction.mail_from.format(),
             ((this.authheader) ? ' ' + this.authheader.replace(/\r?\n\t?$/, '') : ''),
+            ((sslheader) ? "\n\t" + sslheader.replace(/\r?\n\t?$/,'') : ''),
         ";\n\t", date_to_str(new Date())
     ].join('');
 };

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -28,7 +28,7 @@ exports.hook_unrecognized_command = function (next, connection, params) {
         connection.respond(220, "Go ahead.");
         /* Upgrade the connection to TLS. */
         var self = this;
-        connection.client.upgrade(options, function (authorized, verifyError, cert) {
+        connection.client.upgrade(options, function (authorized, verifyError, cert, cipher) {
             connection.reset_transaction();
             connection.hello_host = undefined;
             connection.using_tls = true;
@@ -36,8 +36,11 @@ exports.hook_unrecognized_command = function (next, connection, params) {
                 authorized: authorized,
                 authorizationError: verifyError,
                 peerCertificate: cert,
+                cipher: cipher
             };
-            connection.loginfo(self, 'secured: verified=' + authorized +
+            connection.loginfo(self, 'secured:' +
+                ((cipher) ? ' cipher=' + cipher.name + ' version=' + cipher.version : '') + 
+                ' verified=' + authorized +
                 ((verifyError) ? ' error="' + verifyError + '"' : '' ) +
                 ((cert && cert.subject) ? ' cn="' + cert.subject.CN + '"' + 
                 ' organization="' + cert.subject.O + '"' : '') +

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -186,11 +186,11 @@ function createServer(cb) {
                     cleartext.authorized = true;
                 }
                 var cert = pair.cleartext.getPeerCertificate();
-                // TODO: this is available in 0.8
-                // var cipher = pair.cleartext.getCipher();
-
+                if (pair.cleartext.getCipher) {
+                    var cipher = pair.cleartext.getCipher();
+                }
                 socket.emit('secure');
-                if (cb) cb(cleartext.authorized, verifyError, cert);
+                if (cb) cb(cleartext.authorized, verifyError, cert, cipher);
             });
 
             cleartext._controlReleased = true;


### PR DESCRIPTION
Example:

```
Received: from 188-223-62-1.zone14.bethere.co.uk ([192.168.30.103] [188.223.62.1]) 
    by mail1-ec2.fsl.com (Haraka/1.3.3) with ESMTPSA id E5D4345F-0627-48D5-ABB8-367D3A753E15.1
    envelope-from <steve.freegard@fsl.com> (authenticated bits=0)
    (version=TLSv1/SSLv3 cipher=AES128-SHA verify=FAIL);
    Tue, 28 Aug 2012 15:26:19 +0000
```
