### PR TITLE
Fix end-of-headers marker detection

### DIFF
--- a/transaction.js
+++ b/transaction.js
@@ -45,10 +45,8 @@ Transaction.prototype.add_data = function(line) {
     if (typeof line !== 'string') {
         line = line.toString('binary').replace(/^\./, '').replace(/\r\n$/, '\n');
     }
-    // check if this is the end of headers line (note the regexp isn't as strong 
-    // as it should be - it accepts whitespace in a blank line - we've found this
-    // to be a good heuristic rule though).
-    if (this.header_pos === 0 && line.match(/^\s*$/)) {
+    // check if this is the end of headers line  
+    if (this.header_pos === 0 && line[0] === '\n') {
         this.header.parse(this.header_lines);
         this.header_pos = this.header_lines.length;
         if (this.parse_body) {


### PR DESCRIPTION
The current heuristic detection isn't RFC compliant.   It broke with the following (valid but stupid) header:

```
References: <7FD4C8B39D0B18439D432908FA1385D302628A82@a16664.marins.lan>

                                                        <A7D88A1E18E690468AB90A60B0E8DAB1787F2C9C@a16664.marins.lan>
 <A7D88A1E18E690468AB90A60B0E8DAB1AB7F0801@a16664.marins.lan>
                              <7FD4C8B39D0B18439D432908FA1385D30325EB79@a16664.marins.lan>
 <1A062DA335F9AF45A55C9AD640966BBF0117830D0040@HLBEHT11>
```

The 2nd line of the header has a bunch of spaces and a \r\n at the end - it should be treated as a header continuation but was being detected as the EOH marker instead.
