### PR TITLE
return after next() in the whitelist checks

### DIFF
--- a/plugins/lookup_rdns.strict.js
+++ b/plugins/lookup_rdns.strict.js
@@ -73,7 +73,7 @@ exports.hook_lookup_rdns = function (next, connection) {
 
     if (_in_whitelist(connection, plugin, connection.remote_ip)) {
         called_next++;
-        next(OK, connection.remote_ip);
+        return next(OK, connection.remote_ip);
     }
 
     timeout_id = setTimeout(function () {
@@ -108,7 +108,7 @@ exports.hook_lookup_rdns = function (next, connection) {
                 if (_in_whitelist(connection, plugin, domains[i])) {
                     called_next++;
                     clearTimeout(timeout_id);
-                    next(OK, domains[i]);
+                    return next(OK, domains[i]);
                 }
             }
 


### PR DESCRIPTION
This throws an error since the plugin keeps running, and we end up doing DNS checks we don't need to.  Low priority bug.
