### PR TITLE
bounce: use new boolean config options

### DIFF
--- a/config/bounce.ini
+++ b/config/bounce.ini
@@ -1,7 +1,7 @@
 ; config/bounce_bad_rcpt: addresses that should never get bounces
 
 
-[checks]
+[check]
 single_recipient=true
 empty_return_path=true
 bad_rcpt=true

--- a/docs/plugins/bounces.md
+++ b/docs/plugins/bounces.md
@@ -11,6 +11,20 @@ This is useful to enable if you have a mail server that gets spoofed too
 much but very few legitimate users. It is potentially bad to block all
 bounce messages, but unfortunately for some hosts, sometimes necessary.
 
+
+# Configuration
+
+## [check]
+
+Each feature can be enabled/disabled with a true/false toggle in the [check]
+section of config/bounce.ini:
+
+    [check]
+    reject_all=false
+    single_recipient=true
+    empty_return_path=true
+    bad_rcpt=true
+
 * single\_recipient
 
 Valid bounces have a single recipient. Assure that the message really is a
@@ -30,23 +44,10 @@ messages. Examples of email addresses that should be listed are:
 autoresponders, do-not-reply@example.com, dmarc-feedback@example.com, and
 any other email addresses used solely for machine generated messages.
 
-# Configuration
-
-## [checks]
-
-Each feature can be enabled/disabled with a true/false toggle in the [checks]
-section of config/bounce.ini:
-
-    reject_all=false
-    single_recipient=true
-    empty_return_path=true
-    bad_rcpt=true
-
-
 ## [reject]
 
 config/bounce.ini can have a [reject] section that toggles rejections on or
-off for each check where it makes sense.
+off for the following checks:
 
     single_recipient=true
     empty_return_path=true

--- a/tests/plugins/bounce.js
+++ b/tests/plugins/bounce.js
@@ -18,7 +18,7 @@ function _set_up(callback) {
     this.plugin.config = config;
     this.plugin.cfg = {
         main: { },
-        checks: {
+        check: {
             reject_all: false,
             single_recipient: true,
             empty_return_path: true,
@@ -53,7 +53,7 @@ exports.refresh_config = {
         var plugin = this.plugin;
         var cb = function () {
             test.ok(plugin.cfg.main);
-            test.ok(plugin.cfg.checks);
+            test.ok(plugin.cfg.check);
             test.ok(plugin.cfg.reject);
         };
         this.plugin.refresh_config(cb);
@@ -75,7 +75,7 @@ exports.reject_all = {
         var cb = function () {
             test.equal(undefined, arguments[0]);
         };
-        this.plugin.cfg.checks.reject_all=false;
+        this.plugin.cfg.check.reject_all=false;
         this.plugin.reject_all(cb, this.connection, new Address.Address('<matt@example.com>'));
         test.done();
     },
@@ -89,7 +89,7 @@ exports.reject_all = {
         var cb = function () {
             test.equal(undefined, arguments[0]);
         };
-        this.plugin.cfg.checks.reject_all=true;
+        this.plugin.cfg.check.reject_all=true;
         this.plugin.reject_all(cb, this.connection, new Address.Address('<matt@example.com>'));
         test.done();
     },
@@ -103,7 +103,7 @@ exports.reject_all = {
         var cb = function () {
             test.equal(DENY, arguments[0]);
         };
-        this.plugin.cfg.checks.reject_all=true;
+        this.plugin.cfg.check.reject_all=true;
         this.plugin.reject_all(cb, this.connection, new Address.Address('<>'));
         test.done();
     },


### PR DESCRIPTION
- update docs for better flow.
- rename [checks] -> [check], so it's consistent among plugins that have it.

% ./run_tests tests/plugins/bounce.js
Running tests:  [ 'tests/plugins/bounce.js' ]

bounce.js
✔ refresh_config - yes
✔ reject_all - disabled
✔ reject_all - not bounce ok
✔ reject_all - bounce rejected
✔ empty_return_path - none
✔ empty_return_path - has
✔ single_recipient - valid
✔ single_recipient - invalid
✔ single_recipient - test@example.com
✔ single_recipient - test@example.com,test2@example.com
✔ bad_rcpt - test@good.com
✔ bad_rcpt - test@bad1.com
✔ bad_rcpt - test@bad1.com, test@bad2.com
✔ bad_rcpt - test@good.com, test@bad2.com
✔ has_null_sender - <>
✔ has_null_sender -  
✔ has_null_sender - user@example
✔ has_null_sender - user@example.com

OK: 20 assertions (109ms)
