### PR TITLE
This update allows you to use auth_smtp with smtp_proxy.

### DIFF
--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -7,10 +7,51 @@ var smtp_client_mod = require('./smtp_client');
 
 exports.hook_queue = function (next, connection) {
     var plugin = this;
-    var config = this.config.get('smtp_forward.ini');
+    var config;
+    if(connection.notes.auth_proxy) {
+	config = { main: connection.notes.auth_proxy };
+        connection.loginfo(this, "Reusing data from auth_proxy.");
+    } else {
+	config = this.config.get('smtp_forward.ini');
+    }
+
+
     connection.loginfo(this, "forwarding to " + config.main.host + ":" + config.main.port);
     smtp_client_mod.get_client_plugin(this, connection, config, function (err, smtp_client) {
         smtp_client.next = next;
+
+
+	if(config.main.user) {
+            connection.loginfo(plugin, "Configuring loging in for SMTP server " + config.main.host + ":" + config.main.port);
+            smtp_client.on('greeting', function() {
+
+                var base64 = function (str) {
+                    var buffer = new Buffer(str, "UTF-8");
+                    return buffer.toString("base64");
+                }
+
+
+                if(config.main.login == 'PLAIN') {
+                    connection.loginfo(plugin, "Logging in with AUTH PLAIN " + config.main.user);
+                    smtp_client.send_command('AUTH','PLAIN ' + base64("\0" + config.main.user + "\0" + config.main.passwd));
+                } else if(config.login == 'LOGIN') {
+                    smtp_client.send_command('AUTH','LOGIN');
+                    smtp_client.on('auth', function() {
+                        connection.loginfo(plugin, "Logging in with AUTH LOGIN " + config.main.user);
+                    });
+                    smtp_client.on('auth_username', function() {
+                        smtp_client.send_command(base64(config.main.user) + "\r\n");
+                    });
+                    smtp_client.on('auth_password', function() {
+                        smtp_client.send_command(base64(config.main.passwd) + "\r\n");
+                    });
+                }
+            });
+        }
+
+
+
+
         var rcpt = 0;
         var send_rcpt = function () {
             if (_is_dead_sender(plugin, connection, smtp_client)) {

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -51,6 +51,16 @@ function SMTPClient(port, host, connect_timeout, idle_timeout) {
             return;
         }
 
+        if (self.command === 'auth') {
+            if (code.match(/^3/) && cont === 'VXNlcm5hbWU6') {
+                self.emit('auth_username');
+                return;
+            } else if (code.match(/^3/) && cont === 'UGFzc3dvcmQ6') {
+                self.emit('auth_password');
+                return;
+            }
+        }
+
         if (self.command === 'ehlo') {
             if (code.match(/^5/)) {
                 // Handle fallback to HELO if EHLO is rejected


### PR DESCRIPTION
It basically provides a transparent SMTP proxy service to the back-end system. You can
then use one SMTP server (Haraka) to forward your emails to different
back-end servers based on your username. Especially useful if you are
using one IP-address and for example, two DavMail servers. This change
directly complements what Perdition (Mail retrieval proxy) does for POP
and IMAP.