### PR TITLE
Handle case where pager has arguments and update deprecated interface to...

### DIFF
--- a/bin/haraka
+++ b/bin/haraka
@@ -284,7 +284,7 @@ else if (parsed.help) {
         }
         var pager = 'less', spawn = require('child_process').spawn;
         if (process.env.PAGER) {
-            var pager_split = process.env.PAGER.split(' ');
+            var pager_split = process.env.PAGER.split(/ +/);
             pager = pager_split.shift(); 
             md_path = pager_split.concat(md_path);
         };


### PR DESCRIPTION
... spawn. I'm a newbie to this, but help wasn't working on my Debian distro from TKLinux due to PAGER being set to "less -X -R -F" by default. Looks like spawn checks the literal command for existence, so this causes the command to fail. I also updated the spawn call for the deprecated customFds option being used. 
