### PR TITLE
Deferred hook

### DIFF
--- a/bin/haraka
+++ b/bin/haraka
@@ -369,7 +369,7 @@ else if (parsed.order) {
                  'capabilities', 'unrecognized_command', 'mail', 'rcpt', 'rcpt_ok', 'data', 
                  'max_data_exceeded', 'data_post', 'queue', 'queue_outbound','queue_ok', 
                  'quit', 'disconnect', 'vrfy', 'noop', 'rset', 'reset_transaction', 'deny',
-                 'get_mx', 'bounce', 'delivered', 'send_email'];
+                 'get_mx', 'bounce', 'delivered', 'send_email','deferred'];
     console.log('');
     for (var h = 0; h < hooks.length; h++) {
         var hook = hooks[h];

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -161,6 +161,7 @@ These are just the name of the hook, with any parameter sent to it:
 * reset\_transaction - called before the transaction is reset (via RSET, or MAIL)
 * deny - called if a plugin returns one of DENY, DENYSOFT or DENYDISCONNECT
 * get\_mx (hmail, domain) - called when sending outbound mail to lookup the MX record
+* deferred (hmail, params) - called when sending outbound mail if the mail was deferred
 * bounce (hmail, err) - called when sending outbound mail if the mail would bounce
 * delivered (hmail, [host, ip, response, delay, port, mode, recipients]) - called
 when outbound mail is delivered to the destination

--- a/outbound.js
+++ b/outbound.js
@@ -1298,8 +1298,8 @@ HMailItem.prototype.temp_fail = function (err, extra) {
     
     var delay = (Math.pow(2, (this.num_failures + 5)) * 1000);
     var until = Date.now() + delay;
-    
-    this.loginfo("Temp failing " + this.filename + " for " + (delay/1000) + " seconds: " + err);
+
+    plugins.run_hooks('deferred', this, {delay: delay/1000, err: err});
     
     var new_filename = this.filename.replace(/^(\d+)_(\d+)_/, until + '_' + this.num_failures + '_');
     
@@ -1317,6 +1317,10 @@ HMailItem.prototype.temp_fail = function (err, extra) {
         temp_fail_queue.add(delay, function () { delivery_queue.push(hmail) });
     });
 }
+
+HMailItem.prototype.deferred_respond = function (retval, msg, params) {
+    this.loginfo("Temp failing " + this.filename + " for " + (params.delay/1000) + " seconds: " + params.err);
+};
 
 // The following handler has an impact on outgoing mail. It does remove the queue file.
 HMailItem.prototype.delivered_respond = function (retval, msg) {


### PR DESCRIPTION
Hi guys,

As I want to be able to monitor the messages in a precise way, I created a new hook "deferred". It should be called when the delivery of a message is being deferred.

For example in my use case I want to send the status of all the messages to a redis database, so I am writing a plugin that uses this hook to log the messages that weren't yet delivered and the reasons.
