### PR TITLE
Fix timeout bug in helo.checks.js

### DIFF
--- a/plugins/helo.checks.js
+++ b/plugins/helo.checks.js
@@ -502,7 +502,9 @@ exports.get_a_records = function (host, cb) {
     }
 
     // Set-up timer
+    var timed_out = false;
     var timer = setTimeout(function () {
+        timed_out = true;
         var err = new Error('timeout resolving: ' + host);
         err.code = 'ETIMEOUT';
         plugin.logerror(err);
@@ -514,6 +516,7 @@ exports.get_a_records = function (host, cb) {
 
     // do the queries
     dns.resolve(host, function(err, ips) {
+        if (timed_out) { return; }
         if (timer) { clearTimeout(timer); }
         if (err) { return cb(err, ips); }
         // plugin.logdebug(plugin, host + ' => ' + ips);


### PR DESCRIPTION
Missing code in timeout caused the following:

The timeout block ran and returned cb(err) which in turn ran next(); 
[helo.checks] forward_dns(Error: timeout resolving: amazon.kwiveolicensings.com.)

Later - the actual DNS result came back with it's own timeout; however because there was no boolean to say that the timeout block had run:
[helo.checks] forward_dns(Error: queryA ETIMEOUT)

This caused next() to be run again:
[core] helo.checks plugin ran callback multiple times - ignoring subsequent calls
[core] Error#012    at callback (/usr/lib/node_modules/Haraka/plugins.js:272:34)#012    at cb (/usr/lib/node_modules/Haraka/plugins/helo.checks.js:427:20)#012    at /usr/lib/node_modules/Haraka/plugins/helo.checks.js:593:25#012    at asyncCallback (dns.js:68:16)#012    at Object.onanswer [as oncomplete](dns.js:149:9)
