### PR TITLE
Bug fix on haproxy ipAddress matching.

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -117,7 +117,7 @@ function setupClient(self) {
     });
 
     if (haproxy_hosts.some(function (element, index, array) {
-        return self.remote_ip.match(element[0], element[1]);
+        return ipaddr.IPv4.parse(self.remote_ip).match(element[0], element[1]);
     })) {
         self.proxy = true;
         // Wait for PROXY command


### PR DESCRIPTION
self.remote_ip is a String at this point. Match is failing against it.

This reparses the the IP address into an IPv4 object and then use the match to check whether it is contained in the CIDR network range.
