### PR TITLE
Fix critical bug: "Plugin graph failed: TypeError: Cannot call method 'call' of undefined"

### DIFF
--- a/plugins/graph.js
+++ b/plugins/graph.js
@@ -46,9 +46,9 @@ exports.register = function () {
     insert = db.prepare( "INSERT INTO graphdata VALUES (?,?)" );
 
     plugin.register_hook('init_master',   'http_init');
-    plugin.register_hook('disconnect',    'disconnect');
-    plugin.register_hook('deny',          'deny');
-    plugin.register_hook('queue_ok',      'queue_ok');
+    plugin.register_hook('disconnect',    'hook_disconnect');
+    plugin.register_hook('deny',          'hook_deny');
+    plugin.register_hook('queue_ok',      'hook_queue_ok');
 };
 
 exports.http_init = function (next) {
@@ -71,7 +71,7 @@ exports.http_init = function (next) {
     });
 };
 
-exports.disconnect = function (next, connection) {
+exports.hook_disconnect = function (next, connection) {
     if (!connection.current_line) {
         // disconnect without saying anything
         return this.hook_deny(next, connection, [DENY, "random disconnect", "disconnect_early"]);
@@ -79,7 +79,7 @@ exports.disconnect = function (next, connection) {
     next();
 };
 
-exports.deny = function (next, connection, params) {
+exports.hook_deny = function (next, connection, params) {
     var plugin = this;
     insert.bind([new Date().getTime(), params[2]], function (err) {
         if (err) {


### PR DESCRIPTION
The graph plugin had several critical errors like this

2014-10-22T23:44:45.698Z [CRIT] [67CCEC68-8D7C-47B1-96F8-500775A274DA.1] [core] Plugin graph failed: TypeError: Cannot call method 'call' of undefined
    at Object.plugins.run_next_hook (/usr/lib/node_modules/Haraka/plugins.js:334:28)
    at Object.plugins.run_hooks (/usr/lib/node_modules/Haraka/plugins.js:223:13)
    at Connection.queue_respond (/usr/lib/node_modules/Haraka/connection.js:1553:25)
    at callback (/usr/lib/node_modules/Haraka/plugins.js:306:39)
    at /usr/lib/node_modules/Haraka/outbound.js:423:19
    at /usr/lib/node_modules/Haraka/node_modules/async/lib/async.js:142:25
    at /usr/lib/node_modules/Haraka/outbound.js:445:17
    at Object.oncomplete (fs.js:107:15)
