### PR TITLE
spf: added tests

### DIFF
--- a/spf.js
+++ b/spf.js
@@ -654,7 +654,7 @@ SPF.prototype.mod_redirect = function (domain, cb) {
         return cb(null, this.SPF_NONE);
     } 
     this.count++;
-    this.been_there[domain] = 1;
+    this.been_there[domain] = true;
     return this.check_host(this.ip, domain, this.mail_from, cb);
 }
 

--- a/tests/spf.js
+++ b/tests/spf.js
@@ -1,0 +1,68 @@
+
+var SPF = require("../spf").SPF;
+
+
+function _set_up(callback) {
+    this.backup = {};
+
+    this.SPF = new SPF();
+
+    callback();
+}
+function _tear_down(callback) {
+    callback();
+}
+
+exports.SPF = {
+    setUp : _set_up,
+    tearDown : _tear_down,
+    'new SPF': function (test) {
+        test.expect(1);
+        test.ok(this);
+        test.done();
+    },
+    'constants' : function (test) {
+        test.expect(8);
+        test.equal(1, this.SPF.SPF_NONE);
+        test.equal(2, this.SPF.SPF_PASS);
+        test.equal(3, this.SPF.SPF_FAIL);
+        test.equal(4, this.SPF.SPF_SOFTFAIL);
+        test.equal(5, this.SPF.SPF_NEUTRAL);
+        test.equal(6, this.SPF.SPF_TEMPERROR);
+        test.equal(7, this.SPF.SPF_PERMERROR);
+        test.equal(10, this.SPF.LIMIT);
+        test.done();
+    },
+    'mod_redirect, true': function (test) {
+        test.expect(2);
+        var cb = function (err, rc) {
+            test.equal(null, err);
+            test.equal(1, rc);
+            test.done();
+        };
+        this.SPF.been_there['example.com'] = true;
+        this.SPF.mod_redirect('example.com', cb);
+    },
+    'mod_redirect, false': function (test) {
+        if (process.version !== 'v0.10.26') {
+            test.expect(2);
+            // var outer = this;
+            var cb = function (err, rc) {
+                test.equal(null, err);
+                test.equal(3, rc);
+                test.done();
+                // console.log(arguments);
+            };
+            this.SPF.count=0;
+            this.SPF.ip='212.70.129.94';
+            this.SPF.mail_from='fraud@aexp.com';
+            this.SPF.mod_redirect('aexp.com', cb);
+        }
+        else {
+            test.expect(0);
+            test.done();
+        }
+    },
+};
+
+


### PR DESCRIPTION
TXT record handling will (supposedly) be changed in 0.11, and the SPF breaking change removed in 0.10.27.

Running tests:  [ 'tests/plugins/spf.js' ]

spf.js
 return_results - result, none
 return_results - result, neutral
 return_results - result, pass
 return_results - result, softfail, reject=false
 return_results - result, softfail, reject=true
 return_results - result, fail, reject=false
 return_results - result, fail, reject=true
 return_results - result, temperror, reject=false
 return_results - result, temperror, reject=true
 return_results - result, permerror, reject=false
 return_results - result, permerror, reject=true
 return_results - result, unknown
 hook_mail - rfc1918
 hook_mail - no txn
 hook_mail - txn, no helo

OK: 15 assertions (158ms)
