### PR TITLE
Reset process.title in process.on to prevent corrupt output

### DIFF
--- a/haraka.js
+++ b/haraka.js
@@ -40,13 +40,15 @@ process.on('uncaughtException', function (err) {
 
 ['SIGTERM', 'SIGINT'].forEach(function (sig) {
     process.on(sig, function () {
-        logger.logcrit(sig + ' received');
+        process.title = path.basename(process.argv[1], '.js');
+        logger.loginfo(sig + ' received');
         logger.dump_logs(1);
     });
 });
 
 process.on('exit', function() {
-    logger.logcrit('Shutting down');
+    process.title = path.basename(process.argv[1], '.js');
+    logger.loginfo('Shutting down');
     logger.dump_logs();
 });
 


### PR DESCRIPTION
- Change log facility on shutdown lines to INFO to match start-up logging
- Reset process.title as it is reported incorrectly when log.syslog is called from process.on and the process_title plugin is used.
