### PR TITLE
Fix recusive loop on command length check

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -370,7 +370,6 @@ Connection.prototype._process_data = function() {
             // In command mode, reject:
             this.client.pause();
             this.current_data = null;
-            this.process_data = function () {};
             return this.respond(521, "Command line too long", function () {
                 self.disconnect();
             });


### PR DESCRIPTION
We have to clear this.current_data because the respond() function calls _process_data() again to get the next command.   This came to light once disconnect became async.

I also found that simply pausing the input socket was good enough to do away with setting the process_data() to an empty function and avoiding the hidden class.
