### PR TITLE
Check whitelists before checking DNS

### DIFF
--- a/plugins/lookup_rdns.strict.js
+++ b/plugins/lookup_rdns.strict.js
@@ -71,18 +71,18 @@ exports.hook_lookup_rdns = function (next, connection) {
     var timeout      = config.general && (config.general['timeout']     || 60);
     var timeout_msg  = config.general && (config.general['timeout_msg'] || '');
 
+    if (_in_whitelist(connection, plugin, connection.remote_ip)) {
+        called_next++;
+        next(OK, connection.remote_ip);
+    }
+
     timeout_id = setTimeout(function () {
         if (!called_next) {
             connection.loginfo(plugin, 'timed out when looking up ' +
                 connection.remote_ip + '. Disconnecting.');
             called_next++;
-
-            if (_in_whitelist(connection, plugin, connection.remote_ip)) {
-                next(OK, connection.remote_ip);
-            } else {
-                next(DENYDISCONNECT, '[' + connection.remote_ip + '] ' +
-                    timeout_msg);
-            }
+            next(DENYDISCONNECT, '[' + connection.remote_ip + '] ' +
+                timeout_msg);
         }
     }, timeout * 1000);
 
@@ -91,13 +91,8 @@ exports.hook_lookup_rdns = function (next, connection) {
             if (!called_next) {
                 called_next++;
                 clearTimeout(timeout_id);
-
-                if (_in_whitelist(connection, plugin, connection.remote_ip)) {
-                    next(OK, connection.remote_ip);
-                } else {
-                    _dns_error(connection, next, err, connection.remote_ip, plugin,
-                        rev_nxdomain, rev_dnserror);
-                }
+                _dns_error(connection, next, err, connection.remote_ip, plugin,
+                    rev_nxdomain, rev_dnserror);
             }
         } else {
             // Anything this strange needs documentation.  Since we are
@@ -106,6 +101,15 @@ exports.hook_lookup_rdns = function (next, connection) {
             // we know to send an error of nothing has been found.  Also,
             // on err, this helps us figure out if we still have more to check.
             total_checks = domains.length;
+
+            // Check whitelist before we start doing a bunch more DNS queries.
+            for(var i = 0; i < domains.length; i++) {
+                if (_in_whitelist(connection, plugin, domains[i])) {
+                    called_next++;
+                    clearTimeout(timeout_id);
+                    next(OK, domains[i]);
+                }
+            }
 
             // Now we should make sure that the reverse response matches
             // the forward address.  Almost no one will have more than one
@@ -120,13 +124,8 @@ exports.hook_lookup_rdns = function (next, connection) {
                         if (!called_next && !total_checks) {
                             called_next++;
                             clearTimeout(timeout_id);
-
-                            if (_in_whitelist(connection, plugin, rdns)) {
-                                next(OK, rdns);
-                            } else {
-                                _dns_error(connection, next, err, rdns, plugin,
-                                    fwd_nxdomain, fwd_dnserror);
-                            }
+                            _dns_error(connection, next, err, rdns, plugin,
+                                fwd_nxdomain, fwd_dnserror);
                         }
                     } else {
                         for (var i = 0; i < addresses.length ; i++) {
@@ -143,13 +142,8 @@ exports.hook_lookup_rdns = function (next, connection) {
                         if (!called_next && !total_checks) {
                             called_next++;
                             clearTimeout(timeout_id);
-
-                            if (_in_whitelist(connection, plugin, rdns)) {
-                                next(OK, rdns);
-                            } else {
-                                next(DENYDISCONNECT, rdns + ' [' +
-                                    connection.remote_ip + '] ' + nomatch);
-                            }
+                            next(DENYDISCONNECT, rdns + ' [' +
+                                connection.remote_ip + '] ' + nomatch);
                         }
                     }
                 });


### PR DESCRIPTION
This change is a slight performance improvement, as well as a bug
fix for the case where an IP address is in the whitelist.  Basically,
the whitelist should always be checked before any run of DNS queries.
