### PR TITLE
SSL_OP_ALL causes incorrect parameter error due to Node bug

### DIFF
--- a/tls_socket.js
+++ b/tls_socket.js
@@ -172,7 +172,8 @@ function createServer(cb) {
             // Set SSL_OP_ALL for maximum compatibility with broken clients
             // See http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
             if (!options) options = {};
-            options.secureOptions = SSL_OP_ALL;
+            // TODO: bug in Node means we can't do this until it's fixed
+            // options.secureOptions = SSL_OP_ALL;
             
             var sslcontext = crypto.createCredentials(options);
 
@@ -229,7 +230,8 @@ function connect(port, host, cb) {
         // Set SSL_OP_ALL for maximum compatibility with broken servers
         // See http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
         if (!options) options = {};
-        options.secureOptions = SSL_OP_ALL;
+        // TODO: bug in Node means we can't do this until it's fixed
+        // options.secureOptions = SSL_OP_ALL;
 
         var sslcontext = crypto.createCredentials(options);
 


### PR DESCRIPTION
Fixed by bnoordhuis in node master, but never made it in to 0.8.15, so I guess we'll see this fixed in 0.10.
