### PR TITLE
tests/stub_conn: add empty notes object

### DIFF
--- a/tests/fixtures/stub_connection.js
+++ b/tests/fixtures/stub_connection.js
@@ -8,6 +8,7 @@ function Connection(client, server) {
     this.client = client;
     this.server = server;
     this.relaying = false;
+    this.notes  = {};
 
     var levels = [ 'data', 'protocol', 'debug', 'info', 'notice', 'warn', 'error', 'crit', 'alert', 'emerg' ];
     for (var i=0; i < levels.length; i++) {


### PR DESCRIPTION
avoids plugins having to set it up for themselves dozens of times
