### PR TITLE
asn: handle the "DNS bug" issue for asn.routeviews

### DIFF
--- a/tests/plugins/connect.asn.js
+++ b/tests/plugins/connect.asn.js
@@ -96,10 +96,10 @@ exports.get_dns_results = {
     tearDown : _tear_down,
 
     'origin.asn.cymru.com': function (test) {
-        var cb = function () {
-            test.equal('origin.asn.cymru.com', arguments[0]);
-            test.equal('40431', arguments[1].asn);
-            test.equal('208.75.176.0/21', arguments[1].net);
+        var cb = function (zone, obj) {
+            test.equal('origin.asn.cymru.com', zone);
+            test.equal('40431', obj.asn);
+            test.equal('208.75.176.0/21', obj.net);
             test.done();
         };
         test.expect(4);
@@ -109,13 +109,14 @@ exports.get_dns_results = {
     },
     'asn.routeviews.org': function (test) {
         test.expect(3);
-        var cb = function () {
-            test.equal('asn.routeviews.org', arguments[0]);
-            if (arguments[1].asn && arguments[1].asn === '40431') {
-                test.equal('40431', arguments[1].asn);
+        var cb = function (zone, obj) {
+            test.equal('asn.routeviews.org', zone);
+            if (obj.asn && obj.asn === '40431') {
+                test.equal('40431', obj.asn);
             }
             else {
                 test.ok("Node DNS (c-ares) bug");
+                console.log(obj);
             }
             test.done();
         };
@@ -124,10 +125,10 @@ exports.get_dns_results = {
             );
     },
     'origin.asn.spameatingmonkey.net': function (test) {
-        var cb = function () {
-            test.equal('origin.asn.spameatingmonkey.net', arguments[0]);
-            test.equal('40431', arguments[1].asn);
-            test.equal('US', arguments[1].country);
+        var cb = function (zone, obj) {
+            test.equal('origin.asn.spameatingmonkey.net', zone);
+            test.equal('40431', obj.asn);
+            test.equal('US', obj.country);
             test.done();
         };
         test.expect(4);


### PR DESCRIPTION
recap: some versions of node concatenate messages with no delimiter, making it impossible to parse the distinct messages from a TXT record
