### PR TITLE
Fix CRIT where local_addr.address is null

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -68,8 +68,10 @@ function setupClient(self) {
     }
   
     var local_addr = self.server.address();
-    self.local_ip = ipaddr.process(local_addr.address).toString();
-    self.local_port = local_addr.port;
+    if (local_addr && local_addr.address) {
+        self.local_ip = ipaddr.process(local_addr.address).toString();
+        self.local_port = local_addr.port;
+    }
     self.remote_ip = ipaddr.process(ip).toString();
     self.remote_port = self.client.remotePort;
     self.lognotice('connect ip=' + self.remote_ip + ' port=' + self.remote_port + 


### PR DESCRIPTION
Fixes:

```
Mar 18 15:06:37 mail1-ec2 haraka[1915]: [CRIT] [-] [core] TypeError: Cannot read property 'address' of null
Mar 18 15:06:37 mail1-ec2 haraka[1915]: [CRIT] [-] [core]     at setupClient (/usr/lib/node_modules/Haraka/connection.js:71:41)
Mar 18 15:06:37 mail1-ec2 haraka[1915]: [CRIT] [-] [core]     at new Connection (/usr/lib/node_modules/Haraka/connection.js:175:5)
Mar 18 15:06:37 mail1-ec2 haraka[1915]: [CRIT] [-] [core]     at Object.exports.createConnection (/usr/lib/node_modules/Haraka/connection.js:181:13)
Mar 18 15:06:37 mail1-ec2 haraka[1915]: [CRIT] [-] [core]     at /usr/lib/node_modules/Haraka/server.js:152:18
Mar 18 15:06:37 mail1-ec2 haraka[1915]: [CRIT] [-] [core]     at Server.<anonymous> (/usr/lib/node_modules/Haraka/tls_socket.js:214:9)
Mar 18 15:06:37 mail1-ec2 haraka[1915]: [CRIT] [-] [core]     at Server.EventEmitter.emit (events.js:96:17)
Mar 18 15:06:37 mail1-ec2 haraka[1915]: [CRIT] [-] [core]     at TCP.onconnection (net.js:1038:8)
```

I suspect it's caused by the client dropping the connection before the method returns.
