### PR TITLE
process_title plugin improvements

### DIFF
--- a/docs/plugins/process_title.md
+++ b/docs/plugins/process_title.md
@@ -20,8 +20,10 @@ where:
 * cn = Total number of connections
 * cc = Total number of concurrent connections
 * cps = Number of connections in the last second / average / maximum
+* msgs = Total number of messages
 * mps = Number of messages in the last second / average / maximum
 * out = Mails being processed / Mails waiting to be processed / Mails in temp fail state
+* respawn = Number of worker processes respawned (only under cluster)
 
 If 'cluster' is used then the master process will show the total
 across all workers, with the exception of outbound stats.

--- a/plugins/process_title.js
+++ b/plugins/process_title.js
@@ -10,20 +10,32 @@ exports.hook_init_master = function (next, server) {
     server.notes.pt_messages = 0;
     server.notes.pt_mps_diff = 0;
     server.notes.pt_mps_max = 0;
+    server.notes.pt_child_exits = 0;
     var title = 'Haraka';
     if (server.cluster) {
         title = 'Haraka (master)';
         process.title = title;
+        server.notes.pt_concurrent_cluster = {};
         server.notes.pt_new_out_stats = [0,0,0,0];
         var cluster = server.cluster;
         var recvMsg = function (msg) {
             switch (msg.event) {
                 case 'process_title.connect':
                     server.notes.pt_connections++;
-                    server.notes.pt_concurrent++;
+                    server.notes.pt_concurrent_cluster[msg.wid]++;
+                    var count = 0;
+                    Object.keys(server.notes.pt_concurrent_cluster).forEach(function (id) {
+                        count += server.notes.pt_concurrent_cluster[id];
+                    });
+                    server.notes.pt_concurrent = count;
                     break;
                 case 'process_title.disconnect':
-                    server.notes.pt_concurrent--;
+                    server.notes.pt_concurrent_cluster[msg.wid]--;
+                    var count = 0;
+                    Object.keys(server.notes.pt_concurrent_cluster).forEach(function (id) {
+                        count += server.notes.pt_concurrent_cluster[id];
+                    });
+                    server.notes.pt_concurrent = count;
                     break;
                 case 'process_title.message':
                     server.notes.pt_messages++;
@@ -45,7 +57,18 @@ exports.hook_init_master = function (next, server) {
         }
         // Register any new workers
         cluster.on('fork', function (worker) {
+            server.notes.pt_concurrent_cluster[worker.id] = 0;
             cluster.workers[worker.id].on('message', recvMsg);
+        });
+        cluster.on('exit', function (worker) {
+            delete server.notes.pt_concurrent_cluster[worker.id];
+            // Update concurrency
+            var count = 0;
+            Object.keys(server.notes.pt_concurrent_cluster).forEach(function (id) {
+                count += server.notes.pt_concurrent_cluster[id];
+            });
+            server.notes.pt_concurrent = count;
+            server.notes.pt_child_exits++;
         });
     }
     setupInterval(title, server);
@@ -71,7 +94,7 @@ exports.hook_lookup_rdns = function (next, connection) {
     connection.notes.pt_connect_run = true;
     if (server.cluster) {
         var worker = server.cluster.worker;
-        worker.send({event: 'process_title.connect'});
+        worker.send({event: 'process_title.connect', wid: worker.id});
     }
     server.notes.pt_connections++;
     server.notes.pt_concurrent++;
@@ -86,14 +109,15 @@ exports.hook_disconnect = function (next, connection) {
     // will exhibit this behaviour.
     if (!connection.notes.pt_connect_run) {
         if (server.cluster) {
-            server.cluster.worker.send({event: 'process_title.connect'});
+            var worker = server.cluster.worker;
+            worker.send({event: 'process_title.connect', wid: worker.id});
         }
         server.notes.pt_connections++;
         server.notes.pt_concurrent++;
     }
     if (server.cluster) {
         var worker = server.cluster.worker;
-        worker.send({event: 'process_title.disconnect'});
+        worker.send({event: 'process_title.disconnect', wid: worker.id});
     }
     server.notes.pt_concurrent--;
     return next();
@@ -128,9 +152,14 @@ var setupInterval = function (title, server) {
             process.send({event: 'process_title.outbound_stats', data: out});
         }
         // Update title
-        process.title = title + ' cn=' + server.notes.pt_connections + 
+        var new_title = title + ' cn=' + server.notes.pt_connections + 
             ' cc=' + server.notes.pt_concurrent + ' cps=' + cps + '/' + av_cps +
-            '/' + server.notes.pt_cps_max + ' mps=' + mps + '/' + av_mps + '/' +
+            '/' + server.notes.pt_cps_max + ' msgs=' + server.notes.pt_messages +
+            ' mps=' + mps + '/' + av_mps + '/' +
             server.notes.pt_mps_max + ' out=' + out + ' ';
+        if (/\(master\)/.test(title)) {
+            new_title += 'respawn=' + server.notes.pt_child_exits + ' ';
+        }
+        process.title = new_title;
     }, 1000);
 }


### PR DESCRIPTION
- Add respawn counter for master to show the number of children restarted
- Add message counter
- Make concurrency counter reflect current state if a child exits by keep count per worker when under cluster.
