### PR TITLE
Fix add_data handling when input is a string

### DIFF
--- a/transaction.js
+++ b/transaction.js
@@ -43,8 +43,9 @@ exports.createTransaction = function(uuid) {
 Transaction.prototype.add_data = function(line) {
     this.message_stream.add_line(line);
     if (typeof line !== 'string') {
-        line = line.toString('binary').replace(/^\./, '').replace(/\r\n$/, '\n');
+        line = line.toString('binary');
     }
+    line = line.replace(/^\./, '').replace(/\r\n$/, '\n');
     // check if this is the end of headers line  
     if (this.header_pos === 0 && line[0] === '\n') {
         this.header.parse(this.header_lines);


### PR DESCRIPTION
Fixes outbound.send_email(from, to, contents) where contents is a string as currently this will incorrectly lead to add_line() receiving the string with \r\n endings and therefore the headers will not be parsed correctly.
