### PR TITLE
bsd.rc: added start method

### DIFF
--- a/contrib/haraka.bsd.rc
+++ b/contrib/haraka.bsd.rc
@@ -13,10 +13,16 @@ rcvar="haraka_enable"
 command="/usr/local/bin/haraka"
 pidfile="/var/run/${name}.pid"
 
+start_cmd="start"
 status_cmd="status"
 stop_cmd="stop"
 
 load_rc_config $name
+
+start()
+{
+    /usr/local/bin/node /usr/local/bin/haraka $haraka_flags
+}
 
 status()
 {


### PR DESCRIPTION
this often failed:  service haraka start

because of this:
   head -n1 /usr/local/bin/haraka

the 'imported from rc.subr' start method only worked when node was in PATH.
Now it works both ways
