### PR TITLE
Allow hyphens in params in config files

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -4,7 +4,7 @@
 // for "ini" type files
 var regex = {
     section:        /^\s*\[\s*([^\]]*?)\s*\]\s*$/,
-    param:          /^\s*([\w@\._]+)\s*=\s*(.*?)\s*$/,
+    param:          /^\s*([\w@\._-]+)\s*=\s*(.*?)\s*$/,
     comment:        /^\s*[;#].*$/,
     line:           /^\s*(.*?)\s*$/,
     blank:          /^\s*$/,


### PR DESCRIPTION
I had a case where the domain contained a hyphen and Haraka would keep rejecting the line in the config file (`relay_dest_domains.ini`) because of it. 
