### PR TITLE
Fixes for all HTML bannering cases

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -152,7 +152,7 @@ function _get_html_insert_position (buf) {
             }
         }
     }
-    return buf.length - 1; // default is at the end
+    return buf.length; // default is at the end
 }
 
 Body.prototype.parse_end = function (line) {
@@ -196,7 +196,7 @@ Body.prototype.parse_end = function (line) {
             }
 
             // Allocate a new buffer: (6 or 1 is <p>...</p> vs \n...\n - correct that if you change those!)
-            var new_buf = new Buffer(buf.length + banner_buf.length + (this.is_html ? 6 : 1));
+            var new_buf = new Buffer(buf.length + banner_buf.length + (this.is_html ? 7 : 1));
 
             // Now we find where to insert it and combine it with the original buf:
             if (this.is_html) {
@@ -218,7 +218,7 @@ Body.prototype.parse_end = function (line) {
                 new_buf[banner_buf.length + insert_pos++] = 62;
 
                 // copy remainder of buf into new_buf, if there is buf remaining
-                if (buf.length > (insert_pos - 6)) {
+                if (buf.length > (insert_pos - 7)) {
                     buf.copy(new_buf, insert_pos + banner_buf.length, insert_pos - 7);
                 }
             }


### PR DESCRIPTION
This fixes HTML bannering for:

quoted-printable with _no_ </body> or </html>
quoted-printable with </body> or </html>
base64 with _no_ </body> or </html>
base64 with </body> or </html>

I have working tests for all of these cases.  The only anomaly is with
quoted-printable HTML bannering cases.  When we re-encode and assemble
the new buffer, we get an extra newline at the end.  I believe this
is an artifact of quoted-printable encoding.  It does not happen in the
base64 cases.
