### PR TITLE
fix : filename is not defined

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -227,7 +227,7 @@ exports.load_queue_files = function (pid, cb_name, files) {
                 return fs.unlink(queue_dir + "/" + file, function () {});
             }
 
-            var matches = filename.match(fn_re);
+            var matches = file.match(fn_re);
             if (!matches) {
                 self.logerror("Unrecognised file in queue folder: " + file);
                 return;


### PR DESCRIPTION
haraka -c /etc/haraka/
loglevel: LOGINFO
Starting up Haraka version 2.1.5
[INFO] [-] [core] Loading plugins
[INFO] [-] [core] Loading plugin: auth/flat_file
[NOTICE] [-] [core] Listening on 127.0.0.1:587
[NOTICE] [-] [core] Listening on 10.66.38.76:587
[INFO] [-] [core] [outbound] Loading outbound queue from /etc/haraka/queue
[INFO] [-] [core] [outbound] Loading the queue...
[CRIT] [-] [core] ReferenceError: filename is not defined
[CRIT] [-] [core]     at /usr/local/lib/node_modules/Haraka/outbound.js:230:27
[CRIT] [-] [core]     at Array.forEach (native)
[CRIT] [-] [core]     at Object.exports.load_queue_files (/usr/local/lib/node_modules/Haraka/outbound.js:223:15)
[CRIT] [-] [core]     at /usr/local/lib/node_modules/Haraka/outbound.js:156:14
[CRIT] [-] [core]     at Object.oncomplete (fs.js:107:15)
[NOTICE] [-] [core] Shutting down
