### PR TITLE
Fix parsing of URIs that have been URL encoded

### DIFF
--- a/plugins/data.uribl.js
+++ b/plugins/data.uribl.js
@@ -7,7 +7,7 @@ var net_utils = require('./net_utils');
 
 // Default regexps to extract the URIs from the message
 var numeric_ip = /\w{3,16}:\/+(\S+@)?(\d+|0[xX][0-9A-Fa-f]+)\.(\d+|0[xX][0-9A-Fa-f]+)\.(\d+|0[xX][0-9A-Fa-f]+)\.(\d+|0[xX][0-9A-Fa-f]+)/gi;
-var schemeless = /((?:www\.)?[a-zA-Z0-9][a-zA-Z0-9\-.]{0,250}\.(?:aero|arpa|asia|biz|cat|com|coop|edu|gov|info|int|jobs|mil|mobi|museum|name|net|org|pro|tel|travel|xxx|[a-zA-Z]{2}))(?!\w)/gi;
+var schemeless = /(?:%(?:25)?(?:2F|3D))?((?:www\.)?[a-zA-Z0-9][a-zA-Z0-9\-.]{0,250}\.(?:aero|arpa|asia|biz|cat|com|coop|edu|gov|info|int|jobs|mil|mobi|museum|name|net|org|pro|tel|travel|xxx|[a-zA-Z]{2}))(?!\w)/gi;
 var schemed    = /(\w{3,16}:\/+(?:\S+@)?([a-zA-Z0-9][a-zA-Z0-9\-.]+\.(?:aero|arpa|asia|biz|cat|com|coop|edu|gov|info|int|jobs|mil|mobi|museum|name|net|org|pro|tel|travel|xxx|[a-zA-Z]{2})))(?!\w)/gi;
 
 var lists;
@@ -35,7 +35,7 @@ exports.register = function() {
     // Override regexps if top_level_tlds file is present
     if (net_utils.top_level_tlds && Object.keys(net_utils.top_level_tlds).length) {
         this.logdebug('Building new regexps from TLD file');
-        var re_schemeless = '((?:www\\.)?[a-zA-Z0-9][a-zA-Z0-9\\-.]{0,250}\\.(?:' +
+        var re_schemeless = '(?:%(?:25)?(?:2F|3D))?((?:www\\.)?[a-zA-Z0-9][a-zA-Z0-9\\-.]{0,250}\\.(?:' +
             Object.keys(net_utils.top_level_tlds).join('|') + '))(?!\\w)';
         schemeless = new RegExp(re_schemeless, 'gi');
         var re_schemed = '(\\w{3,16}:\\/+(?:\\S+@)?([a-zA-Z0-9][a-zA-Z0-9\\-.]+\\.(?:' +


### PR DESCRIPTION
This attempts to fix the following cases where the schemeless regexp will parse incorrectly parse the following if the parsed URI is encoded within another:

%2ftwitter.com
%3dyoutu.be
%252Fwww.fastcompany.com

For reference:

| Encoded | Actual | Notes |
| --- | --- | --- |
| %25 | % | Checked before 2F or 3D as it will appear if the URI is incorrectly double encoded |
| %2F | / | e.g. http:// |
| %3D | = | this would appear in URIs like https://www.youtube.com/watch?v=w2zlW0O4nig&feature=youtu.be |
