### PR TITLE
permit HAproxy hosts to be IPv6 addresses

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -61,7 +61,7 @@ function loadHAProxyHosts() {
     var new_host_list = [];
     for (var i=0; i<hosts.length; i++) {
         var host = hosts[i].split(/\//);
-        new_host_list[i] = [ipaddr.IPv4.parse(host[0]), parseInt(host[1] || 32)];
+        new_host_list[i] = [ipaddr.parse(host[0]), parseInt(host[1] || 32)];
     }
     haproxy_hosts = new_host_list;
 }


### PR DESCRIPTION
solves this problem:

/usr/local/lib/node_modules/Haraka/node_modules/ipaddr.js/lib/ipaddr.js:372
      throw new Error("ipaddr: string is not formatted like ip address");
            ^
Error: ipaddr: string is not formatted like ip address
    at Function.ipaddr.IPv4.parse.ipaddr.IPv6.parse (/usr/local/lib/node_modules/Haraka/node_modules/ipaddr.js/lib/ipaddr.js:372:13)
    at loadHAProxyHosts (/usr/local/lib/node_modules/Haraka/connection.js:64:41)
    at Object.<anonymous> (/usr/local/lib/node_modules/Haraka/connection.js:68:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/Haraka/plugins.js:12:19)
