### PR TITLE
Fixes a CRIT in smtp_forward if sender goes away

### DIFF
--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -6,23 +6,17 @@
 var smtp_client_mod = require('./smtp_client');
 
 exports.hook_queue = function (next, connection) {
-    var self = this;
+    var plugin = this;
     var config = this.config.get('smtp_forward.ini');
     connection.loginfo(this, "forwarding to " + config.main.host + ":" + config.main.port);
     smtp_client_mod.get_client_plugin(this, connection, config, function (err, smtp_client) {
         smtp_client.next = next;
         var rcpt = 0;
         var send_rcpt = function () {
-            if (!connection.transaction) {
-                // This likely means the sender went away on us, cleanup.
-                connection.logwarn(
-                  self, "transaction went away, releasing smtp_client"
-                );
-                smtp_client.release();
+            if (_is_dead_sender(plugin, connection, smtp_client)) {
                 return;
             }
-
-            if (rcpt < connection.transaction.rcpt_to.length) {
+            else if (rcpt < connection.transaction.rcpt_to.length) {
                 smtp_client.send_command('RCPT',
                     'TO:' + connection.transaction.rcpt_to[rcpt]);
                 rcpt++;
@@ -40,11 +34,17 @@ exports.hook_queue = function (next, connection) {
         }
 
         smtp_client.on('data', function () {
+            if (_is_dead_sender(plugin, connection, smtp_client)) {
+                return;
+            }
             smtp_client.start_data(connection.transaction.message_stream);
         });
 
         smtp_client.on('dot', function () {
-            if (rcpt < connection.transaction.rcpt_to.length) {
+            if (_is_dead_sender(plugin, connection, smtp_client)) {
+                return;
+            }
+            else if (rcpt < connection.transaction.rcpt_to.length) {
                 smtp_client.send_command('RSET');
             }
             else {
@@ -54,16 +54,35 @@ exports.hook_queue = function (next, connection) {
         });
 
         smtp_client.on('rset', function () {
+            if (_is_dead_sender(plugin, connection, smtp_client)) {
+                return;
+            }
             smtp_client.send_command('MAIL',
                 'FROM:' + connection.transaction.mail_from);
         });
 
         smtp_client.on('bad_code', function (code, msg) {
+            if (_is_dead_sender(plugin, connection, smtp_client)) {
+                return;
+            }
             smtp_client.call_next(((code && code[0] === '5') ? DENY : DENYSOFT), 
                                   msg + ' (' + connection.transaction.uuid + ')');
             smtp_client.release();
         });
     });
 };
+
+function _is_dead_sender(plugin, connection, smtp_client) {
+    if (!connection.transaction) {
+        // This likely means the sender went away on us, cleanup.
+        connection.logwarn(
+          plugin,"transaction went away, releasing smtp_client"
+        );
+        smtp_client.release();
+        return true;
+    }
+
+    return false;
+}
 
 exports.hook_queue_outbound = exports.hook_queue;


### PR DESCRIPTION
If the sender goes away while we're forwarding, we get a CRIT error.  This fix should detect the sender going away and cleanup the smtp_client connection.  It will also logwarn that the event happened.

This fix is not yet production tested, and should be open for discussion.
