### PR TITLE
Update auth_base.js

### DIFF
--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -105,6 +105,10 @@ exports.check_user = function (next, connection, credentials, method) {
                 connection.notes.auth_fails = 0;
             }
             connection.notes.auth_fails++;
+
+            connection.notes.auth_login_userlogin = null;
+            connection.notes.auth_login_asked_login = false;
+
             var delay = Math.pow(2, connection.notes.auth_fails - 1);
             if (plugin.timeout && delay >= plugin.timeout) { delay = plugin.timeout - 1 }
             connection.lognotice(plugin, 'delaying response for ' + delay + ' seconds');


### PR DESCRIPTION
FIX
after the first failed authenticate attempt further attempts on the same connection will throw an exception:

[CRIT] [2EE3F682-53B6-4419-AD06-2778F452B39C] [core] Plugin auth/flat_file failed: Error: First argument needs to be a number, array or string.
    at new Buffer (buffer.js:237:15)
    at unbase64 (/usr/local/lib/node_modules/Haraka/plugins/auth/auth_base.js:216:18)
    at Plugin.exports.auth_login (/usr/local/lib/node_modules/Haraka/plugins/auth/auth_base.js:180:11)
    at Plugin.exports.select_auth_method (/usr/local/lib/node_modules/Haraka/plugins/auth/auth_base.js:142:25)
    at Plugin.exports.hook_unrecognized_command (/usr/local/lib/node_modules/Haraka/plugins/auth/auth_base.js:30:21)
    at Object.plugins.run_next_hook (/usr/local/lib/node_modules/Haraka/plugins.js:334:28)
    at plugins.run_next_hook.callback (/usr/local/lib/node_modules/Haraka/plugins.js:310:21)
    at Plugin.exports.hook_unrecognized_command (/usr/local/lib/node_modules/Haraka/plugins/tls.js:61:16)
    at Object.plugins.run_next_hook (/usr/local/lib/node_modules/Haraka/plugins.js:334:28)
    at Object.plugins.run_hooks (/usr/local/lib/node_modules/Haraka/plugins.js:223:13)
