### PR TITLE
Bannering Fixes

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -195,8 +195,8 @@ Body.prototype.parse_end = function (line) {
                 banner_buf = new Buffer(banner_str);
             }
 
-            // Allocate a new buffer: (7 or 1 is <P>...</P> vs \n...\n - correct that if you change those!)
-            var new_buf = new Buffer(buf.length + banner_buf.length + (this.is_html ? 7 : 1));
+            // Allocate a new buffer: (7 or 2 is <P>...</P> vs \n...\n - correct that if you change those!)
+            var new_buf = new Buffer(buf.length + banner_buf.length + (this.is_html ? 7 : 2));
 
             // Now we find where to insert it and combine it with the original buf:
             if (this.is_html) {


### PR DESCRIPTION
This fixes incorrect TEXT banners, as well as a bug with HTML banners when Content-Type was text/html and there were no MIME entities.  In those cases, the terminal DOT on the protocol was removed, so the receiving back-end server never saw DATA portion of the protocol terminated.
