### PR TITLE
fcrdns: handle a null hostname

### DIFF
--- a/net_utils.js
+++ b/net_utils.js
@@ -126,10 +126,12 @@ exports.ip_to_long = function (ip) {
         var d = ip.split('.');
         return ((((((+d[0])*256)+(+d[1]))*256)+(+d[2]))*256)+(+d[3]);
     }
-}
+};
 
 exports.is_ip_in_str = function(ip, str) {
     // Only IPv4 for now
+    if (!str) { return false; }
+    if (!ip) { return false; }
     if (net.isIPv4(ip)) {
         var host_part = (this.split_hostname(str,1))[0].toString();
         var ip_split = ip.split('.');

--- a/plugins/connect.fcrdns.js
+++ b/plugins/connect.fcrdns.js
@@ -3,6 +3,21 @@ var dns       = require('dns'),
     utils     = require('./utils'),
     net_utils = require('./net_utils');
 
+exports.register = function () {
+    var plugin = this;
+    var load_config = function () {
+        plugin.cfg = plugin.config.get('connect.fcrdns.ini', {
+            booleans: [
+                '-reject.no_rdns',
+                '-reject.no_fcrdns',
+                '-reject.invalid_tld',
+                '-reject.generic_rdns',
+            ]
+        }, load_config);
+    };
+    load_config();
+};
+
 exports.hook_lookup_rdns = function (next, connection) {
     var plugin = this;
     var rip = connection.remote_ip;
@@ -161,6 +176,7 @@ exports.check_fcrdns = function(connection, results, do_next) {
     var plugin = this;
 
     for (var fdom in results) {    // mail.example.com
+        if (!fdom) continue;
         var org_domain = net_utils.get_organizational_domain(fdom); // example.com
 
         // Multiple domains?
@@ -195,6 +211,7 @@ exports.check_fcrdns = function(connection, results, do_next) {
 
 exports.ptr_compare = function (ip_list, connection, domain) {
     var plugin = this;
+    if (!ip_list) return false;
     if (!ip_list.length) return false;
 
     if (ip_list.indexOf(connection.remote_ip) !== -1) {
@@ -235,6 +252,8 @@ exports.save_auth_results = function (connection) {
 exports.is_generic_rdns = function (connection, domain) {
     var plugin = this;
     // IP in rDNS? (Generic rDNS)
+    if (!domain) return false;
+
     if (!net_utils.is_ip_in_str(connection.remote_ip, domain)) {
         connection.results.add(plugin, {pass: 'is_generic_rdns'});
         return false;
@@ -273,19 +292,6 @@ exports.log_summary = function (connection) {
 
 exports.refresh_config = function (connection) {
     var plugin = this;
-    plugin.cfg = plugin.config.get('connect.fcrdns.ini', {
-        booleans: [
-            '-reject.no_rdns',
-            '-reject.no_fcrdns',
-            '-reject.invalid_tld',
-            '-reject.generic_rdns',
-        ]
-    });
-
-    var defaults = {
-        timeout: 30,
-    };
-
     // allow rdns_acccess whitelist to override
     if (connection.notes.rdns_access && connection.notes.rdns_access === 'white') {
         plugin.cfg.reject.no_rdns = 0;


### PR DESCRIPTION
Prevent this error, when a hostname of 'null' is encountered. Experienced in the wild. :(

[CRIT] [-] [core] TypeError: Cannot call method 'split' of null
[CRIT] [-] [core]     at Plugin.exports.is_generic_rdns (/usr/local/lib/node_modules/Haraka/plugins/connect.fcrdns.js:246:54)
[CRIT] [-] [core]     at Plugin.exports.check_fcrdns (/usr/local/lib/node_modules/Haraka/plugins/connect.fcrdns.js:179:20)
[CRIT] [-] [core]     at /usr/local/lib/node_modules/Haraka/plugins/connect.fcrdns.js:86:31
[CRIT] [-] [core]     at asyncCallback (dns.js:68:16)
[CRIT] [-] [core]     at Object.onanswer [as oncomplete](dns.js:147:9)

So, add a null test, and fix all the places it goes _boom._
