### PR TITLE
Fix undefined variable error in mailbody.

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -105,7 +105,7 @@ Body.prototype.parse_start = function (line) {
     }
     else if (/^multipart\//i.test(ct)) {
         var match = ct.match(/boundary\s*=\s*["']?([^"';]+)["']?/i);
-        this.boundary = match[1] || '';
+        this.boundary = match ? match[1] : '';
         this.state = 'multipart_preamble';
     }
     else {


### PR DESCRIPTION
To fix this:

Sep 10 07:14:01 relay1 haraka[32563]: [CRIT] [-] [core] TypeError: Cannot read property '1' of null
Sep 10 07:14:01 relay1 haraka[32563]: [CRIT] [-] [core]     at Body.parse_start (/usr/lib/node_modules/Haraka/mailbody.js:108:30)
Sep 10 07:14:01 relay1 haraka[32563]: [CRIT] [-] [core]     at Body.parse_more (/usr/lib/node_modules/Haraka/mailbody.js:29:39)
Sep 10 07:14:01 relay1 haraka[32563]: [CRIT] [-] [core]     at Transaction.add_data (/usr/lib/node_modules/Haraka/transaction.js:50:
26)
