### PR TITLE
Helo.checks

### DIFF
--- a/tests/plugins/helo.checks.js
+++ b/tests/plugins/helo.checks.js
@@ -29,23 +29,10 @@ function _tear_down(callback) {
     callback();
 }
 
-exports.mismatch = {
+exports.host_mismatch = {
     setUp : _set_up,
     tearDown : _tear_down,
-    'disabled' : function (test) {
-        test.expect(2);
-        var outer = this;
-        var cb = function () {
-            test.equal(undefined, arguments[0]);
-            test.ok(outer.connection.results.get('helo.checks').skip.length);
-        };
-        this.plugin.init(stub, this.connection, 'helo.example.com');
-        this.plugin.cfg.check.mismatch=false;
-        this.plugin.cfg.reject.mismatch=true;
-        this.plugin.mismatch(cb, this.connection, 'any.example.com');
-        test.done();
-    },
-    'enabled=true, mismatch, reject=false' : function (test) {
+    'host_mismatch, reject=false' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -56,10 +43,10 @@ exports.mismatch = {
         this.plugin.init(stub, this.connection, 'helo.example.com');
         this.plugin.cfg.check.mismatch=true;
         this.plugin.cfg.reject.mismatch=false;
-        this.plugin.mismatch(cb, this.connection, 'anything');
+        this.plugin.host_mismatch(cb, this.connection, 'anything');
         test.done();
     },
-    'enabled=true, mismatch, reject=true' : function (test) {
+    'host_mismatch, reject=true' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -70,30 +57,15 @@ exports.mismatch = {
         this.plugin.init(stub, this.connection, 'helo.example.com');
         this.plugin.cfg.check.mismatch=true;
         this.plugin.cfg.reject.mismatch=true;
-        this.plugin.mismatch(cb, this.connection, 'anything');
+        this.plugin.host_mismatch(cb, this.connection, 'anything');
         test.done();
     },
 };
 
-
 exports.proto_mismatch = {
     setUp : _set_up,
     tearDown : _tear_down,
-    'disabled' : function (test) {
-        test.expect(2);
-        var outer = this;
-        var cb = function () {
-            test.equal(undefined, arguments[0]);
-            test.ok(outer.connection.results.get('helo.checks').skip.length);
-        };
-        this.plugin.init(stub, this.connection, 'helo.example.com');
-        this.plugin.cfg.check.proto_mismatch=false;
-        this.plugin.cfg.reject.proto_mismatch=true;
-        this.connection.esmtp = false;
-        this.plugin.proto_mismatch(cb, this.connection, 'any.example.com', 'esmtp');
-        test.done();
-    },
-    'enabled=true, proto_mismatch, reject=false, esmtp=false' : function (test) {
+    'proto_mismatch, reject=false, esmtp=false' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -108,7 +80,7 @@ exports.proto_mismatch = {
         this.plugin.proto_mismatch(cb, this.connection, 'anything', 'esmtp');
         test.done();
     },
-    'enabled=true, proto_mismatch, reject=false, esmtp=true' : function (test) {
+    'proto_mismatch, reject=false, esmtp=true' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -123,7 +95,7 @@ exports.proto_mismatch = {
         this.plugin.proto_mismatch(cb, this.connection, 'anything', 'esmtp');
         test.done();
     },
-    'enabled=true, proto_mismatch, reject=true' : function (test) {
+    'proto_mismatch, reject=true' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -143,21 +115,7 @@ exports.proto_mismatch = {
 exports.rdns_match = {
     setUp : _set_up,
     tearDown : _tear_down,
-    'disabled' : function (test) {
-        test.expect(2);
-        var outer = this;
-        var cb = function () {
-            test.equal(undefined, arguments[0]);
-            test.ok(outer.connection.results.get('helo.checks').skip.length);
-        };
-        this.plugin.init(stub, this.connection, 'helo.example.com');
-        this.connection.remote_host='ehlo.example.com';
-        this.plugin.cfg.check.rdns_match=false;
-        this.plugin.cfg.reject.rdns_match=true;
-        this.plugin.rdns_match(cb, this.connection, 'helo.example.com');
-        test.done();
-    },
-    'enabled, pass' : function (test) {
+    'pass' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -171,7 +129,7 @@ exports.rdns_match = {
         this.plugin.rdns_match(cb, this.connection, 'helo.example.com');
         test.done();
     },
-    'enabled, pass (org dom match)' : function (test) {
+    'pass (org dom match)' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -186,7 +144,7 @@ exports.rdns_match = {
         this.plugin.rdns_match(cb, this.connection, 'helo.example.com');
         test.done();
     },
-    'enabled, fail' : function (test) {
+    'fail' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -201,7 +159,7 @@ exports.rdns_match = {
         this.plugin.rdns_match(cb, this.connection, 'helo.example.com');
         test.done();
     },
-    'enabled, fail, reject' : function (test) {
+    'fail, reject' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -221,20 +179,7 @@ exports.rdns_match = {
 exports.bare_ip = {
     setUp : _set_up,
     tearDown : _tear_down,
-    'disabled' : function (test) {
-        test.expect(2);
-        var outer = this;
-        var cb = function () {
-            test.equal(undefined, arguments[0]);
-            test.ok(outer.connection.results.get('helo.checks').skip.length);
-        };
-        this.plugin.init(stub, this.connection, '192.168.1.1');
-        this.plugin.cfg.check.bare_ip=false;
-        this.plugin.cfg.reject.bare_ip=true;
-        this.plugin.bare_ip(cb, this.connection, '192.168.1.1');
-        test.done();
-    },
-    'enabled, pass' : function (test) {
+    'pass' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -247,7 +192,7 @@ exports.bare_ip = {
         this.plugin.bare_ip(cb, this.connection, '[192.168.1.2]');
         test.done();
     },
-    'enabled, fail' : function (test) {
+    'fail' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -260,7 +205,7 @@ exports.bare_ip = {
         this.plugin.bare_ip(cb, this.connection, '192.168.1.1');
         test.done();
     },
-    'enabled, fail, reject' : function (test) {
+    'fail, reject' : function (test) {
         test.expect(2);
         var outer = this;
         var cb = function () {
@@ -279,22 +224,7 @@ exports.bare_ip = {
 exports.dynamic = {
     setUp : _set_up,
     tearDown : _tear_down,
-    'disabled' : function (test) {
-        test.expect(2);
-        var outer = this;
-        var test_helo = 'c-76-121-96-159.hsd1.wa.comcast.net';
-        var cb = function () {
-            test.equal(undefined, arguments[0]);
-            test.ok(outer.connection.results.get('helo.checks').skip.length);
-        };
-        this.connection.remote_ip='76.121.96.159';
-        this.plugin.init(stub, this.connection, test_helo);
-        this.plugin.cfg.check.dynamic=false;
-        this.plugin.cfg.reject.dynamic=true;
-        this.plugin.dynamic(cb, this.connection, test_helo);
-        test.done();
-    },
-    'enabled, pass' : function (test) {
+    'pass' : function (test) {
         test.expect(2);
         var outer = this;
         var test_helo = 'matt.simerson.tld';
@@ -309,7 +239,7 @@ exports.dynamic = {
         this.plugin.dynamic(cb, this.connection, test_helo);
         test.done();
     },
-    'enabled, fail' : function (test) {
+    'fail' : function (test) {
         test.expect(2);
         var outer = this;
         var test_helo = 'c-76-121-96-159.hsd1.wa.comcast.net';
@@ -325,7 +255,7 @@ exports.dynamic = {
         this.plugin.dynamic(cb, this.connection, test_helo);
         test.done();
     },
-    'enabled, fail, reject' : function (test) {
+    'fail, reject' : function (test) {
         test.expect(2);
         var outer = this;
         var test_helo = 'c-76-121-96-159.hsd1.wa.comcast.net';
@@ -346,21 +276,6 @@ exports.dynamic = {
 exports.big_company = {
     setUp : _set_up,
     tearDown : _tear_down,
-    'disabled' : function (test) {
-        test.expect(2);
-        var outer = this;
-        var test_helo = 'yahoo.com';
-        var cb = function () {
-            test.equal(undefined, arguments[0]);
-            test.ok(outer.connection.results.get('helo.checks').skip.length);
-            test.done();
-        };
-        this.connection.remote_host='anything-else.com';
-        this.plugin.init(stub, this.connection, test_helo);
-        this.plugin.cfg.check.big_company=false;
-        this.plugin.cfg.reject.big_company=true;
-        this.plugin.big_company(cb, this.connection, test_helo);
-    },
     'pass, reject=false' : function (test) {
         test.expect(2);
         var outer = this;
@@ -411,22 +326,6 @@ exports.big_company = {
 exports.literal_mismatch = {
     setUp : _set_up,
     tearDown : _tear_down,
-    'disabled' : function (test) {
-        test.expect(2);
-        var outer = this;
-        var test_helo = '[10.0.1.1]';
-        var cb = function () {
-            // console.log(outer.connection.results.get('helo.checks'));
-            test.equal(undefined, arguments[0]);
-            test.ok(outer.connection.results.get('helo.checks').skip.length);
-            test.done();
-        };
-        this.connection.remote_ip='192.168.1.1';
-        this.plugin.init(stub, this.connection, test_helo);
-        this.plugin.cfg.check.literal_mismatch=0;
-        this.plugin.cfg.reject.literal_mismatch=true;
-        this.plugin.literal_mismatch(cb, this.connection, test_helo);
-    },
     'pass' : function (test) {
         test.expect(2);
         var outer = this;
@@ -496,21 +395,6 @@ exports.literal_mismatch = {
 exports.valid_hostname = {
     setUp : _set_up,
     tearDown : _tear_down,
-    'disabled' : function (test) {
-        test.expect(2);
-        var outer = this;
-        var test_helo = 'great.domain.non-existent-tld';
-        var cb = function () {
-            // console.log(outer.connection.results.get('helo.checks'));
-            test.equal(undefined, arguments[0]);
-            test.ok(outer.connection.results.get('helo.checks').skip.length);
-            test.done();
-        };
-        this.plugin.init(stub, this.connection, test_helo);
-        this.plugin.cfg.check.valid_hostname=false;
-        this.plugin.cfg.reject.valid_hostname=true;
-        this.plugin.valid_hostname(cb, this.connection, test_helo);
-    },
     'pass' : function (test) {
         test.expect(2);
         var test_helo = 'great.domain.com';
@@ -561,21 +445,7 @@ exports.valid_hostname = {
 exports.forward_dns = {
     setUp : _set_up,
     tearDown : _tear_down,
-    'disabled' : function (test) {
-        test.expect(2);
-        var outer = this;
-        var test_helo = 'great.domain.non-existent-tld';
-        var cb = function () {
-            test.equal(undefined, arguments[0]);
-            test.ok(outer.connection.results.get('helo.checks').skip.length);
-            test.done();
-        };
-        this.plugin.init(stub, this.connection, test_helo);
-        this.plugin.cfg.check.forward_dns=false;
-        this.plugin.cfg.reject.forward_dns=true;
-        this.plugin.forward_dns(cb, this.connection, test_helo);
-    },
-    'enabled, pass' : function (test) {
+    'pass' : function (test) {
         test.expect(2);
         var outer = this;
         var test_helo = 'b.resolvers.level3.net';
@@ -593,7 +463,7 @@ exports.forward_dns = {
         this.connection.results.add(this.plugin, {pass: 'valid_hostname'});
         this.plugin.forward_dns(cb, this.connection, test_helo);
     },
-    'enabled, fail, reject=false' : function (test) {
+    'fail, reject=false' : function (test) {
         test.expect(2);
         var outer = this;
         var test_helo = 'www.google.com';
@@ -609,7 +479,7 @@ exports.forward_dns = {
         this.plugin.cfg.reject.forward_dns=false;
         this.plugin.forward_dns(cb, this.connection, test_helo);
     },
-    'enabled, fail, reject=true' : function (test) {
+    'fail, reject=true' : function (test) {
         test.expect(2);
         var outer = this;
         var test_helo = 'www.google.com';


### PR DESCRIPTION
- helo.checks: don't register disabled checks
  - before: always load every check, on each connection, skip the ones disabled in the config file
  - after: load the .ini earlier and don't register when [check]name=false
- refactored load_helo_checks_ini() out of register()
- renamed mismatch() to host_mismatch (the word 'mismatch' appears in 3 methods now)
