### PR TITLE
Tidy up tls_socket, improve compatibility and add missing function args

### DIFF
--- a/tls_socket.js
+++ b/tls_socket.js
@@ -7,9 +7,9 @@ var tls = require('tls');
 var crypto = require('crypto');
 var util = require('util');
 var net = require('net');
-var events = require('events');
 var stream = require('stream');
 var log = require('./logger');
+var SSL_OP_ALL = require('constants').SSL_OP_ALL;
 
 // provides a common socket for attaching
 // and detaching from either main socket, or crypto socket
@@ -24,19 +24,9 @@ function pluggableStream(socket) {
 }
 
 util.inherits(pluggableStream, stream.Stream);
-util.inherits(pluggableStream, events.EventEmitter);
-
-// This should come from Stream in node core.
-// pluggableStream.prototype.pipe = function    (socket) {
-//     this.on('data', function (data) {
-//         if (socket.write)
-//             socket.write(data);
-//     });
-// };
 
 pluggableStream.prototype.pause = function () {
     if (this.targetsocket.pause) {
-        // console.log("XXXX: Got backpressure...");
         this.targetsocket.pause();
         this.readable = false;
     }
@@ -44,9 +34,8 @@ pluggableStream.prototype.pause = function () {
 
 pluggableStream.prototype.resume = function () {
     if (this.targetsocket.resume) {
-        // console.log("XXXX: Resuming backpressure...");
-        this.targetsocket.resume();
         this.readable = true;
+        this.targetsocket.resume();
     }
 }
 
@@ -71,9 +60,9 @@ pluggableStream.prototype.attach = function (socket) {
         self.writable = self.targetsocket.writable;
         self.emit('end');
     });
-    self.targetsocket.on('close', function () {
+    self.targetsocket.on('close', function (had_error) {
         self.writable = self.targetsocket.writable;
-        self.emit('close');
+        self.emit('close', had_error);
     });
     self.targetsocket.on('drain', function () {
         self.emit('drain');
@@ -88,11 +77,9 @@ pluggableStream.prototype.attach = function (socket) {
     if (self.targetsocket.remotePort) {
         self.remotePort = self.targetsocket.remotePort;
     }
-
     if (self.targetsocket.remoteAddress) {
         self.remoteAddress = self.targetsocket.remoteAddress;
     }
-
 };
 
 pluggableStream.prototype.clean = function (data) {
@@ -105,22 +92,20 @@ pluggableStream.prototype.clean = function (data) {
         this.targetsocket.removeAllListeners('error');
         this.targetsocket.removeAllListeners('drain');
     }
-    ;
     this.targetsocket = {};
-    this.targetsocket.write = function () {
-    };
+    this.targetsocket.write = function () {};
 };
 
-pluggableStream.prototype.write = function (data) {
+pluggableStream.prototype.write = function (data, encoding, callback) {
     if (this.targetsocket.write) {
-        return this.targetsocket.write(data);
+        return this.targetsocket.write(data, encoding, callback);
     }
     return false;
 };
 
-pluggableStream.prototype.end = function () {
+pluggableStream.prototype.end = function (data, encoding) {
     if (this.targetsocket.end) {
-        return this.targetsocket.end();
+        return this.targetsocket.end(data, encoding);
     }
 }
 
@@ -183,9 +168,16 @@ function createServer(cb) {
             
             socket.clean();
             cryptoSocket.removeAllListeners('data');
+
+            // Set SSL_OP_ALL for maximum compatibility with broken clients
+            // See http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
+            if (!options) options = {};
+            options.secureOptions = SSL_OP_ALL;
+            
             var sslcontext = crypto.createCredentials(options);
 
             var pair = tls.createSecurePair(sslcontext, true, true, false);
+
             var cleartext = pipe(pair, cryptoSocket);
 
             pair.on('error', function(exception) {
@@ -233,6 +225,12 @@ function connect(port, host, cb) {
     socket.upgrade = function (options) {
         socket.clean();
         cryptoSocket.removeAllListeners('data');
+
+        // Set SSL_OP_ALL for maximum compatibility with broken servers
+        // See http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
+        if (!options) options = {};
+        options.secureOptions = SSL_OP_ALL;
+
         var sslcontext = crypto.createCredentials(options);
 
         var pair = tls.createSecurePair(sslcontext, false);


### PR DESCRIPTION
- Inheriting from EventEmitter is unnecessary as Stream already inherits from it.
- Remove commented code
- Add missing arguments to write() and end() functions
- Set SSL_OP_ALL for maximum compatibility
