### PR TITLE
spamassassin: fixes Haraka crash when spamd_response.headers not defined

### DIFF
--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -79,16 +79,14 @@ exports.hook_data_post = function (next, connection) {
         // Abort if the transaction is gone
         if (!connection.transaction) return next();
 
-        if (spamd_response.headers['Tests']) {
-            spamd_response.tests = spamd_response.headers['Tests'];
+        if (spamd_response.headers && spamd_response.headers.Tests) {
+            spamd_response.tests = spamd_response.headers.Tests;
         }
         if (spamd_response.tests === undefined) {
             // strip the 'tests' from the X-Spam-Status header
-            var tests;
-            if (spamd_response.headers['Status'] && 
-                tests = /tests=([^ ]+)/.exec(spamd_response.headers['Status'].replace(/\r?\n\t/g,''))) 
-            {
-                spamd_response.tests = tests[1];
+            if (spamd_response.headers && spamd_response.headers.Status) {
+                var tests = /tests=([^ ]+)/.exec(spamd_response.headers.Status.replace(/\r?\n\t/g,''));
+                if (tests) { spamd_response.tests = tests[1]; }
             }
         }
 


### PR DESCRIPTION
happens when local SA config doesn't enable that header and results in this:

[CRIT] [-] [core] ReferenceError: Invalid left-hand side in assignment
    at Socket.<anonymous> (/usr/local/haraka/plugins/spamassassin.js:88:13)

tested again Haraka 2.5.0(ish) and SpamAssassin 3.4.0
