### PR TITLE
config: provably correct handling of config.get args

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,7 +2,7 @@
 
 var configloader = require('./configfile');
 var path         = require('path');
-// var logger       = require('./logger');
+var logger       = require('./logger');
 
 var config = exports;
 
@@ -13,10 +13,8 @@ config.get = function(name, type, cb, options) {
     var config_path = process.env.HARAKA
                     ? path.join(process.env.HARAKA, 'config')
                     : path.join(__dirname, './config');
-    // console.log('config_path: ' + config_path);
 
     var full_path = path.resolve(config_path, args[0]);
-    // console.log('full_path: ' + full_path);
 
     var results = configloader.read_config(full_path, args[1], args[2], args[3]);
 

--- a/configfile.js
+++ b/configfile.js
@@ -270,4 +270,3 @@ cfreader.load_binary_config = function(name, type) {
 var fs     = require('fs');
 var utils  = require('./utils');
 var logger = require('./logger');
-

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,130 +1,103 @@
-
-var config       = require('../config');
+var stub             = require('./fixtures/stub'),
+    Plugin           = require('./fixtures/stub_plugin'),
+    configfile   = require('../configfile'),
+    config       = require('../config');
 
 var cb = function () { return false; };
 var opts = { booleans: ['arg1'] };
 
-function _test_arrange_args(test, args, expected) {
-    /*
-    console.log("args: " + args);
-    console.log("config: " + config);
-    for (var i in config) { console.log("config key: " + i); }
-    console.log("arrange_args: " + config.arrange_args);
-    */
-    test.expect(1);
-    test.deepEqual(config.arrange_args(args), expected);
-    test.done();
-}
-
 exports.arrange_args = {
     // config.get('name');
     'name' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini'],
-                ['test.ini', 'ini', undefined, undefined ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini']), ['test.ini', 'ini', undefined, undefined]);
+        test.done();
     },
     // config.get('name', type);
     'name, type' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'ini'],
-                ['test.ini', 'ini', undefined, undefined ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini','ini']), ['test.ini', 'ini', undefined, undefined]);
+        test.done();
     },
     // config.get('name', cb);
     'name, callback' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', cb],
-                ['test.ini', 'ini', cb, undefined ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini',cb]), ['test.ini', 'ini', cb, undefined]);
+        test.done();
     },
     // config.get('name', cb, options);
     'name, callback, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', cb, opts],
-                ['test.ini', 'ini', cb, opts ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini',cb,opts]), ['test.ini', 'ini', cb, opts]);
+        test.done();
     },
     // config.get('name', options);
     'name, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', opts],
-                ['test.ini', 'ini', undefined, opts ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini',opts]), ['test.ini', 'ini', undefined, opts]);
+        test.done();
     },
     // config.get('name', type, cb);
     'name, type, callback' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'ini', cb],
-                ['test.ini', 'ini', cb, undefined ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini','ini',cb]), ['test.ini', 'ini', cb, undefined]);
+        test.done();
     },
     // config.get('name', type, options);
     'name, type, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'ini', opts],
-                ['test.ini', 'ini', undefined, opts ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini','ini',opts]), ['test.ini', 'ini', undefined, opts]);
+        test.done();
     },
     // config.get('name', type, cb, options);
     'name, type, callback, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'ini', cb, opts],
-                ['test.ini', 'ini', cb, opts ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini','ini',cb, opts]), ['test.ini', 'ini', cb, opts]);
+        test.done();
     },
     // config.get('name', list, cb, options);
     'name, list type, callback, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'list', cb, opts],
-                ['test.ini', 'list', cb, opts ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini','list',cb, opts]), ['test.ini', 'list', cb, opts]);
+        test.done();
     },
     // config.get('name', binary, cb, options);
     'name, binary type, callback, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'binary', cb, opts],
-                ['test.ini', 'binary', cb, opts ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini','binary',cb, opts]), ['test.ini', 'binary', cb, opts]);
+        test.done();
     },
     // config.get('name', type, cb, options);
     'name, value type, callback, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'value', cb, opts],
-                ['test.ini', 'value', cb, opts ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini','value',cb, opts]), ['test.ini', 'value', cb, opts]);
+        test.done();
     },
     // config.get('name', type, cb, options);
     'name, json type, callback, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'json', cb, opts],
-                ['test.ini', 'json', cb, opts ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini','json',cb, opts]), ['test.ini', 'json', cb, opts]);
+        test.done();
     },
     // config.get('name', type, cb, options);
     'name, data type, callback, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'data', cb, opts],
-                ['test.ini', 'data', cb, opts ]
-        );
-    },
-    // config.get('name', type, cb, options);
-    'name, ini type, callback, options' : function (test) {
-        _test_arrange_args(test,
-                ['test.ini', 'ini', cb, opts],
-                ['test.ini', 'ini', cb, opts ]
-        );
+        test.expect(1);
+        test.deepEqual(config.arrange_args(['test.ini','data',cb, opts]), ['test.ini', 'data', cb, opts]);
+        test.done();
     },
 };
+
+var res = { "main": {} };
+var res2 = { "main": { "reject": true } };
+var testopts = { booleans: ['main.bool_true','main.bool_false'] };
+var testini1 = { main: { bool_true: 'true', bool_false: 'false', str_true: 'true', str_false: 'false' } };
+var testini2 = { main: { bool_true: true, bool_false: false, str_true: 'true', str_false: 'false' } };
 
 function _test_get(test, name, type, callback, options, expected) {
     test.expect(1);
     test.deepEqual(config.get(name,type,callback,options), expected);
     test.done();
 }
-
-var res = { "main": {} };
-var res2 = { "main": { "reject": true } };
 
 exports.get = {
     // config.get('name');
@@ -135,6 +108,50 @@ exports.get = {
     'name.ini' : function (test) {
         _test_get(test, 'test.ini', null, null, null, res);
     },
-    // TODO: write out a 'test.ini' file into the config dir, do a config.get
-    // on it and validate contents against res2
+    'test.ini, no opts' : function (test) {
+        _test_get(test, '../tests/test.ini', null, null, null, testini1);
+    },
+    // CACHE BUG
+    /*
+    'test.ini, opts' : function (test) {
+        _test_get(test, '../tests/test.ini', null, null, testopts, testini2);
+    },
+    */
+};
+
+exports.load_ini_config = {
+    'non-exist.ini empty' : function (test) {
+        test.expect(1);
+        test.deepEqual(
+                configfile.load_ini_config('non-exist.ini'),
+                { main: { } }
+                );
+        test.done();
+    },
+    'non-exist.ini boolean' : function (test) {
+        test.expect(1);
+        test.deepEqual(
+                configfile.load_ini_config('non-exist.ini', { booleans: ['reject']}),
+                { main: { reject: false } }
+                );
+        test.done();
+    },
+    'test.ini, no opts' : function (test) {
+        test.expect(4);
+        var r = configfile.load_ini_config('tests/test.ini');
+        test.strictEqual(r.main.bool_true, 'true');
+        test.strictEqual(r.main.bool_false, 'false');
+        test.strictEqual(r.main.str_true, 'true');
+        test.strictEqual(r.main.str_false, 'false');
+        test.done();
+    },
+    'test.ini, opts' : function (test) {
+        test.expect(4);
+        var r = configfile.load_ini_config('tests/test.ini', testopts);
+        test.strictEqual(r.main.bool_true, true);
+        test.strictEqual(r.main.bool_false, false);
+        test.strictEqual(r.main.str_true, 'true');
+        test.strictEqual(r.main.str_false, 'false');
+        test.done();
+    },
 };

--- a/tests/test.ini
+++ b/tests/test.ini
@@ -1,0 +1,6 @@
+
+bool_true=true
+bool_false=false
+
+str_true=true
+str_false=false


### PR DESCRIPTION
% nodeunit tests/config.js 

config.js
✔ arrange_args - name
✔ arrange_args - name, type
✔ arrange_args - name, callback
✔ arrange_args - name, callback, options
✔ arrange_args - name, options
✔ arrange_args - name, type, callback
✔ arrange_args - name, type, options
✔ arrange_args - name, type, callback, options
✔ get - name, bare
✔ get - name.ini

OK: 10 assertions (15ms)

Works a treat, except I can't figure out why logger breaks it when it gets loaded. Besides that detail, this works.
