### PR TITLE
acl: don't crash if relay_dest_domains.ini missing

### DIFF
--- a/plugins/relay_acl.js
+++ b/plugins/relay_acl.js
@@ -63,9 +63,9 @@ function dest_domain_action(connection, plugin, domains_ini, dest_domain) {
 /**
  * @return bool}
  */
-exports.is_acl_allowed = function (connection) {
+exports.is_acl_allowed = function (connection, ip) {
     var plugin = this;
-    var ip = connection.remote_ip;
+    if (!ip) ip = connection.remote_ip;
     for (var i in plugin.acl_allow) {
         var item = plugin.acl_allow[i];
         connection.logdebug(plugin, 'checking if ' + ip + ' is in ' + item);

--- a/tests/plugins/relay_acl.js
+++ b/tests/plugins/relay_acl.js
@@ -23,6 +23,20 @@ function _tear_down(callback) {
     callback();
 }
 
+exports.relay_dest_domains = {
+    setUp : _set_up,
+    tearDown : _tear_down,
+    'relaying' : function (test) {
+        test.expect(1);
+        var next = function() {
+            test.equal(undefined, arguments[0]);
+            test.done();
+        };
+        this.connection.relaying=true;
+        this.plugin.relay_dest_domains(next, this.connection, [{host:'foo'}]);
+    },
+};
+
 exports.is_acl_allowed = {
     setUp : _set_up,
     tearDown : _tear_down,


### PR DESCRIPTION
plugin attempts to access a section of relay_dest_domains.ini. If the config file is missing, the access attempt crashes the plugin. This checks for the required section and skips domain test if missing.

Also updated the log entry and variable names to reflect this plugins current name.
