### PR TITLE
Reject commands containing non-ASCII characters

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -167,6 +167,10 @@ Connection.prototype.process_line = function (line) {
     var self = this;
     if (this.state !== STATE_DATA) {
         this.logprotocol("C: " + line + ' state=' + this.state);
+        // Check for non-ASCII characters
+        if (/[^\x00-\x7F]/.test(line)) {
+            return this.respond(501, 'Syntax error');
+        }
     }
     if (this.state === STATE_CMD) {
         this.state = STATE_PAUSE_SMTP;


### PR DESCRIPTION
I noticed a few connections like this in my logs:

[core] disconnect ip=37.114.171.69 rdns="DNSERROR" helo="æëîðæë-ÏÊ" relay=N early=N esmtp=Y tls=N pipe=N txns=1 rcpts=0/0/1 msgs=0/0/0 bytes=0 lr="550 host [37.114.171.69] is blacklisted by zen.ip.fslupdate.com" time=1.646

Note the EHLO/EHLO argument.   This connection did actually yield a sender and recipient too, it was just the EHLO/HELO that was bogus.  This patch rejects this with a '501 Syntax error'.
