### PR TITLE
server: consistent config handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -19,12 +19,6 @@ logger.add_log_methods(exports, 'server');
 
 var Server = exports;
 
-var defaults = {
-    inactivity_timeout: 600,
-    daemon_log_file: '/var/log/haraka.log',
-    daemon_pid_file: '/var/run/haraka.pid'
-};
-
 Server.load_smtp_ini = function () {
     Server.cfg = config.get('smtp.ini', {
         booleans: [
@@ -32,6 +26,12 @@ Server.load_smtp_ini = function () {
             ],
     },
     Server.load_smtp_ini);
+
+    var defaults = {
+        inactivity_timeout: 600,
+        daemon_log_file: '/var/log/haraka.log',
+        daemon_pid_file: '/var/run/haraka.pid'
+    };
 
     for (var key in defaults) {
         if (Server.cfg[key] !== undefined) continue;


### PR DESCRIPTION
- added load_smtp_ini() with booleans + callback
- merged apply_defaults into load_smtp_ini
- replaced config loading (3x)
- removed cfg passing

It's not yet a convention in our code, but what I've been using consistently
in the plugins and elsewhere is:

   cfg = a reference to whatever is returned by config.get()
   c = a reference to something within cfg
- used named (vs inline anon) functions
- add aliases for host and port (increase readability)
