### PR TITLE
connection: fix bug in config name

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -155,7 +155,7 @@ function Connection(client, server) {
     this.transaction = null;
     this.tran_count = 0;
     this.capabilities = null;
-    this.early_talker_delay = config.get('early_talker.pause') || 1000;
+    this.early_talker_delay = config.get('early_talker.pause') || config.get('early_talker_delay') || 1000;
     this.banner_includes_uuid = config.get('banner_includes_uuid') ? true : false;
     this.deny_includes_uuid = config.get('deny_includes_uuid') || null;
     this.early_talker = 0;


### PR DESCRIPTION
docs say early_talker.pause, config/early_talker.pause exists, make code match docs.
