### PR TITLE
relay_acl: added result_store

### DIFF
--- a/tests/plugins/relay_acl.js
+++ b/tests/plugins/relay_acl.js
@@ -54,6 +54,21 @@ exports.is_acl_allowed = {
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
         test.done();
     },
+    'mixed (ipv4 & ipv6 (Issue #428))' : function (test) {
+        test.expect(3);
+        this.connection.remote_ip='2607:f060:b008:feed::2';
+        test.equal(false, this.plugin.is_acl_allowed(this.connection));
+
+        this.plugin.acl_allow=['2607:f060:b008:feed::2/64'];
+        this.connection.remote_ip='2607:f060:b008:feed::2';
+        test.equal(true, this.plugin.is_acl_allowed(this.connection));
+
+        this.plugin.acl_allow=['127.0.0.6/24'];
+        this.connection.remote_ip='2607:f060:b008:feed::2';
+        test.equal(false, this.plugin.is_acl_allowed(this.connection));
+
+        test.done();
+    },
 };
 
 exports.relay_dest_domains = {


### PR DESCRIPTION
and refactored for simplicity and testability.

config loading is done in refresh_config, mainly to make writing tests
convenient. Tests can set plugin.cfg values, test, set other values, repeat ad testium)
