### PR TITLE
outbound: don't attempt STARTTLS twice

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -921,7 +921,7 @@ HMailItem.prototype.try_deliver_host = function (mx) {
     var ok_recips = 0;
     var fail_recips = [];
     var bounce_recips = [];
-    var secured = 0;
+    var secured = false;
     var smtp_properties = {
         "tls": false,
         "max_size": 0,
@@ -969,7 +969,7 @@ HMailItem.prototype.try_deliver_host = function (mx) {
             this.on('secure', function () {
                 // Set this flag so we don't try STARTTLS again if it
                 // is incorrectly offered at EHLO once we are secured.
-                secured = 1;
+                secured = true;
                 socket.send_command('EHLO', config.get('me'));
             });
             this.send_command('STARTTLS');


### PR DESCRIPTION
It would appear that MXLogic incorrectly re-advertises STARTTLS after the session is secured causing outbound to try again:

```
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 220 p01c11m093.mxlogic.net ESMTP mxl_mta-7.1.0-4 [2ba16ba18940.15421083.00-450]; Wed, 16 Oct 2013 03:31:41 -0600 (MDT); NO UCE, INBOUND\r\n
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] C: EHLO mail1-ec2.fsl.com
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-p01c11m093.mxlogic.net\r\n
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-SIZE 0\r\n
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-STARTTLS\r\n
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-SUBMITTER\r\n
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-8BITMIME\r\n
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250 PIPELINING\r\n
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] C: STARTTLS
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 220 Ready to start TLS negotiation\r\n
Oct 16 09:31:41 mail1-ec2 haraka[28535]: [DEBUG] [-] [core] client TLS upgrade in progress, awaiting secured.
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [DEBUG] [-] [core] client TLS secured.
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] C: EHLO mail1-ec2.fsl.com
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-p01c11m093.mxlogic.net\r\n
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-SIZE 0\r\n
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-STARTTLS\r\n
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-SUBMITTER\r\n
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250-8BITMIME\r\n
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 250 PIPELINING\r\n
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] C: STARTTLS
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] S: 454 TLS not available, must be connected via TCP\r\n
Oct 16 09:31:42 mail1-ec2 haraka[28535]: [PROTOCOL] [D639C386-70AE-4E79-A816-F5E9C40C1F7E.1] [outbound] C: QUIT
```
