### PR TITLE
host_list: huge performance increase, esp for many hosts

### DIFF
--- a/plugins/rcpt_to.in_host_list.js
+++ b/plugins/rcpt_to.in_host_list.js
@@ -10,6 +10,7 @@
 
 exports.register = function() {
     var plugin = this;
+    plugin.host_list = {};
 
     var load_host_list = function () {
         plugin.loginfo(plugin, "loading host_list");

--- a/tests/plugins/rcpt_to.in_host_list.js
+++ b/tests/plugins/rcpt_to.in_host_list.js
@@ -17,6 +17,7 @@ function _set_up(callback) {
     // needed for tests
     this.plugin = Plugin('rcpt_to.in_host_list');
     this.plugin.cfg = {};
+    this.plugin.host_list = {};
     this.connection = Connection.createConnection();
     this.connection.transaction = {
         results: new ResultStore(this.connection),
@@ -41,7 +42,7 @@ exports.in_host_list = {
     },
     'hit' : function (test) {
         test.expect(1);
-        this.plugin.host_list=['test.com'];
+        this.plugin.host_list['test.com'] = true;
         var r = this.plugin.in_host_list('test.com');
         test.equal(true, r);
         test.done();
@@ -105,7 +106,7 @@ exports.hook_mail = {
             test.notEqual(-1, res.msg.indexOf('mail_from!local'));
             test.done();
         }.bind(this);
-        this.plugin.host_list = ['miss.com'];
+        this.plugin.host_list = { 'miss.com': true };
         this.plugin.hook_mail(next, this.connection, [new Address('<user@example.com>')]);
     },
     'hit' : function (test) {
@@ -118,7 +119,7 @@ exports.hook_mail = {
             test.notEqual(-1, res.pass.indexOf('mail_from'));
             test.done();
         }.bind(this);
-        this.plugin.host_list = ['example.com'];
+        this.plugin.host_list = { 'example.com': true };
         this.plugin.hook_mail(next, this.connection, [new Address('<user@example.com>')]);
     },
     'hit, regex, exact' : function (test) {
@@ -173,7 +174,7 @@ exports.hook_rcpt = {
             test.equal(undefined, msg);
             test.done();
         };
-        this.plugin.host_list=['test.com'];
+        this.plugin.host_list = { 'test.com': true };
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
     },
     'miss list' : function (test) {
@@ -183,7 +184,7 @@ exports.hook_rcpt = {
             test.equal(undefined, msg);
             test.done();
         };
-        this.plugin.host_list=['miss.com'];
+        this.plugin.host_list = { 'miss.com': true };
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
     },
     'hit regex, exact' : function (test) {
@@ -227,7 +228,7 @@ exports.hook_rcpt = {
             test.done();
         };
         this.connection.relaying=true;
-        this.connection.transaction.notes={ local_sender: true };
+        this.connection.transaction.notes = { local_sender: true };
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
     },
 };


### PR DESCRIPTION
Before I crap all over the implementation of rcpt_to.in_host_list, allow me to first point out the one area where it excels:

loaded 90822 hosts
loading config took 0.066 seconds (array)
loading config took 0.087 seconds (array+toLowerCase())
loading config took 0.152 seconds (object+toLowerCase())

That's right, the existing implementation is fastest at loading the config file to an array. But it's all downhill from there. In the next test, we look up every hostname in the list one time (90,822 iterations, to average the lookup time):

searching config took 1662.722 seconds (array)
searching config took   87.560 seconds (array (lc during load))
searching config took    0.208 seconds (object (lc during load))
