### PR TITLE
relay_acl: add a default netmask

### DIFF
--- a/plugins/relay_acl.js
+++ b/plugins/relay_acl.js
@@ -13,7 +13,7 @@ exports.check_acl = function (next, connection, params) {
     this.acl_allow = this.config.get('relay_acl_allow', 'list');
 
     connection.logdebug(this, 'checking ' + connection.remote_ip + ' in check_acl_allow');
-    if (is_acl_allowed(connection, this, connection.remote_ip)) {
+    if (this.is_acl_allowed(connection)) {
         connection.relaying = 1;
         next(OK);
     } else {
@@ -62,15 +62,19 @@ function dest_domain_action(connection, plugin, domains_ini, dest_domain) {
 /**
  * @return bool}
  */
-function is_acl_allowed(connection, plugin, ip) {
+exports.is_acl_allowed = function (connection) {
+    var plugin = this;
+    var ip = connection.remote_ip;
     var i = 0;
     for (i in plugin.acl_allow) {
-        connection.logdebug(plugin, 'checking if ' + ip + ' is in ' + plugin.acl_allow[i]);
+        var item = plugin.acl_allow[i];
+        connection.logdebug(plugin, 'checking if ' + ip + ' is in ' + item);
         var cidr = plugin.acl_allow[i].split("/");
+        if (!cidr[1]) cidr[1] = 32;
         if (ipaddr.parse(ip).match(ipaddr.parse(cidr[0]), cidr[1])) {
-            connection.logdebug(plugin, 'checking if ' + ip + ' is in ' + plugin.acl_allow[i] + ": yes");
+            connection.logdebug(plugin, 'checking if ' + ip + ' is in ' + item + ": yes");
             return true;
         }
     }
     return false;
-}
+};

--- a/tests/fixtures/stub_plugin.js
+++ b/tests/fixtures/stub_plugin.js
@@ -17,7 +17,7 @@ function Plugin(name) {
     this.register_hook = stub();
     this.config = stub();
 
-    var levels = [ 'data', 'protocol', 'debug', 'info', 'notice', 'warn', 'error', 'crit', 'aler  t', 'emerg' ];
+    var levels = [ 'data', 'protocol', 'debug', 'info', 'notice', 'warn', 'error', 'crit', 'alert', 'emerg' ];
     for (var i=0; i < levels.length; i++) {
         this['log' + levels[i]] = stub();
     }

--- a/tests/plugins/relay_acl.js
+++ b/tests/plugins/relay_acl.js
@@ -1,0 +1,45 @@
+var stub             = require('../fixtures/stub'),
+//  constants        = require('../../constants'),
+    Connection       = require('../fixtures/stub_connection'),
+    Plugin           = require('../fixtures/stub_plugin');
+
+// huge hack here, but plugin tests need constants
+// constants.import(global);
+
+function _set_up(callback) {
+    this.backup = {};
+
+    // needed for tests
+    this.plugin = Plugin('relay_acl');
+    this.connection = Connection.createConnection();
+
+    // going to need these in multiple tests
+    // this.plugin.register();
+
+    callback();
+}
+
+function _tear_down(callback) {
+    callback();
+}
+
+exports.is_acl_allowed = {
+    setUp : _set_up,
+    tearDown : _tear_down,
+    'bare IP' : function (test) {
+        test.expect(3);
+        this.plugin.acl_allow=['127.0.0.6'];
+        test.equal(true, this.plugin.is_acl_allowed(this.connection, '127.0.0.6'));
+        test.equal(false, this.plugin.is_acl_allowed(this.connection, '127.0.0.5'));
+        test.equal(false, this.plugin.is_acl_allowed(this.connection, '127.0.1.5'));
+        test.done();
+    },
+    'netmask' : function (test) {
+        test.expect(3);
+        this.plugin.acl_allow=['127.0.0.6/24'];
+        test.equal(true, this.plugin.is_acl_allowed(this.connection, '127.0.0.6'));
+        test.equal(true, this.plugin.is_acl_allowed(this.connection, '127.0.0.5'));
+        test.equal(false, this.plugin.is_acl_allowed(this.connection, '127.0.1.5'));
+        test.done();
+    },
+};


### PR DESCRIPTION
(Yes, the docs _do_ say to use CIDR notation, but putting a bare IP in there turns the server into an open relay)
