### PR TITLE
auth_vpopmaild: mention vuserinfo in sysadmin docs

### DIFF
--- a/docs/plugins/auth/auth_vpopmaild.md
+++ b/docs/plugins/auth/auth_vpopmaild.md
@@ -5,7 +5,7 @@ daemon.
 
 ## Configuration
 
-Configuration is stored in `config/auth_vpopmaild.ini` and uses the INI
+Configuration is stored in `config/auth_vpopmaild.ini` and uses INI
 style formatting.
 
 There are three configuration settings:


### PR DESCRIPTION
to point users towards the tool that sets up a user with SYSADMIN privs
