### PR TITLE
config: fix for .ini booleans being returned as strings

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -45,7 +45,7 @@ cfreader.read_config = function(name, type, cb, options) {
     }
 
     return result;
-}
+};
 
 cfreader.empty_config = function(type) {
     if (type === 'ini') {
@@ -110,12 +110,14 @@ cfreader.load_json_config = function(name) {
         }
     }
     return result;
-}
+};
 
 cfreader.load_ini_config = function(name, options) {
     var result       = cfreader.empty_config('ini');
     var current_sect = result.main;
     var current_sect_name = 'main';
+    var bool_matches = [];
+    if (options && options.booleans) bool_matches = options.booleans.slice();
 
     // Initialize any booleans
     if (options && Array.isArray(options.booleans)) {
@@ -131,6 +133,11 @@ cfreader.load_ini_config = function(name, options) {
 
                 if (section.match(/^(\-|\+)/)) section = section.substr(1);
                 if (    key.match(/^(\-|\+)/)) key     =     key.substr(1);
+
+                // so the boolean detection in the next section will match
+                if (options.booleans.indexOf(section+'.'+key) === -1) {
+                    bool_matches.push(section+'.'+key);
+                }
 
                 if (!result[section]) result[section] = {};
                 result[section][key] = bool_default;
@@ -165,7 +172,7 @@ cfreader.load_ini_config = function(name, options) {
                 pre = '';
                 if (match = regex.param.exec(line)) {
                     if (options && Array.isArray(options.booleans) &&
-                        options.booleans.indexOf(current_sect_name + '.' + match[1]) !== -1)
+                        bool_matches.indexOf(current_sect_name + '.' + match[1]) !== -1)
                     {
                         current_sect[match[1]] = regex.is_truth.test(match[2]);
                         logger.logdebug('Returning boolean ' + current_sect[match[1]] +
@@ -183,7 +190,7 @@ cfreader.load_ini_config = function(name, options) {
                 }
                 else {
                     logger.logerror("Invalid line in config file '" + name + "': " + line);
-                };
+                }
             });
         }
     }

--- a/tests/config.js
+++ b/tests/config.js
@@ -90,7 +90,6 @@ exports.arrange_args = {
 var res = { "main": {} };
 var res2 = { "main": { "reject": true } };
 var testopts = { booleans: ['main.bool_true','main.bool_false'] };
-var testini1 = { main: { bool_true: 'true', bool_false: 'false', str_true: 'true', str_false: 'false' } };
 var testini2 = { main: { bool_true: true, bool_false: false, str_true: 'true', str_false: 'false' } };
 
 function _test_get(test, name, type, callback, options, expected) {
@@ -109,7 +108,10 @@ exports.get = {
         _test_get(test, 'test.ini', null, null, null, res);
     },
     'test.ini, no opts' : function (test) {
-        _test_get(test, '../tests/test.ini', null, null, null, testini1);
+        _test_get(test, '../tests/test.ini', null, null, null, {
+            main: { bool_true: 'true', bool_false: 'false', str_true: 'true', str_false: 'false' },
+            sect1: { bool_true: 'true', bool_false: 'false', str_true: 'true', str_false: 'false' }
+        });
     },
     // CACHE BUG
     /*
@@ -168,6 +170,18 @@ exports.load_ini_config = {
                 );
         test.done();
     },
+    'non-exist.ini boolean false default, section' : function (test) {
+        test.expect(2);
+        test.deepEqual(
+                configfile.load_ini_config('non-exist.ini', { booleans: ['-reject.boolf']}),
+                { main: { }, reject: {boolf: false} }
+                );
+        test.deepEqual(
+                configfile.load_ini_config('non-exist.ini', { booleans: ['+reject.boolt']}),
+                { main: { }, reject: {boolt: true} }
+                );
+        test.done();
+    },
     'test.ini, no opts' : function (test) {
         test.expect(4);
         var r = configfile.load_ini_config('tests/test.ini');
@@ -184,6 +198,28 @@ exports.load_ini_config = {
         test.strictEqual(r.main.bool_false, false);
         test.strictEqual(r.main.str_true, 'true');
         test.strictEqual(r.main.str_false, 'false');
+        test.done();
+    },
+    'test.ini, sect1, opts' : function (test) {
+        test.expect(4);
+        var r = configfile.load_ini_config('tests/test.ini', {
+            booleans: ['sect1.bool_true','sect1.bool_false']
+        });
+        test.strictEqual(r.sect1.bool_true, true);
+        test.strictEqual(r.sect1.bool_false, false);
+        test.strictEqual(r.sect1.str_true, 'true');
+        test.strictEqual(r.sect1.str_false, 'false');
+        test.done();
+    },
+    'test.ini, sect1, opts, w/defaults' : function (test) {
+        test.expect(4);
+        var r = configfile.load_ini_config('tests/test.ini', {
+            booleans: ['+sect1.bool_true','-sect1.bool_false']
+        });
+        test.strictEqual(r.sect1.bool_true, true);
+        test.strictEqual(r.sect1.bool_false, false);
+        test.strictEqual(r.sect1.str_true, 'true');
+        test.strictEqual(r.sect1.str_false, 'false');
         test.done();
     },
 };

--- a/tests/test.ini
+++ b/tests/test.ini
@@ -4,3 +4,10 @@ bool_false=false
 
 str_true=true
 str_false=false
+
+[sect1]
+bool_true=true
+bool_false=false
+
+str_true=true
+str_false=false


### PR DESCRIPTION
My previous boolean fix fixed the default case for when the value wasn't declared in the ini file. then it always returned a boolean. However, when a default was defined ('+sect.key') **and** the setting was in the .ini file, that option wasn't matched in options.booleans array because of the +/- prefix.
