### PR TITLE
config: initialize bools as undefined (vs false)

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -124,7 +124,7 @@ cfreader.load_ini_config = function(name, options) {
             if (m = /^(?:([^\. ]+)\.)?(.+)/.exec(options.booleans[i])) {
                 if (!m[1]) m[1] = 'main';
                 if (!result[m[1]]) result[m[1]] = {};
-                result[m[1]][m[2]] = false;
+                result[m[1]][m[2]] = undefined;
             }
         }
     }

--- a/tests/config.js
+++ b/tests/config.js
@@ -132,7 +132,7 @@ exports.load_ini_config = {
         test.expect(1);
         test.deepEqual(
                 configfile.load_ini_config('non-exist.ini', { booleans: ['reject']}),
-                { main: { reject: false } }
+                { main: { reject: undefined } }
                 );
         test.done();
     },


### PR DESCRIPTION
If booleans are initialized as false, how does one tell the difference between a missing config setting (old config file) and a boolean that someone explicitly turned off (false)?

Being unable to distinguish between them makes it really hard to apply defaults.
