### PR TITLE
vpopmail: fail faster during a CRAM-MD5 auth attempt with an invalid use...

### DIFF
--- a/plugins/auth/auth_vpopmaild.js
+++ b/plugins/auth/auth_vpopmaild.js
@@ -140,7 +140,14 @@ exports.get_plain_passwd = function (user, cb) {
             socket.end();             // disconnect
         }
         if (chunk_count > 2) {
-            if (!/clear_text_password/.test(chunk)) { return; }
+            if (/^\-ERR/.test(chunk)) {
+                plugin.logerror("get_plain failed: " + chunk);
+                socket.end();         // disconnect
+                return;
+            }
+            if (!/clear_text_password/.test(chunk)) {
+                return;   // pass might be in the next chunk
+            }
             var pass = chunk.match(/clear_text_password\s(\S+)\s/);
             plain_pass = pass[1];
             socket.write("quit\n\r");


### PR DESCRIPTION
...rname
