### PR TITLE
attachment: include tmp plugin in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "ldapjs"        : "~0.7.1",
     "vs-stun"       : "~0.0.7",
     "geoip-lite"    : "~1.1.3",
-    "redis"         : "~0.10.1"
+    "redis"         : "~0.10.1",
+    "tmp"           : "~0.0.24"
   },
   "devDependencies": {
     "nodeunit" : "https://github.com/godsflaw/nodeunit/archive/master.tar.gz"


### PR DESCRIPTION
optional section. This goes with Steve's July 2 changes to the attachment plugin. It prevents error messages like this:

[WARN] [-] [attachment] This module requires the 'tmp' module to extract filenames from archive files
