### PR TITLE
tests/plugins/* cleanups

### DIFF
--- a/tests/fixtures/stub_plugin.js
+++ b/tests/fixtures/stub_plugin.js
@@ -18,6 +18,7 @@ function Plugin(name) {
     this.base = {};
     this.register_hook = stub();
     this.config = stub();
+    constants.import(global);
 
     logger.add_log_methods(this, 'test');
 

--- a/tests/plugins/access.js
+++ b/tests/plugins/access.js
@@ -1,38 +1,28 @@
-var stub         = require('../fixtures/stub'),
-    Plugin       = require('../fixtures/stub_plugin'),
-    Connection   = require('../fixtures/stub_connection'),
-    Address      = require('../../address').Address,
-    configfile   = require('../../configfile'),
-    config       = require('../../config'),
-    ResultStore  = require('../../result_store'),
-    constants    = require('../../constants');
+'use strict';
 
-constants.import(global);
+var stub         = require('../fixtures/stub');
+var Plugin       = require('../fixtures/stub_plugin');
+var Connection   = require('../fixtures/stub_connection');
+var Address      = require('../../address').Address;
+var config       = require('../../config');
+var ResultStore  = require('../../result_store');
 
-function _set_up(callback) {
-    this.backup = {};
+var _set_up = function (done) {
 
-    // needed for tests
-    this.plugin = Plugin('access');
+    this.plugin = new Plugin('access');
     this.plugin.config = config;
 
-    // stub out functions
     this.connection = Connection.createConnection();
     this.connection.results = new ResultStore(this.connection);
     this.connection.transaction = {
         results: new ResultStore(this.connection),
     };
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.in_list = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'white, mail': function (test) {
         var list = {'matt@exam.ple':true,'matt@example.com':true};
         this.plugin.cfg  = { white: { mail: 'test no file' }};
@@ -97,7 +87,6 @@ exports.in_list = {
 
 exports.in_re_list = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'white, mail': function (test) {
         var list = ['.*exam.ple','.*example.com'];
         this.plugin.cfg = { re: { white: { mail: 'test file name' }}};
@@ -162,7 +151,6 @@ exports.in_re_list = {
 
 exports.load_re_file = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'whitelist': function (test) {
         test.expect(3);
         this.plugin.init_config();
@@ -177,7 +165,6 @@ exports.load_re_file = {
 
 exports.in_file = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'in_file': function (test) {
         test.expect(2);
         var file = 'mail_from.access.whitelist';
@@ -189,7 +176,6 @@ exports.in_file = {
 
 exports.in_re_file = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'in_re_file': function (test) {
         test.expect(2);
         var file = 'mail_from.access.whitelist_regex';
@@ -201,7 +187,6 @@ exports.in_re_file = {
 
 exports.rdns_access = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no list': function (test) {
         test.expect(2);
         this.plugin.init_config();
@@ -269,7 +254,6 @@ exports.rdns_access = {
 
 exports.helo_access = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no list': function (test) {
         test.expect(2);
         this.plugin.init_config();
@@ -301,7 +285,6 @@ exports.helo_access = {
 
 exports.mail_from_access = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no lists populated': function (test) {
         test.expect(2);
         this.plugin.init_config();
@@ -368,7 +351,6 @@ exports.mail_from_access = {
 
 exports.rcpt_to_access = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no lists populated': function (test) {
         test.expect(2);
         this.plugin.init_config();

--- a/tests/plugins/aliases.js
+++ b/tests/plugins/aliases.js
@@ -1,24 +1,23 @@
-var stub             = require('../fixtures/stub'),
-    Address          = require('../../address').Address,
-    Connection       = require('../fixtures/stub_connection'),
-    Plugin           = require('../fixtures/stub_plugin');
+'use strict';
 
-function _set_up(callback) {
-    this.backup = {};
+var stub             = require('../fixtures/stub');
+var Plugin           = require('../fixtures/stub_plugin');
+var Connection       = require('../fixtures/stub_connection');
+var Address          = require('../../address').Address;
+
+var _set_up = function (done) {
 
     // needed for tests
     this.plugin = new Plugin('aliases');
-    this.connection = Connection.createConnection();
-    this.recip = new Address('<test1@example.com>');
+    this.recip  = new Address('<test1@example.com>');
     this.params = [this.recip];
 
-    // stub out functions
+    this.connection = Connection.createConnection();
     this.connection.loginfo = stub();
-    this.connection.logdebug = stub();
-    this.connection.notes = stub();
-    this.connection.transaction = stub();
-    this.connection.transaction.notes = stub();
-    this.connection.transaction.rcpt_to = [ this.params ];
+    this.connection.transaction = {
+        notes: stub(),
+        rcpt_to: [ this.params ],
+    };
 
     // some test data
     this.configfile = {
@@ -33,6 +32,7 @@ function _set_up(callback) {
         "test8" : { "to" : "should_fail" },
         "test9" : { "action" : "alias" }
     };
+
     this.plugin.config.get = function (file, type) {
         return this.configfile;
     }.bind(this);
@@ -42,16 +42,11 @@ function _set_up(callback) {
     // going to need these in multiple tests
     this.plugin.register();
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.aliases = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'should have register function' : function (test) {
         test.expect(2);
         test.isNotNull(this.plugin);

--- a/tests/plugins/auth/auth_base.js
+++ b/tests/plugins/auth/auth_base.js
@@ -1,42 +1,28 @@
-var stub         = require('../../fixtures/stub'),
-    Plugin       = require('../../fixtures/stub_plugin'),
-    Connection   = require('../../fixtures/stub_connection'),
-    configfile   = require('../../../configfile'),
-    config       = require('../../../config'),
-    constants    = require('../../../constants'),
-    ResultStore  = require('../../../result_store'),
-    utils        = require('../../../utils');
+'use strict';
 
-constants.import(global);
+var Plugin       = require('../../fixtures/stub_plugin');
+var Connection   = require('../../fixtures/stub_connection');
+var config       = require('../../../config');
+var utils        = require('../../../utils');
 
-function _set_up(callback) {
-    this.backup = {};
+var _set_up = function (done) {
 
-    // needed for tests
-    this.plugin = Plugin('auth/auth_base');
+    this.plugin = new Plugin('auth/auth_base');
     this.plugin.config = config;
+
     this.plugin.get_plain_passwd = function (user, cb) {
         if (user === 'test') return cb('testpass');
         return cb(null);
     };
 
-    // stub out functions
     this.connection = Connection.createConnection();
-
-    this.connection.results = new ResultStore(this.connection);
-    this.connection.notes = {};
     this.connection.capabilities=null;
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.hook_capabilities = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no TLS, no auth': function (test) {
         var cb = function (rc, msg) {
             test.expect(3);
@@ -65,7 +51,6 @@ exports.hook_capabilities = {
 
 exports.get_plain_passwd = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'get_plain_passwd, no result': function (test) {
         this.plugin.get_plain_passwd('user', function (pass) {
             test.expect(1);
@@ -84,7 +69,6 @@ exports.get_plain_passwd = {
 
 exports.check_plain_passwd = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'valid password': function (test) {
         this.plugin.check_plain_passwd(this.connection, 'test', 'testpass', function (pass) {
             test.expect(1);
@@ -110,7 +94,6 @@ exports.check_plain_passwd = {
 
 exports.select_auth_method = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no auth methods yield no result': function (test) {
         var next = function (code) {
             test.equal(code, null);
@@ -144,7 +127,6 @@ exports.select_auth_method = {
 
 exports.auth_plain = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'params type=string returns OK': function (test) {
         var next = function () {
             test.expect(2);
@@ -177,7 +159,6 @@ exports.auth_plain = {
 
 exports.check_user = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'bad auth': function (test) {
         var next = function (code) {
             test.expect(2);
@@ -202,7 +183,6 @@ exports.check_user = {
 
 exports.hook_unrecognized_command = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'AUTH type FOO': function (test) {
         var next = function (code) {
             test.expect(2);
@@ -241,7 +221,6 @@ exports.hook_unrecognized_command = {
 
 exports.hexi = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'hexi': function (test) {
         test.expect(2);
         test.equal(this.plugin.hexi(512), 200);

--- a/tests/plugins/auth/auth_vpopmaild.js
+++ b/tests/plugins/auth/auth_vpopmaild.js
@@ -1,34 +1,26 @@
-var stub         = require('../../fixtures/stub'),
-    Plugin       = require('../../fixtures/stub_plugin'),
+'use strict';
+
+var Plugin       = require('../../fixtures/stub_plugin'),
     Connection   = require('../../fixtures/stub_connection'),
-    configfile   = require('../../../configfile'),
     config       = require('../../../config');
 
-function _set_up(callback) {
+var _set_up = function(done) {
     this.backup = {};
 
     // needed for tests
-    this.plugin = Plugin('auth/auth_vpopmaild');
+    this.plugin = new Plugin('auth/auth_vpopmaild');
     this.plugin.inherits('auth/auth_base');
     this.plugin.config = config;
     this.plugin.cfg = config.get('auth_vpopmaild.ini');
 
-    // stub out functions
     this.connection = Connection.createConnection();
-    // this.connection.results = new ResultStore(this.connection);
-    this.connection.notes = {};
     this.connection.capabilities=null;
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.hook_capabilities = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no TLS': function (test) {
         var cb = function (rc, msg) {
             test.expect(3);
@@ -69,7 +61,6 @@ exports.hook_capabilities = {
 
 exports.get_vpopmaild_socket = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'any': function (test) {
         test.expect(1);
         var socket = this.plugin.get_vpopmaild_socket('foo@localhost.com');
@@ -82,7 +73,6 @@ exports.get_vpopmaild_socket = {
 
 exports.get_plain_passwd = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'matt@example.com': function (test) {
         var cb = function(pass) {
             test.expect(1);

--- a/tests/plugins/bounce.js
+++ b/tests/plugins/bounce.js
@@ -1,16 +1,14 @@
-var Plugin       = require('../fixtures/stub_plugin'),
-    Connection   = require('../fixtures/stub_connection'),
-    constants    = require('../../constants'),
-    Address      = require('../../address'),
-    config       = require('../../config'),
-    ResultStore  = require('../../result_store'),
-    Header       = require('../../mailheader').Header;
+'use strict';
 
-constants.import(global);
+var Plugin       = require('../fixtures/stub_plugin');
+var Connection   = require('../fixtures/stub_connection');
+var Address      = require('../../address');
+var config       = require('../../config');
+var ResultStore  = require('../../result_store');
+var Header       = require('../../mailheader').Header;
 
-function _set_up(done) {
+var _set_up = function (done) {
 
-    // needed for tests
     this.plugin = new Plugin('bounce');
     this.plugin.config = config;
     this.plugin.cfg = {
@@ -28,24 +26,17 @@ function _set_up(done) {
         invalid_addrs: { 'test@bad1.com': true, 'test@bad2.com': true },
     };
 
-    // stub out functions
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.plugin);
     this.connection.transaction = {
         header: new Header(),
         results: new ResultStore(this.plugin),
     };
 
     done();
-}
-
-function _tear_down(done) {
-    done();
-}
+};
 
 exports.load_configs = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'load_bounce_ini': function (test) {
         test.expect(3);
         this.plugin.load_bounce_ini();
@@ -66,7 +57,6 @@ exports.load_configs = {
 
 exports.reject_all = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'disabled': function (test) {
         test.expect(1);
         this.connection.transaction.mail_from= new Address.Address('<matt@example.com>');
@@ -104,7 +94,6 @@ exports.reject_all = {
 
 exports.empty_return_path = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'none': function (test) {
         test.expect(1);
         this.connection.transaction.mail_from= new Address.Address('<>');
@@ -130,7 +119,6 @@ exports.empty_return_path = {
 
 exports.single_recipient = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'valid': function (test) {
         test.expect(1);
         this.connection.transaction.mail_from= new Address.Address('<>');
@@ -181,7 +169,6 @@ exports.single_recipient = {
 
 exports.bad_rcpt = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'test@good.com': function (test) {
         test.expect(1);
         this.connection.transaction.mail_from= new Address.Address('<>');
@@ -235,7 +222,6 @@ exports.bad_rcpt = {
 
 exports.has_null_sender = {
     setUp : _set_up,
-    tearDown : _tear_down,
     '<>': function (test) {
         test.expect(1);
         this.connection.transaction.mail_from= new Address.Address('<>');

--- a/tests/plugins/clamd.js
+++ b/tests/plugins/clamd.js
@@ -1,35 +1,29 @@
+'use strict';
 
 var stub         = require('../fixtures/stub'),
     Plugin       = require('../fixtures/stub_plugin'),
     Connection   = require('../fixtures/stub_connection'),
-    configfile   = require('../../configfile'),
     config       = require('../../config'),
     ResultStore  = require('../../result_store');
 
-function _set_up(callback) {
-    this.backup = {};
-
-    // needed for tests
-    this.plugin = Plugin('clamd');
+var _set_up = function (done) {
+    
+    this.plugin = new Plugin('clamd');
     this.plugin.config = config;
     this.plugin.register();
+    
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.plugin);
-    this.connection.transaction = { notes: {} };
-    this.connection.transaction.results = new ResultStore(this.plugin);
+    
+    this.connection.transaction = {
+        notes: {},
+        results: new ResultStore(this.plugin),
+    };
 
-    this.plugin.loginfo = stub();
-
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.load_clamd_ini = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'none': function (test) {
         test.expect(1);
         test.deepEqual([], this.plugin.skip_list);
@@ -50,7 +44,6 @@ exports.load_clamd_ini = {
 
 exports.hook_data = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'only_with_attachments, false': function (test) {
         test.expect(2);
         test.equal(false, this.plugin.cfg.main.only_with_attachments);
@@ -75,7 +68,6 @@ exports.hook_data = {
 
 exports.hook_data_post = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'skip attachment': function (test) {
         this.connection.transaction.notes = { clamd_found_attachment: false };
         this.plugin.cfg.main.only_with_attachments=true;

--- a/tests/plugins/connect.asn.js
+++ b/tests/plugins/connect.asn.js
@@ -1,26 +1,21 @@
+'use strict';
 
-var stub             = require('../fixtures/stub'),
-    Connection       = require('../fixtures/stub_connection'),
-    Plugin           = require('../fixtures/stub_plugin');
+var stub             = require('../fixtures/stub');
+var Plugin           = require('../fixtures/stub_plugin');
+var Connection       = require('../fixtures/stub_connection');
 
-function _set_up(callback) {
-    this.backup = {};
-
-    // needed for tests
+var _set_up = function (done) {
+    
     this.plugin = new Plugin('connect.asn');
+
     this.plugin.cfg = { main: {} };
     this.connection = Connection.createConnection();
 
-    callback();
-}
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.parse_monkey = {
     setUp : _set_up,
-    tearDown : _tear_down,
-
     '15169/23': function (test) {
         test.expect(1);
         test.deepEqual(
@@ -45,8 +40,6 @@ exports.parse_monkey = {
 
 exports.parse_routeviews = {
     setUp : _set_up,
-    tearDown : _tear_down,
-
     '40431 string, asn-only': function (test) {
         test.expect(1);
         test.equal(
@@ -75,8 +68,6 @@ exports.parse_routeviews = {
 
 exports.parse_cymru = {
     setUp : _set_up,
-    tearDown : _tear_down,
-
     '40431': function (test) {
         test.expect(1);
         test.deepEqual(
@@ -101,8 +92,6 @@ exports.parse_cymru = {
 
 exports.get_dns_results = {
     setUp : _set_up,
-    tearDown : _tear_down,
-
     'origin.asn.cymru.com': function (test) {
         var cb = function (err, zone, obj) {
             if (obj) {

--- a/tests/plugins/connect.fcrdns.js
+++ b/tests/plugins/connect.fcrdns.js
@@ -1,36 +1,25 @@
-var stub         = require('../fixtures/stub'),
-    Plugin       = require('../fixtures/stub_plugin'),
-    Connection   = require('../fixtures/stub_connection'),
-    constants    = require('../../constants'),
-    config       = require('../../config'),
-    ResultStore  = require('../../result_store'),
-    dns          = require('dns');
+'use strict';
 
+var stub         = require('../fixtures/stub');
+var Plugin       = require('../fixtures/stub_plugin');
+var Connection   = require('../fixtures/stub_connection');
+var config       = require('../../config');
+var dns          = require('dns');
 
-constants.import(global);
+var _set_up = function (done) {
 
-function _set_up(callback) {
-    this.backup = {};
-
-    // needed for tests
     this.plugin = new Plugin('connect.fcrdns');
     this.plugin.config = config;
     this.plugin.register();
 
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.connection);
     this.connection.auth_results = stub();
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.refresh_config = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'defaults return': function (test) {
         test.expect(4);
         var r = this.plugin.refresh_config(this.connection);
@@ -53,7 +42,6 @@ exports.refresh_config = {
 
 exports.handle_ptr_error = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'ENOTFOUND reject.no_rdns=0': function (test) {
         test.expect(1);
         this.plugin.refresh_config(this.connection);
@@ -129,7 +117,6 @@ exports.handle_ptr_error = {
 
 exports.handle_a_error = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'ENOTFOUND': function (test) {
         test.expect(1);
         this.plugin.refresh_config(this.connection);
@@ -170,7 +157,6 @@ exports.handle_a_error = {
 
 exports.is_generic_rdns = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'mail.theartfarm.com': function (test) {
         test.expect(1);
         this.connection.remote_ip='208.75.177.101';
@@ -217,7 +203,6 @@ exports.is_generic_rdns = {
 
 exports.save_auth_results = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'fcrdns fail': function (test) {
         test.expect(1);
         this.connection.results.add(this.plugin, { pass: 'fcrdns' });
@@ -234,7 +219,6 @@ exports.save_auth_results = {
 
 exports.ptr_compare = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'fail': function (test) {
         test.expect(1);
         this.connection.remote_ip = '10.1.1.1';
@@ -260,7 +244,6 @@ exports.ptr_compare = {
 
 exports.check_fcrdns = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'fail, tolerate': function (test) {
         test.expect(1);
         var cb = function (rc, msg) {

--- a/tests/plugins/connect.geoip.js
+++ b/tests/plugins/connect.geoip.js
@@ -3,22 +3,20 @@
 var Connection       = require('../fixtures/stub_connection');
 var Plugin           = require('../fixtures/stub_plugin');
 var config           = require('../../config');
-var ResultStore      = require("../../result_store");
 
-var _set_up = function (callback) {
+var _set_up = function (done) {
     this.plugin = new Plugin('connect.geoip');
     this.plugin.config = config;
     
     this.plugin.load_geoip_ini();
 
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.plugin);
 
-    callback();
+    done();
 };
 
 exports.register = {
-    setUp : function (callback) {
+    setUp : function (done) {
         this.plugin = new Plugin('connect.geoip');
         this.plugin.config = config;
 
@@ -28,7 +26,7 @@ exports.register = {
         catch (ignore) {}
 
         this.plugin.register();
-        callback();
+        done();
     },
     'config loaded': function (test) {
         test.expect(2);
@@ -77,16 +75,15 @@ exports.load_geoip_lite = {
 };
 
 exports.lookup_maxmind = {
-    setUp : function (callback) {
+    setUp : function (done) {
         this.plugin = new Plugin('connect.geoip');
         this.plugin.config = config;
         this.plugin.load_geoip_ini();
 
         this.connection = Connection.createConnection();
-        this.connection.results = new ResultStore(this.plugin);
 
         this.plugin.load_maxmind();
-        callback();
+        done();
     },
     'servedby.tnpi.net': function (test) {
         var cb = function() {
@@ -111,7 +108,7 @@ exports.lookup_maxmind = {
 // WMISD  [ 38, -97 ]
 
 exports.get_geoip = {
-    setUp : function (callback) {
+    setUp : function (done) {
         this.plugin = new Plugin('connect.geoip');
         this.plugin.config = config;
 
@@ -121,7 +118,7 @@ exports.get_geoip = {
         catch (ignore) {}
 
         this.plugin.register();
-        callback();
+        done();
     },
     'no IP fails': function (test) {
         if (!this.plugin.hasProvider) { return test.done(); }
@@ -138,14 +135,13 @@ exports.get_geoip = {
 };
 
 exports.lookup_geoip = {
-    setUp : function (callback) {
+    setUp : function (done) {
         this.plugin = new Plugin('connect.geoip');
         this.plugin.config = config;
         this.plugin.load_geoip_ini();
         this.connection = Connection.createConnection();
-        this.connection.results = new ResultStore(this.plugin);
         this.plugin.load_geoip_lite();
-        callback();
+        done();
     },
     'seattle: lat + long': function (test) {
         var cb = function (rc) {
@@ -178,7 +174,7 @@ exports.lookup_geoip = {
 };
 
 exports.get_geoip_maxmind = {
-    setUp : function (callback) {
+    setUp : function (done) {
         this.plugin = new Plugin('connect.geoip');
         this.plugin.config = config;
         this.plugin.load_geoip_ini();
@@ -186,12 +182,12 @@ exports.get_geoip_maxmind = {
         this.plugin.load_maxmind();
         if (!p.maxmind) {
             p.logerror("maxmind not loaded!");
-            return callback();
+            return done();
         }
         if (!p.maxmind.dbsLoaded) {
             p.logerror("no maxmind DBs loaded!");
         }
-        callback();
+        done();
     },
     'ipv4 public passes': function (test) {
         if (!this.plugin.maxmind) { return test.done(); }
@@ -211,12 +207,12 @@ exports.get_geoip_maxmind = {
 };
 
 exports.get_geoip_lite = {
-    setUp : function (callback) {
+    setUp : function (done) {
         this.plugin = new Plugin('connect.geoip');
         this.plugin.config = config;
         this.plugin.load_geoip_ini();
         this.plugin.load_geoip_lite();
-        callback();
+        done();
     },
     'no IP fails': function (test) {
         if (!this.plugin.geoip) {

--- a/tests/plugins/data.headers.js
+++ b/tests/plugins/data.headers.js
@@ -1,46 +1,37 @@
+'use strict';
 
-var stub         = require('../fixtures/stub'),
-    Plugin       = require('../fixtures/stub_plugin'),
-    Connection   = require('../fixtures/stub_connection'),
-    Address      = require('../../address'),
-    configfile   = require('../../configfile'),
-    config       = require('../../config'),
-    constants    = require('../../constants'),
-    Header       = require('../../mailheader').Header,
-    ResultStore  = require("../../result_store");
+var Plugin       = require('../fixtures/stub_plugin');
+var Connection   = require('../fixtures/stub_connection');
+var Address      = require('../../address');
+var config       = require('../../config');
+var Header       = require('../../mailheader').Header;
+var ResultStore  = require("../../result_store");
 
-constants.import(global);
-
-function _set_up(callback) {
+var _set_up = function (done) {
 
     this.plugin = new Plugin('data.headers');
     this.plugin.config = config;
+
     this.plugin.register();
+
     try {
         this.plugin.addrparser = require('address-rfc2822');
     }
     catch (ignore) {}
 
-    // stub out functions
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.connection);
+
     this.connection.transaction = {
         header: new Header(),
         results: new ResultStore(this.plugin),
         rcpt_to: [],
     };
-    this.connection.notes = {};
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.invalid_date = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'none': function (test) {
         test.expect(0);
         test.done();
@@ -49,7 +40,6 @@ exports.invalid_date = {
 
 exports.user_agent = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'none': function (test) {
         test.expect(2);
         var outer = this;
@@ -92,7 +82,6 @@ exports.user_agent = {
 
 exports.direct_to_mx = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'auth user': function (test) {
         test.expect(3);
         this.connection.notes.auth_user = 'test@example.com';
@@ -151,7 +140,6 @@ exports.direct_to_mx = {
 
 exports.from_match = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'match bare': function (test) {
         test.expect(1);
         var outer = this;
@@ -208,7 +196,6 @@ exports.from_match = {
 
 exports.mailing_list = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'ezmlm true': function (test) {
         test.expect(2);
         var outer = this;
@@ -299,7 +286,6 @@ exports.mailing_list = {
 
 exports.delivered_to = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'disabled': function (test) {
         test.expect(2);
         var next_cb = function(res, msg) {

--- a/tests/plugins/deprecated/relay_acl.js
+++ b/tests/plugins/deprecated/relay_acl.js
@@ -1,41 +1,27 @@
-var stub         = require('../fixtures/stub'),
-    constants    = require('../../constants'),
-    Connection   = require('../fixtures/stub_connection'),
-    Plugin       = require('../fixtures/stub_plugin'),
-    configfile   = require('../../configfile'),
-    config       = require('../../config'),
-    ResultStore  = require("../../result_store");
+'use strict';
 
-// huge hack here, but plugin tests need constants
-constants.import(global);
+var Connection   = require('../../fixtures/stub_connection');
+var Plugin       = require('../../fixtures/stub_plugin');
+var config       = require('../../../config');
+var ResultStore  = require("../../../result_store");
 
-function _set_up(callback) {
-    this.backup = {};
+var _set_up = function (done) {
 
-    // needed for tests
-    this.plugin = Plugin('relay_acl');
+    this.plugin = new Plugin('relay_acl');
     this.plugin.config = config;
     this.plugin.cfg = {};
 
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.connection);
+
     this.connection.transaction = {
         results: new ResultStore(this.connection),
     };
 
-    // going to need these in multiple tests
-    // this.plugin.register();
-
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.is_acl_allowed = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'bare IP' : function (test) {
         test.expect(3);
         this.plugin.acl_allow=['127.0.0.6'];
@@ -77,7 +63,6 @@ exports.is_acl_allowed = {
 
 exports.relay_dest_domains = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'relaying' : function (test) {
         test.expect(2);
         var outer = this;
@@ -149,7 +134,6 @@ exports.relay_dest_domains = {
 
 exports.refresh_config = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'callback' : function (test) {
         test.expect(1);
         var outer = this;

--- a/tests/plugins/deprecated/relay_all.js
+++ b/tests/plugins/deprecated/relay_all.js
@@ -1,35 +1,22 @@
-var stub             = require('../fixtures/stub'),
-    constants        = require('../../constants'),
-    Connection       = require('../fixtures/stub_connection'),
-    Plugin           = require('../fixtures/stub_plugin');
+'use strict';
 
-// huge hack here, but plugin tests need constants
-constants.import(global);
+var stub             = require('../../fixtures/stub');
+var Connection       = require('../../fixtures/stub_connection');
+var Plugin           = require('../../fixtures/stub_plugin');
 
-function _set_up(callback) {
-    this.backup = {};
+var _set_up = function (callback) {
 
-    // needed for tests
-    this.plugin = Plugin('relay_all');
+    this.plugin = new Plugin('relay_all');
     this.connection = Connection.createConnection();
     this.params = ['foo@bar.com'];
 
-    // stub out functions
-    this.connection.loginfo = stub();
-
-    // going to need these in multiple tests
     this.plugin.register();
 
     callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+};
 
 exports.relay_all = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'should have register function' : function (test) {
         test.expect(2);
         test.isNotNull(this.plugin);
@@ -56,7 +43,7 @@ exports.relay_all = {
     'confirm_all hook always returns OK' : function (test) {
         var next = function (action) {
             test.expect(1);
-            test.equals(action, constants.ok);
+            test.equals(action, OK);
             test.done();
         };
 

--- a/tests/plugins/dkim_sign.js
+++ b/tests/plugins/dkim_sign.js
@@ -1,19 +1,15 @@
+'use strict';
 
-var stub         = require('../fixtures/stub'),
-    Plugin       = require('../fixtures/stub_plugin'),
-    configfile   = require('../../configfile'),
-    config       = require('../../config'),
-    Address      = require('../../address'),
-    Connection   = require('../fixtures/stub_connection'),
-    ResultStore  = require("../../result_store"),
-    Header       = require('../../mailheader').Header,
-    utils        = require('../../utils');
+var Plugin       = require('../fixtures/stub_plugin');
+var Connection   = require('../fixtures/stub_connection');
+var config       = require('../../config');
+var Address      = require('../../address');
+var Header       = require('../../mailheader').Header;
+var utils        = require('../../utils');
 
-function _set_up(callback) {
-    this.backup = {};
+var _set_up = function (done) {
 
-    // needed for tests
-    this.plugin = Plugin('dkim_sign');
+    this.plugin = new Plugin('dkim_sign');
     this.plugin.config = config;
     this.plugin.cfg = { main: { } };
 
@@ -21,18 +17,12 @@ function _set_up(callback) {
     this.connection.transaction = {
         header: new Header(),
     };
-    this.connection.results = new ResultStore(this.plugin);
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.get_sender_domain = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no transaction': function (test) {
         test.expect(1);
         delete this.connection.transaction;
@@ -103,7 +93,6 @@ exports.get_sender_domain = {
 
 exports.get_key_dir = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no transaction': function (test) {
         test.expect(1);
         var cb = function (dir) {
@@ -127,7 +116,6 @@ exports.get_key_dir = {
 
 exports.get_headers_to_sign = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'none': function (test) {
         test.expect(1);
         var r = this.plugin.get_headers_to_sign(this.plugin.cfg);

--- a/tests/plugins/dns_list_base.js
+++ b/tests/plugins/dns_list_base.js
@@ -3,22 +3,15 @@
 var stub         = require('../fixtures/stub'),
     Plugin       = require('../fixtures/stub_plugin');
 
-function _set_up(callback) {
-    this.backup = {};
-
-    // needed for tests
+var _set_up = function (done) {
+    
     this.plugin = new Plugin('dns_list_base');
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.disable_zone = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'empty request': function (test) {
         test.expect(1);
         var res = this.plugin.disable_zone();
@@ -53,7 +46,6 @@ exports.disable_zone = {
 
 exports.lookup = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'Spamcop, test IP': function (test) {
         test.expect(2);
         var cb = function (err, a) {
@@ -76,7 +68,6 @@ exports.lookup = {
 
 exports.multi = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'Spamcop': function (test) {
         test.expect(4);
         var cb = function (err, zone, a, pending) {
@@ -146,7 +137,6 @@ exports.multi = {
 
 exports.first = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'positive result': function (test) {
         test.expect(3);
         var cb = function (err, zone, a) {
@@ -154,7 +144,7 @@ exports.first = {
             test.ok(zone);
             test.ok((Array.isArray(a) && a.length > 0));
             test.done();
-        }
+        };
         var dnsbls = [ 'cbl.abuseat.org', 'bl.spamcop.net' ];
         this.plugin.first('127.0.0.2', dnsbls , cb);
     },
@@ -165,7 +155,7 @@ exports.first = {
             test.equal(null, zone);
             test.equal(null, a);
             test.done();
-        }
+        };
         var dnsbls = [ 'cbl.abuseat.org', 'bl.spamcop.net' ];
         this.plugin.first('127.0.0.1', dnsbls, cb);
     },
@@ -175,14 +165,14 @@ exports.first = {
         var pending = dnsbls.length;
         var cb = function () {
             test.ok(pending);
-        }
+        };
         var cb_each = function (err, zone, a) {
             pending--;
             test.equal(null, err);
             test.ok(zone);
             test.ok((Array.isArray(a) && a.length > 0));
             if (pending === 0) test.done(); 
-        }
+        };
         this.plugin.first('127.0.0.2', dnsbls, cb, cb_each);
     }
-}
+};

--- a/tests/plugins/dnsbl.js
+++ b/tests/plugins/dnsbl.js
@@ -1,16 +1,18 @@
-var stub         = require('../fixtures/stub'),
-    Plugin       = require('../fixtures/stub_plugin'),
-    config       = require('../../config'),
-    Connection   = require('../fixtures/stub_connection');
+'use strict';
 
-function _set_up(done) {
+var Plugin       = require('../fixtures/stub_plugin');
+var config       = require('../../config');
+var Connection   = require('../fixtures/stub_connection');
 
-    // needed for tests
+var _set_up = function (done) {
+
     this.plugin = new Plugin('dnsbl');
     this.plugin.config = config;
 
+    this.connection = Connection.createConnection();
+
     done();
-}
+};
 
 exports.load_config = {
     setUp : _set_up,
@@ -57,20 +59,18 @@ exports.should_skip = {
     },
     'no remote_ip': function (test) {
         test.expect(1);
-        this.connection = Connection.createConnection();
+        
         test.equal(true, this.plugin.should_skip(this.connection));
         test.done();
     },
     'private remote_ip, no zones': function (test) {
         test.expect(1);
-        this.connection = Connection.createConnection();
         this.connection.remote_ip = '192.168.1.1';
         test.equal(true, this.plugin.should_skip(this.connection));
         test.done();
     },
     'private remote_ip': function (test) {
         test.expect(1);
-        this.connection = Connection.createConnection();
         this.connection.remote_ip = '192.168.1.1';
 
         this.plugin.load_config();
@@ -82,7 +82,6 @@ exports.should_skip = {
     },
     'public remote_ip': function (test) {
         test.expect(1);
-        this.connection = Connection.createConnection();
         this.connection.remote_ip = '208.1.1.1';
 
         this.plugin.load_config();
@@ -94,7 +93,6 @@ exports.should_skip = {
     },
     'public remote_ip, no zones': function (test) {
         test.expect(1);
-        this.connection = Connection.createConnection();
         this.connection.remote_ip = '208.1.1.1';
         test.equal(true, this.plugin.should_skip(this.connection));
         test.done();

--- a/tests/plugins/earlytalker.js
+++ b/tests/plugins/earlytalker.js
@@ -1,20 +1,17 @@
-var Plugin       = require('../fixtures/stub_plugin'),
-    Connection   = require('../fixtures/stub_connection'),
-    configfile   = require('../../configfile'),
-    config       = require('../../config'),
-    constants    = require('../../constants');
+'use strict';
 
-constants.import(global);
+var Plugin       = require('../fixtures/stub_plugin');
+var Connection   = require('../fixtures/stub_connection');
+var config       = require('../../config');
 
-function _set_up(callback) {
-    this.backup = {};
-
-    this.plugin = Plugin('early_talker');
+var _set_up = function (callback) {
+    
+    this.plugin = new Plugin('early_talker');
     this.plugin.config = config;
 
     this.connection = Connection.createConnection();
     callback();
-}
+};
 
 function _tear_down(callback) { callback(); }
 

--- a/tests/plugins/helo.checks.js
+++ b/tests/plugins/helo.checks.js
@@ -1,37 +1,27 @@
-var stub         = require('../fixtures/stub'),
-    Plugin       = require('../fixtures/stub_plugin'),
-    Connection   = require('../fixtures/stub_connection'),
-    constants    = require('../../constants'),
-    configfile   = require('../../configfile'),
-    config       = require('../../config'),
-    Address      = require('../../address'),
-    ResultStore  = require("../../result_store");
+'use strict';
 
-constants.import(global);
+var stub         = require('../fixtures/stub');
+var Plugin       = require('../fixtures/stub_plugin');
+var Connection   = require('../fixtures/stub_connection');
+var config       = require('../../config');
+var Address      = require('../../address');
 
-function _set_up(callback) {
-    this.backup = {};
-
-    // needed for tests
-    this.plugin = Plugin('helo.checks');
+var _set_up = function (done) {
+    
+    this.plugin = new Plugin('helo.checks');
     this.plugin.config = config;
 
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.connection);
+
     this.connection.remote_ip='208.75.199.19';
 
     this.plugin.register();
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.host_mismatch = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'host_mismatch, reject=false' : function (test) {
         test.expect(2);
         var outer = this;
@@ -64,7 +54,6 @@ exports.host_mismatch = {
 
 exports.proto_mismatch = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'proto_mismatch, reject=false, esmtp=false' : function (test) {
         test.expect(2);
         var outer = this;
@@ -114,7 +103,6 @@ exports.proto_mismatch = {
 
 exports.rdns_match = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'pass' : function (test) {
         test.expect(2);
         var outer = this;
@@ -178,7 +166,6 @@ exports.rdns_match = {
 
 exports.bare_ip = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'pass' : function (test) {
         test.expect(2);
         var outer = this;
@@ -223,7 +210,6 @@ exports.bare_ip = {
 
 exports.dynamic = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'pass' : function (test) {
         test.expect(2);
         var outer = this;
@@ -275,7 +261,6 @@ exports.dynamic = {
 
 exports.big_company = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'pass, reject=false' : function (test) {
         test.expect(2);
         var outer = this;
@@ -325,7 +310,6 @@ exports.big_company = {
 
 exports.literal_mismatch = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'pass' : function (test) {
         test.expect(2);
         var outer = this;
@@ -394,7 +378,6 @@ exports.literal_mismatch = {
 
 exports.valid_hostname = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'pass' : function (test) {
         test.expect(2);
         var test_helo = 'great.domain.com';
@@ -444,7 +427,6 @@ exports.valid_hostname = {
 
 exports.forward_dns = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'pass' : function (test) {
         test.expect(2);
         var outer = this;
@@ -500,7 +482,6 @@ exports.forward_dns = {
 
 exports.match_re = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'miss' : function (test) {
         test.expect(3);
         var test_helo = 'not_in_re_list.net';

--- a/tests/plugins/karma.js
+++ b/tests/plugins/karma.js
@@ -1,11 +1,10 @@
-var stub             = require('../fixtures/stub'),
-    Connection       = require('../fixtures/stub_connection'),
-    Plugin           = require('../fixtures/stub_plugin'),
-    configfile       = require('../../configfile'),
-    config           = require('../../config'),
-//  Header           = require('../../mailheader').Header,
-    ResultStore      = require("../../result_store"),
-    constants        = require('../../constants');
+'use strict';
+
+var stub             = require('../fixtures/stub');
+var Connection       = require('../fixtures/stub_connection');
+var Plugin           = require('../fixtures/stub_plugin');
+var config           = require('../../config');
+var ResultStore      = require("../../result_store");
 
 try {
     var redis = require('redis');
@@ -15,32 +14,25 @@ catch (e) {
     return;
 }
 
-constants.import(global);
-
-function _set_up(callback) {
-    this.backup = {};
-
-    // needed for tests
+var _set_up = function (done) {
+    
     this.plugin = new Plugin('karma');
+
     this.plugin.config = config;
     this.plugin.cfg = { main: {} };
     this.plugin.deny_hooks = {'connect': true};
     this.plugin.tarpit_hooks = ['connect'];
 
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.plugin);
+
     this.connection.transaction = stub;
     this.connection.transaction.results = new ResultStore(this.plugin);
 
-    callback();
-}
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.karma_init = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'register': function (test) {
         test.expect(2);
         this.plugin.register();
@@ -52,7 +44,6 @@ exports.karma_init = {
 
 exports.results_init = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'init, pre': function (test) {
         test.expect(1);
         var r = this.connection.results.get('karma');
@@ -79,7 +70,6 @@ exports.results_init = {
 
 exports.assemble_note_obj = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no auth fails': function (test) {
         test.expect(1);
         var obj = this.plugin.assemble_note_obj(this.connection, 'notes.auth_fails');
@@ -97,7 +87,6 @@ exports.assemble_note_obj = {
 
 exports.max_concurrent = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no results': function (test) {
         test.expect(2);
         var cb = function (rc, msg) {
@@ -132,7 +121,6 @@ exports.max_concurrent = {
 
 exports.hook_deny = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no params': function (test) {
         test.expect(1);
         var next = function (rc) {
@@ -189,7 +177,6 @@ exports.hook_deny = {
 
 exports.max_concurrent = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no results': function (test) {
         test.expect(2);
         var next = function (rc, msg) {
@@ -226,7 +213,6 @@ exports.max_concurrent = {
 
 exports.karma_penalty = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no results': function (test) {
         test.expect(2);
         var next = function (rc, msg) {
@@ -263,7 +249,6 @@ exports.karma_penalty = {
 
 exports.get_award_location = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'relaying=false': function (test) {
         test.expect(1);
         this.connection.relaying=false;
@@ -329,7 +314,6 @@ exports.get_award_location = {
 
 exports.get_award_condition = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'geoip.distance': function (test) {
         test.expect(2);
         test.equal(4000, this.plugin.get_award_condition(
@@ -344,7 +328,6 @@ exports.get_award_condition = {
 
 exports.check_awards = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no results': function (test) {
         test.expect(1);
         var r = this.plugin.check_awards(this.connection);
@@ -384,7 +367,6 @@ exports.check_awards = {
 
 exports.apply_tarpit = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'tarpit=false': function (test) {
         test.expect(2);
         var next = function (rc, msg) {
@@ -455,7 +437,6 @@ exports.apply_tarpit = {
 
 exports.should_we_deny = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no results': function (test) {
         test.expect(2);
         var next = function (rc, msg) {

--- a/tests/plugins/log.syslog.js
+++ b/tests/plugins/log.syslog.js
@@ -1,19 +1,17 @@
+'use strict';
+
 var stub             = require('../fixtures/stub'),
-    constants        = require('../../constants'),
-    Logger           = require('../fixtures/stub_logger'),
     Plugin           = require('../fixtures/stub_plugin');
 
-function _set_up(callback) {
+var _set_up = function (done) {
     this.backup = {};
 
-    // needed for tests
     try {
         this.plugin = new Plugin('log.syslog');
     }
     catch (e) {
         console.log(e);
     }
-    this.logger = Logger.createLogger();
 
     // backup modifications
     this.backup.plugin = {};
@@ -43,16 +41,11 @@ function _set_up(callback) {
         }.bind(this);
     }
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.register = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'should have register function' : function (test) {
         if (this.plugin) {
             test.expect(2);
@@ -127,7 +120,6 @@ exports.register = {
 
 exports.hook = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'returns just next() by default (missing always_ok)' : function (test) {
         if (!this.plugin) { return; }
 
@@ -165,7 +157,7 @@ exports.hook = {
 
         var next = function (action) {
             test.expect(1);
-            test.equals(action, constants.ok);
+            test.equals(action, OK);
             test.done();
         };
 
@@ -200,7 +192,7 @@ exports.hook = {
 
         var next = function (action) {
             test.expect(1);
-            test.equals(action, constants.ok);
+            test.equals(action, OK);
             test.done();
         };
 
@@ -232,7 +224,6 @@ exports.hook = {
 
 exports.log = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'syslog hook logs correct thing' : function (test) {
         if (!this.plugin) { return; }
 

--- a/tests/plugins/mail_from.is_resolvable.js
+++ b/tests/plugins/mail_from.is_resolvable.js
@@ -1,37 +1,27 @@
+'use strict';
 
 var stub         = require('../fixtures/stub'),
     Plugin       = require('../fixtures/stub_plugin'),
     Connection   = require('../fixtures/stub_connection'),
-    configfile   = require('../../configfile'),
     config       = require('../../config'),
-    logger       = require('../../logger'),
     ResultStore  = require('../../result_store');
 
-function _set_up(callback) {
-    this.backup = {};
-
-    // needed for tests
+var _set_up = function (done) {
+    
     this.plugin = new Plugin('mail_from.is_resolvable');
     this.plugin.config = config;
     this.plugin.register();
+
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.plugin);
+
     this.connection.transaction = { notes: {} };
     this.connection.transaction.results = new ResultStore(this.plugin);
 
-    logger.add_log_methods(this);
-    // this.plugin.loginfo = stub();
-
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.mxErr = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'any.com, no err code': function (test) {
         test.expect(3);
         var t = this;
@@ -63,10 +53,8 @@ exports.mxErr = {
     }
 };
 
-
 exports.implicit_mx = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'tnpi.net': function (test) {
         test.expect(2);
         var t = this;

--- a/tests/plugins/queue/smtp_forward.js
+++ b/tests/plugins/queue/smtp_forward.js
@@ -1,24 +1,17 @@
 'use strict';
 
 var stub         = require('../../fixtures/stub');
-var constants    = require('../../../constants');
 var Connection   = require('../../fixtures/stub_connection');
 var Plugin       = require('../../fixtures/stub_plugin');
-var configfile   = require('../../../configfile');
-var config       = require('../../../config');
-var ResultStore  = require('../../../result_store');
-var Address      = require('../../../address').Address;
 
-constants.import(global);
+var config       = require('../../../config');
+var Address      = require('../../../address').Address;
 
 var _set_up = function (done) {
 
     this.plugin = new Plugin('queue/smtp_forward');
     this.plugin.config = config;
 
-    done();
-};
-var _tear_down = function (done) {
     done();
 };
 
@@ -28,7 +21,6 @@ exports.register = {
         this.plugin.config = config;
         done();
     },
-    tearDown : _tear_down,
     'register': function (test) {
         test.expect(1);
         this.plugin.register();
@@ -44,12 +36,10 @@ exports.get_config = {
         this.plugin.register();
 
         this.connection = Connection.createConnection();
-        this.connection.results = new ResultStore(this.plugin);
         this.connection.transaction = { rcpt_to: [] };
 
         done();
     },
-    tearDown : _tear_down,
     'no recipient': function (test) {
         test.expect(1);
         var cfg = this.plugin.get_config(this.connection);

--- a/tests/plugins/rcpt_to.host_list_base.js
+++ b/tests/plugins/rcpt_to.host_list_base.js
@@ -1,38 +1,29 @@
+'use strict';
+
 var stub             = require('../fixtures/stub'),
     Plugin           = require('../fixtures/stub_plugin'),
     Connection       = require('../fixtures/stub_connection'),
-    constants        = require('../../constants'),
     Address          = require('../../address').Address,
-    configfile       = require('../../configfile'),
-    config           = require('../../config'),
     ResultStore      = require('../../result_store');
 
-// huge hack here, but plugin tests need constants
-constants.import(global);
+var _set_up = function (done) {
 
-function _set_up(callback) {
-    this.backup = {};
+    this.plugin = new Plugin('rcpt_to.host_list_base');
 
-    // needed for tests
-    this.plugin = Plugin('rcpt_to.host_list_base');
     this.plugin.cfg = {};
     this.plugin.host_list = {};
+
     this.connection = Connection.createConnection();
     this.connection.transaction = {
         results: new ResultStore(this.connection),
         notes: {},
     };
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.in_host_list = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'miss' : function (test) {
         test.expect(1);
         test.equal(false, this.plugin.in_host_list('test.com'));
@@ -48,7 +39,6 @@ exports.in_host_list = {
 
 exports.in_host_regex = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'undef' : function (test) {
         test.expect(1);
         var r = this.plugin.in_host_regex('test.com');
@@ -83,7 +73,6 @@ exports.in_host_regex = {
 
 exports.hook_mail = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'null sender' : function (test) {
         test.expect(2);
         var next = function (rc, msg) {

--- a/tests/plugins/rcpt_to.in_host_list.js
+++ b/tests/plugins/rcpt_to.in_host_list.js
@@ -1,39 +1,30 @@
-var stub             = require('../fixtures/stub'),
-    Plugin           = require('../fixtures/stub_plugin'),
-    Connection       = require('../fixtures/stub_connection'),
-    constants        = require('../../constants'),
-    Address          = require('../../address').Address,
-    configfile       = require('../../configfile'),
-    config           = require('../../config'),
-    ResultStore      = require('../../result_store');
+'use strict';
 
-// huge hack here, but plugin tests need constants
-constants.import(global);
+var stub             = require('../fixtures/stub');
+var Plugin           = require('../fixtures/stub_plugin');
+var Connection       = require('../fixtures/stub_connection');
+var Address          = require('../../address').Address;
+var ResultStore      = require('../../result_store');
 
-function _set_up(callback) {
-    this.backup = {};
+var _set_up = function (done) {
 
-    // needed for tests
-    this.plugin = Plugin('rcpt_to.in_host_list');
+    this.plugin = new Plugin('rcpt_to.in_host_list');
     this.plugin.inherits('rcpt_to.host_list_base');
+
     this.plugin.cfg = {};
     this.plugin.host_list = {};
+
     this.connection = Connection.createConnection();
     this.connection.transaction = {
         results: new ResultStore(this.connection),
         notes: {},
     };
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.in_host_list = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'miss' : function (test) {
         test.expect(1);
         var r = this.plugin.in_host_list('test.com');
@@ -51,7 +42,6 @@ exports.in_host_list = {
 
 exports.in_host_regex = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'undef' : function (test) {
         test.expect(1);
         var r = this.plugin.in_host_regex('test.com');
@@ -86,7 +76,6 @@ exports.in_host_regex = {
 
 exports.hook_mail = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'null sender' : function (test) {
         test.expect(2);
         var next = function (rc, msg) {
@@ -154,7 +143,6 @@ exports.hook_mail = {
 
 exports.hook_rcpt = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'missing txn' : function (test) {
         test.expect(1);
         // sometimes txn goes away, make sure it's handled

--- a/tests/plugins/rcpt_to.ldap.js
+++ b/tests/plugins/rcpt_to.ldap.js
@@ -1,21 +1,16 @@
-var stub             = require('../fixtures/stub'),
-    Plugin           = require('../fixtures/stub_plugin'),
+'use strict';
+
+var Plugin           = require('../fixtures/stub_plugin'),
     Connection       = require('../fixtures/stub_connection'),
-    constants        = require('../../constants'),
     Address          = require('../../address').Address,
-    configfile       = require('../../configfile'),
     config           = require('../../config'),
     ResultStore      = require('../../result_store');
 
-// huge hack here, but plugin tests need constants
-constants.import(global);
+var _set_up = function (done) {
 
-function _set_up(callback) {
-    this.backup = {};
-
-    // needed for tests
-    this.plugin = Plugin('rcpt_to.ldap');
+    this.plugin = new Plugin('rcpt_to.ldap');
     this.plugin.inherits('rcpt_to.host_list_base');
+
     this.plugin.cfg = {};
     this.plugin.host_list = {};
     this.connection = Connection.createConnection();
@@ -24,16 +19,11 @@ function _set_up(callback) {
         notes: {},
     };
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.in_host_list = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'miss' : function (test) {
         test.expect(1);
         test.equal(false, this.plugin.in_host_list('test.com'));
@@ -49,7 +39,6 @@ exports.in_host_list = {
 
 exports.in_ldap_ini = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'miss' : function (test) {
         test.expect(1);
         test.equal(false, this.plugin.in_ldap_ini('test.com'));
@@ -65,7 +54,6 @@ exports.in_ldap_ini = {
 
 exports.ldap_rcpt = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'missing txn' : function (test) {
         test.expect(3);
         // sometimes txn goes away, make sure it's handled

--- a/tests/plugins/rcpt_to.qmail_deliverable.js
+++ b/tests/plugins/rcpt_to.qmail_deliverable.js
@@ -1,32 +1,21 @@
-var stub             = require('../fixtures/stub'),
-    Plugin           = require('../fixtures/stub_plugin'),
-    Connection       = require('../fixtures/stub_connection'),
-    constants        = require('../../constants'),
-    Address          = require('../../address');
+'use strict';
 
-// huge hack here, but plugin tests need constants
-constants.import(global);
+var stub             = require('../fixtures/stub');
+var Plugin           = require('../fixtures/stub_plugin');
+var Connection       = require('../fixtures/stub_connection');
+var Address          = require('../../address');
 
-function _set_up(callback) {
-    this.backup = {};
+var _set_up = function (done) {
 
-    // needed for tests
-    this.plugin = Plugin('rcpt_to.qmail_deliverable');
+    this.plugin = new Plugin('rcpt_to.qmail_deliverable');
+
     this.connection = Connection.createConnection();
 
-    // going to need these in multiple tests
-    // this.plugin.register();
-
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.get_qmd_response = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'stub' : function (test) {
         test.expect(0);
         // can't really test this very well without a QMD server
@@ -36,7 +25,6 @@ exports.get_qmd_response = {
 
 exports.check_qmd_reponse = {
     setUp : _set_up,
-    tearDown : _tear_down,
     '11' : function (test) {
         test.expect(1);
         var r = this.plugin.check_qmd_reponse(this.connection, '11');

--- a/tests/plugins/rcpt_to.routes.js
+++ b/tests/plugins/rcpt_to.routes.js
@@ -1,19 +1,16 @@
-var stub             = require('../fixtures/stub'),
-    Plugin           = require('../fixtures/stub_plugin'),
-    Connection       = require('../fixtures/stub_connection'),
-    constants        = require('../../constants'),
-    Address          = require('../../address').Address,
-    configfile       = require('../../configfile'),
-    config           = require('../../config'),
-    ResultStore      = require('../../result_store');
+'use strict';
 
-// huge hack here, but plugin tests need constants
-constants.import(global);
+var Plugin        = require('../fixtures/stub_plugin');
+var Connection    = require('../fixtures/stub_connection');
+var Address       = require('../../address').Address;
+var config        = require('../../config');
+var ResultStore   = require('../../result_store');
 
 var hmail = {
     "queue_time":1402091363826,
     "domain":"example.com",
-    "rcpt_to":[{"original":"matt@example.com","user":"matt","host":"example.com"}],
+    "rcpt_to":[
+        {"original":"matt@example.com","user":"matt","host":"example.com"}],
     "mail_from":{"original":"<>",
     "user":null,
     "host":null},
@@ -21,11 +18,10 @@ var hmail = {
     "uuid":"DFB28F2B-CC21-438B-864D-934E6860AB61.1",
 };
 
-function _set_up_file(callback) {
-    this.backup = {};
+var _set_up_file = function (done) {
 
     // needed for tests
-    this.plugin = Plugin('rcpt_to.routes');
+    this.plugin = new Plugin('rcpt_to.routes');
     this.plugin.config = config;
     this.plugin.register();
     this.connection = Connection.createConnection();
@@ -34,14 +30,13 @@ function _set_up_file(callback) {
         notes: {},
     };
 
-    callback();
-}
+    done();
+};
 
-function _set_up_redis(callback) {
+var _set_up_redis = function (done) {
     this.backup = {};
 
-    // needed for tests
-    this.plugin = Plugin('rcpt_to.routes');
+    this.plugin = new Plugin('rcpt_to.routes');
     this.plugin.config = config;
     this.plugin.register();
     this.connection = Connection.createConnection();
@@ -50,20 +45,15 @@ function _set_up_redis(callback) {
         notes: {},
     };
 
-    this.plugin.redis_ping(callback);
-}
+    this.plugin.redis_ping(done);
+};
 
-function _tear_down(callback) {
-    callback();
-}
-
-function _tear_down_redis(callback) {
-    this.plugin.delete_route('matt@example.com', callback);
-}
+var _tear_down_redis = function (done) {
+    this.plugin.delete_route('matt@example.com', done);
+};
 
 exports.rcpt_file = {
     setUp : _set_up_file,
-    tearDown : _tear_down,
     'miss' : function (test) {
         test.expect(2);
         var cb = function (rc, msg) {
@@ -128,7 +118,6 @@ exports.rcpt_redis = {
 
 exports.get_mx_file = {
     setUp : _set_up_file,
-    tearDown : _tear_down,
     'email address file hit' : function (test) {
         test.expect(2);
         var cb = function (rc, mx) {

--- a/tests/plugins/relay.js
+++ b/tests/plugins/relay.js
@@ -1,14 +1,9 @@
 'use strict';
 
-var stub         = require('../fixtures/stub'),
-    constants    = require('../../constants'),
-    Connection   = require('../fixtures/stub_connection'),
+var Connection   = require('../fixtures/stub_connection'),
     Plugin       = require('../fixtures/stub_plugin'),
-    configfile   = require('../../configfile'),
     config       = require('../../config'),
     ResultStore  = require("../../result_store");
-
-constants.import(global);
 
 var _set_up = function (done) {
 
@@ -107,7 +102,6 @@ exports.acl = {
         this.plugin.config = config;
         this.plugin.cfg = { relay: { dest_domains: true } };
         this.connection = Connection.createConnection();
-        this.connection.results = new ResultStore(this.connection);
         callback();
     },
     'relay.acl=false' : function (test) {
@@ -169,12 +163,11 @@ exports.acl = {
 
 exports.dest_domains = {
     setUp : function (callback) {
-        this.plugin = Plugin('relay');
+        this.plugin = new Plugin('relay');
         this.plugin.config = config;
         this.plugin.cfg = { relay: { dest_domains: true } };
 
         this.connection = Connection.createConnection();
-        this.connection.results = new ResultStore(this.connection);
         this.connection.transaction = {
             results: new ResultStore(this.connection),
         };
@@ -253,13 +246,12 @@ exports.dest_domains = {
 
 exports.force_routing = {
     setUp : function (callback) {
-        this.plugin = Plugin('relay');
+        this.plugin = new Plugin('relay');
         this.plugin.config = config;
         this.plugin.cfg = { relay: { force_routing: true } };
         this.plugin.dest = {};
 
         this.connection = Connection.createConnection();
-        this.connection.results = new ResultStore(this.connection);
         this.connection.transaction = {
             results: new ResultStore(this.connection),
         };
@@ -322,7 +314,7 @@ exports.all = {
     'all hook always returns OK' : function (test) {
         var next = function (action) {
             test.expect(1);
-            test.equals(action, constants.ok);
+            test.equals(action, OK);
             test.done();
         };
         this.plugin.cfg.relay = { all: true };

--- a/tests/plugins/spamassassin.js
+++ b/tests/plugins/spamassassin.js
@@ -4,30 +4,23 @@ var stub         = require('../fixtures/stub'),
     Plugin       = require('../fixtures/stub_plugin'),
     Connection   = require('../fixtures/stub_connection'),
     Address      = require('../../address'),
-    configfile   = require('../../configfile'),
     config       = require('../../config');
 
-function _set_up(callback) {
+var _set_up = function (done) {
 
     this.plugin = new Plugin('spamassassin');
     this.plugin.config = config;
     this.plugin.cfg = { main: { } };
 
     this.connection = Connection.createConnection();
-    // this.connection.results = new ResultStore(this.plugin);
     this.connection.transaction = stub;
     this.connection.transaction.notes = {};
 
-    callback();
-}
-
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.register = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'loads the spamassassin plugin': function (test) {
         test.expect(1);
         test.equal('spamassassin', this.plugin.name);
@@ -44,7 +37,6 @@ exports.register = {
 
 exports.load_spamassassin_ini = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'loads spamassassin.ini': function (test) {
         test.expect(2);
         test.equal(undefined, this.plugin.cfg.main.spamd_socket);
@@ -56,7 +48,6 @@ exports.load_spamassassin_ini = {
 
 exports.msg_too_big = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'max_size not set': function (test) {
         test.expect(1);
         test.equal(false, this.plugin.msg_too_big(this.connection));
@@ -82,7 +73,6 @@ exports.msg_too_big = {
 
 exports.get_spamd_headers = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'returns a spamd protocol request': function (test) {
         test.expect(1);
         this.connection.transaction.mail_from = new Address.Address('<matt@example.com>');
@@ -102,7 +92,6 @@ exports.get_spamd_headers = {
 
 exports.get_spamd_username = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'default': function (test) {
         test.expect(1);
         test.equal('default', this.plugin.get_spamd_username(this.connection));
@@ -131,7 +120,6 @@ exports.get_spamd_username = {
 
 exports.score_too_high = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'no threshhold is not too high': function (test) {
         test.expect(1);
         test.ok(!this.plugin.score_too_high(this.connection, {score: 5}));

--- a/tests/plugins/spf.js
+++ b/tests/plugins/spf.js
@@ -1,43 +1,35 @@
-var stub         = require('../fixtures/stub'),
-    constants    = require('../../constants'),
-    Connection   = require('../fixtures/stub_connection'),
+'use strict';
+
+var Connection   = require('../fixtures/stub_connection'),
     Plugin       = require('../fixtures/stub_plugin'),
     SPF          = require('../../spf').SPF,
-    configfile   = require('../../configfile'),
     config       = require('../../config'),
-    ResultStore  = require("../../result_store"),
     Address      = require('../../address').Address;
 
-constants.import(global);
 var spf = new SPF();
 
-function _set_up(callback) {
-    this.backup = {};
+var _set_up = function (done) {
 
     // needed for tests
-    this.plugin = Plugin('spf');
+    this.plugin = new Plugin('spf');
     this.plugin.config = config;
     this.plugin.cfg = { main: { }, defer: {}, deny: {} };
 
     this.connection = Connection.createConnection();
-    this.connection.results = new ResultStore(this.plugin);
 
-    callback();
-}
-function _tear_down(callback) {
-    callback();
-}
+    done();
+};
 
 exports.return_results = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'result, none': function (test) {
         var next = function () {
             test.equal(undefined, arguments[0]);
             test.done();
         };
         test.expect(1);
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.NONE, 'test@example.com');
+        this.plugin.return_results(next, this.connection, 
+            spf, 'mfrom', spf.NONE, 'test@example.com');
     },
     'result, neutral': function (test) {
         var next = function () {
@@ -45,7 +37,8 @@ exports.return_results = {
             test.done();
         };
         test.expect(1);
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.NEUTRAL, 'test@example.com');
+        this.plugin.return_results(next, this.connection,
+            spf, 'mfrom', spf.NEUTRAL, 'test@example.com');
     },
     'result, pass': function (test) {
         var next = function () {
@@ -53,7 +46,8 @@ exports.return_results = {
             test.done();
         };
         test.expect(1);
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_PASS, 'test@example.com');
+        this.plugin.return_results(next, this.connection,
+            spf, 'mfrom', spf.SPF_PASS, 'test@example.com');
     },
     'result, softfail, reject=false': function (test) {
         var next = function () {
@@ -62,7 +56,8 @@ exports.return_results = {
         };
         test.expect(1);
         this.plugin.cfg.deny.mfrom_softfail=false;
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_SOFTFAIL, 'test@example.com');
+        this.plugin.return_results(next, this.connection,
+            spf, 'mfrom', spf.SPF_SOFTFAIL, 'test@example.com');
     },
     'result, softfail, reject=true': function (test) {
         var next = function () {
@@ -71,7 +66,8 @@ exports.return_results = {
         };
         test.expect(1);
         this.plugin.cfg.deny.mfrom_softfail=true;
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_SOFTFAIL, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf,
+            'mfrom', spf.SPF_SOFTFAIL, 'test@example.com');
     },
     'result, fail, reject=false': function (test) {
         var next = function () {
@@ -80,7 +76,8 @@ exports.return_results = {
         };
         test.expect(1);
         this.plugin.cfg.deny.mfrom_fail=false;
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_FAIL, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf,
+            'mfrom', spf.SPF_FAIL, 'test@example.com');
     },
     'result, fail, reject=true': function (test) {
         var next = function () {
@@ -89,7 +86,8 @@ exports.return_results = {
         };
         test.expect(1);
         this.plugin.cfg.deny.mfrom_fail=true;
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_FAIL, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf,
+            'mfrom', spf.SPF_FAIL, 'test@example.com');
     },
     'result, temperror, reject=false': function (test) {
         var next = function () {
@@ -98,7 +96,8 @@ exports.return_results = {
         };
         test.expect(1);
         this.plugin.cfg.defer.mfrom_temperror=false;
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_TEMPERROR, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf,
+            'mfrom', spf.SPF_TEMPERROR, 'test@example.com');
     },
     'result, temperror, reject=true': function (test) {
         var next = function () {
@@ -107,7 +106,8 @@ exports.return_results = {
         };
         test.expect(1);
         this.plugin.cfg.defer.mfrom_temperror=true;
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_TEMPERROR, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf,
+            'mfrom', spf.SPF_TEMPERROR, 'test@example.com');
     },
     'result, permerror, reject=false': function (test) {
         var next = function () {
@@ -116,7 +116,8 @@ exports.return_results = {
         };
         test.expect(1);
         this.plugin.cfg.deny.mfrom_permerror=false;
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_PERMERROR, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf,
+            'mfrom', spf.SPF_PERMERROR, 'test@example.com');
     },
     'result, permerror, reject=true': function (test) {
         var next = function () {
@@ -125,7 +126,8 @@ exports.return_results = {
         };
         test.expect(1);
         this.plugin.cfg.deny.mfrom_permerror=true;
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_PERMERROR, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf,
+            'mfrom', spf.SPF_PERMERROR, 'test@example.com');
     },
     'result, unknown': function (test) {
         var next = function () {
@@ -133,13 +135,13 @@ exports.return_results = {
             test.done();
         };
         test.expect(1);
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', 'unknown', 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf,
+            'mfrom', 'unknown', 'test@example.com');
     },
 };
 
 exports.hook_helo = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'rfc1918': function (test) {
         var completed = 0;
         var next = function (rc) {
@@ -169,7 +171,6 @@ exports.hook_helo = {
 
 exports.hook_mail = {
     setUp : _set_up,
-    tearDown : _tear_down,
     'rfc1918': function (test) {
         var next = function () {
             test.equal(undefined, arguments[0]);
@@ -205,7 +206,8 @@ exports.hook_mail = {
         };
         test.expect(1);
         this.connection.remote_ip='207.85.1.1';
-        this.plugin.hook_mail(next, this.connection, [new Address('<test@example.com>')]);
+        this.plugin.hook_mail(next, this.connection,
+            [new Address('<test@example.com>')]);
     },
     'txn': function (test) {
         var next = function (rc) {
@@ -215,7 +217,8 @@ exports.hook_mail = {
         test.expect(1);
         this.connection.remote_ip='207.85.1.1';
         this.connection.hello_host = 'mail.example.com';
-        this.plugin.hook_mail(next, this.connection, [new Address('<test@example.com>')]);
+        this.plugin.hook_mail(next, this.connection,
+            [new Address('<test@example.com>')]);
     },
     'txn, relaying': function (test) {
         var next = function (rc) {
@@ -226,7 +229,8 @@ exports.hook_mail = {
         this.connection.remote_ip='207.85.1.1';
         this.connection.relaying=true;
         this.connection.hello_host = 'mail.example.com';
-        this.plugin.hook_mail(next, this.connection, [new Address('<test@example.com>')]);
+        this.plugin.hook_mail(next, this.connection,
+            [new Address('<test@example.com>')]);
     },
 };
 


### PR DESCRIPTION
- remove lots of unused boilerplate
- move constants importing into fixtures/plugins (and removed to dozen+ plugins)
- purged unused requires
- updated tests that were still manually adding stuff to plugins and connections that have since been added to the test figures.
