### PR TITLE
Fix SPF MX mechanism when no records are returned

### DIFF
--- a/spf.js
+++ b/spf.js
@@ -534,6 +534,9 @@ SPF.prototype.mech_mx = function (qualifier, args, cb) {
                 return cb(null, self.SPF_NONE);
             }
         }
+        if (pending === 0) {
+            return cb(null, self.SPF_NONE);
+        }
     });
 }
 
@@ -573,8 +576,11 @@ SPF.prototype.mech_ptr = function (qualifier, args, cb) {
                     else {
                         for (var a=0; a<addrs.length; a++) {
                             if (addrs[a] === self.ip) {
-                                self.log_debug('mech_ptr: ' + self.ip + ' => ' + ptr + ' => ' + addrs[a]);
+                                self.log_debug('mech_ptr: ' + self.ip + ' => ' + ptr + ' => ' + addrs[a] + ': MATCH!');
                                 names.push(ptr.toLowerCase());
+                            }
+                            else {
+                                self.log_debug('mech_ptr: ' + self.ip + ' => ' + ptr + ' => ' + addrs[a] + ': NO MATCH');
                             }
                         }
                     }


### PR DESCRIPTION
Bug found by @godsflaw on the IRC channel last night:

```
[root@mail1-ec2 plugins]# haraka_spf --debug --domain ofa0.bounce.bluestatedigital.com --ip 66.151.230.132
DEBUG: ip=66.151.230.132 domain=ofa0.bounce.bluestatedigital.com mail_from=postmaster@ofa0.bounce.bluestatedigital.com
DEBUG: found SPF record for domain ofa0.bounce.bluestatedigital.com: v=spf1 a mx include:_spf.ip.bluestatedigital.com include:_spf.a.bluestatedigital.com include:_spf.google.com ~all
DEBUG: found mechanism: a,+,a
DEBUG: found mechanism: mx,+,mx
DEBUG: found mechanism: include:_spf.ip.bluestatedigital.com,+,include,:_spf.ip.bluestatedigital.com
DEBUG: found mechanism: include:_spf.a.bluestatedigital.com,+,include,:_spf.a.bluestatedigital.com
DEBUG: found mechanism: include:_spf.google.com,+,include,:_spf.google.com
DEBUG: found mechanism: ~all,~,all
DEBUG: SPF record for 'ofa0.bounce.bluestatedigital.com' validated OK
DEBUG: running mechanism: a args=+, domain=ofa0.bounce.bluestatedigital.com
DEBUG: mech_a: 66.151.230.132 => 64.94.250.117: NO MATCH
DEBUG: running mechanism: mx args=+, domain=ofa0.bounce.bluestatedigital.com
```

Note that no result was actually returned.

This was caused because:

[smf@mail1-ec2 Haraka]$ host -t MX  ofa0.bounce.bluestatedigital.com
ofa0.bounce.bluestatedigital.com is an alias for bounce.bluestatedigital.com.

CNAMES are not allowed in MX records and node's DNS MX lookup function will not follow them, thus an empty result is returned for the MX lookup which was not correctly handled.

After this fix:

```
[root@mail1-ec2 plugins]#  haraka_spf --debug --domain ofa0.bounce.bluestatedigital.com --ip 66.151.230.132
DEBUG: ip=66.151.230.132 domain=ofa0.bounce.bluestatedigital.com mail_from=postmaster@ofa0.bounce.bluestatedigital.com
DEBUG: found SPF record for domain ofa0.bounce.bluestatedigital.com: v=spf1 a mx include:_spf.ip.bluestatedigital.com include:_spf.a.bluestatedigital.com include:_spf.google.com ~all
DEBUG: found mechanism: a,+,a
DEBUG: found mechanism: mx,+,mx
DEBUG: found mechanism: include:_spf.ip.bluestatedigital.com,+,include,:_spf.ip.bluestatedigital.com
DEBUG: found mechanism: include:_spf.a.bluestatedigital.com,+,include,:_spf.a.bluestatedigital.com
DEBUG: found mechanism: include:_spf.google.com,+,include,:_spf.google.com
DEBUG: found mechanism: ~all,~,all
DEBUG: SPF record for 'ofa0.bounce.bluestatedigital.com' validated OK
DEBUG: running mechanism: a args=+, domain=ofa0.bounce.bluestatedigital.com
DEBUG: mech_a: 66.151.230.132 => 64.94.250.117: NO MATCH
DEBUG: running mechanism: mx args=+, domain=ofa0.bounce.bluestatedigital.com
DEBUG: running mechanism: include args=+,:_spf.ip.bluestatedigital.com domain=ofa0.bounce.bluestatedigital.com
DEBUG: ip=66.151.230.132 domain=_spf.ip.bluestatedigital.com mail_from=postmaster@ofa0.bounce.bluestatedigital.com
DEBUG: found SPF record for domain _spf.ip.bluestatedigital.com: v=spf1 ip4:64.94.250.0/24 ip4:66.151.182.16/29 ip4:66.151.230.0/24 ip4:69.25.202.0/24 ip4:69.25.74.0/24 ip4:70.42.50.0/24 ip4:70.42.57.0/24 ~all
DEBUG: found mechanism: ip4:64.94.250.0/24,+,ip4,:64.94.250.0/24
DEBUG: found mechanism: ip4:66.151.182.16/29,+,ip4,:66.151.182.16/29
DEBUG: found mechanism: ip4:66.151.230.0/24,+,ip4,:66.151.230.0/24
DEBUG: found mechanism: ip4:69.25.202.0/24,+,ip4,:69.25.202.0/24
DEBUG: found mechanism: ip4:69.25.74.0/24,+,ip4,:69.25.74.0/24
DEBUG: found mechanism: ip4:70.42.50.0/24,+,ip4,:70.42.50.0/24
DEBUG: found mechanism: ip4:70.42.57.0/24,+,ip4,:70.42.57.0/24
DEBUG: found mechanism: ~all,~,all
DEBUG: SPF record for '_spf.ip.bluestatedigital.com' validated OK
DEBUG: running mechanism: ip4 args=+,:64.94.250.0/24 domain=_spf.ip.bluestatedigital.com
DEBUG: mech_ip: 66.151.230.132 => 64.94.250.0/24: NO MATCH
DEBUG: running mechanism: ip4 args=+,:66.151.182.16/29 domain=_spf.ip.bluestatedigital.com
DEBUG: mech_ip: 66.151.230.132 => 66.151.182.16/29: NO MATCH
DEBUG: running mechanism: ip4 args=+,:66.151.230.0/24 domain=_spf.ip.bluestatedigital.com
DEBUG: mech_ip: 66.151.230.132 => 66.151.230.0/24: MATCH!
DEBUG: mech_include: domain=_spf.ip.bluestatedigital.com returned=SPF_PASS
ip=66.151.230.132 helo="" domain="ofa0.bounce.bluestatedigital.com" result=Pass
```

We now have a correct result:

**ip=66.151.230.132 helo="" domain="ofa0.bounce.bluestatedigital.com" result=Pass**
