### PR TITLE
config.js: small updates

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,26 +1,25 @@
-"use strict";
+'use strict';
 
-var configloader = require('./configfile');
+var cfreader     = require('./configfile');
 var path         = require('path');
 var logger       = require('./logger');
 
 var config = exports;
 
 config.get = function(name, type, cb, options) {
-    var args = this.arrange_args([name, type, cb, options]);
-    if (!args[1]) args[1] = 'value';
+    var a = this.arrange_args([name, type, cb, options]);
+    if (!a[1]) a[1] = 'value';
 
-    var full_path = path.resolve(configloader.config_path, args[0]);
+    var full_path = path.resolve(cfreader.config_path, a[0]);
 
-    var results = configloader.read_config(full_path, args[1], args[2], args[3]);
+    var results = cfreader.read_config(full_path, a[1], a[2], a[3]);
 
     // Pass arrays by value to prevent config being modified accidentally.
     if (Array.isArray(results)) {
         return results.slice();
     } 
-    else {
-        return results;
-    }
+
+    return results;
 };
 
 /* ways get() can be called:
@@ -39,30 +38,33 @@ config.arrange_args = function (args) {
     var fs_type = null;
     var cb, options;
 
-    for (var a=0; a < args.length; a++) {
-        if (args[a] === undefined) continue;
-        var what_is_it = args[a];
-        if (typeof what_is_it == 'function') {
-            cb = what_is_it;
-            continue;
+    for (var i=0; i < args.length; i++) {
+        if (args[i] === undefined) continue;
+        var what_is_it = args[i];
+        switch (typeof args[i]) {   // what is it?
+            case 'function':
+                cb = args[i];
+                break;
+            case 'object':
+                options = args[i];
+                break;
+            case 'string':
+                if (/^(ini|value|list|data|json|yaml|binary)$/.test(args[i])) {
+                    fs_type = args[i];
+                    break;
+                }
+                console.log('unknown string:' + args[i]);
+                break;
         }
-        if (typeof what_is_it == 'object') {
-            options = what_is_it;
-            continue;
-        }
-        if (typeof what_is_it == 'string') {
-            if (what_is_it.match(/^(ini|value|list|data|json|binary)$/)) {
-                fs_type = what_is_it;
-                continue;
-            }
-            // console.log('not recognized string:' + what_is_it);
-            continue;
-        }
-        // console.log('unknown arg:' + what_is_it + ', typeof: ' + typeof what_is_it);
+        // console.log('unknown arg:' + args[i] + ', typeof: ' +
+        //      typeof args[i]);
     }
 
-    if (!fs_type && fs_name.match(/\.ini$/)) {
-        fs_type = 'ini';
+    if (!fs_type) {
+             if (/\.json$/.test(fs_name)) fs_type = 'json';
+        else if (/\.yaml$/.test(fs_name)) fs_type = 'yaml';
+        else if (/\.ini$/.test(fs_name))  fs_type = 'ini';
+        else                              fs_type = 'value';
     }
 
     return [fs_name, fs_type, cb, options];

--- a/configfile.js
+++ b/configfile.js
@@ -184,32 +184,34 @@ cfreader.get_filetype_reader = function (type) {
 cfreader.load_config = function(name, type, options) {
     var result;
 
-    if (type === 'ini' || /\.ini$/.test(name)) {
-        result = cfreader.load_ini_config(name, options);
-    }
-    else if (type === 'json' || /\.json$/.test(name)) {
-        result = cfreader.load_json_config(name);
-    }
-    else if (type === 'yaml' || /\.yaml$/.test(name)) {
-        result = cfreader.load_yaml_config(name);
-    }
-    else if (type === 'binary') {
-        result = cfreader.load_binary_config(name, type);
-    }
-    else {
-        result = cfreader.load_flat_config(name, type, options);
-        if (result && type !== 'list' && type !== 'data') {
-            result = result[0];
-            if (options && Array.isArray(options.booleans) && options.booleans.indexOf(result) === -1) {
-                result = regex.is_truth.test(result);
+    switch (type) {
+        case 'ini':
+            result = cfreader.load_ini_config(name, options);
+            break;
+        case 'json':
+            result = cfreader.load_json_config(name);
+            break;
+        case 'yaml':
+            result = cfreader.load_yaml_config(name);
+            break;
+        case 'binary':
+            result = cfreader.load_binary_config(name, type);
+            break;
+        default:
+            result = cfreader.load_flat_config(name, type, options);
+            if (result && type !== 'list' && type !== 'data') {
+                result = result[0];
+                if (options && Array.isArray(options.booleans) &&
+                    options.booleans.indexOf(result) === -1) {
+                    result = regex.is_truth.test(result);
+                }
+                else if (regex.is_integer.test(result)) {
+                    result = parseInt(result, 10);
+                }
+                else if (regex.is_float.test(result)) {
+                    result = parseFloat(result);
+                }
             }
-            else if (regex.is_integer.test(result)) {
-                result = parseInt(result, 10);
-            }
-            else if (regex.is_float.test(result)) {
-                result = parseFloat(result);
-            }
-        }
     }
 
     if (!options || !options.no_cache) {
@@ -232,7 +234,7 @@ cfreader.load_json_config = function(name) {
                 var yaml_name = name.replace(/\.json$/, '.yaml');
                 if (utils.existsSync(yaml_name)) {
                     // We have to read_config() here, so the file is watched
-                    result = cfreader.read_config(yaml_name);
+                    result = cfreader.read_config(yaml_name, 'yaml');
                     // Replace original config cache with this result
                     cfreader._config_cache[name] = result;
                 }

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -1,28 +1,28 @@
 Config Files
 ============
 
-Haraka contains a flexible config loader which can load a few different types
-of configuration files.
+Haraka's config loader can load several types of configuration files.
 
 The API is fairly simple:
 
     // From within a plugin:
-    var config_item = this.config.get(name, [type], [callback], [options]);
+    var cfg = this.config.get(name, [type], [callback], [options]);
 
 `name` is not a filename, but a name in the config/ directory. For example:
 
-    var config_item = this.config.get('rambling.paths', 'list');
+    var cfg = this.config.get('rambling.paths', 'list');
 
 This will load the file config/rambling.paths in the Haraka directory.
 
 `type` can be one of:
 
 * 'value' - load a flat file containing a single value (default)
-* 'ini' - load an "ini" style file
-* 'json' - load a json file
-* 'yaml' - load a yaml file
-* 'list' - load a flat file containing a list of values
-* 'data' - load a flat file containing a list of values, keeping comments and whitespace.
+* 'ini'   - load an "ini" style file
+* 'json'  - load a json file
+* 'yaml'  - load a yaml file
+* 'list'  - load a flat file containing a list of values
+* 'data'  - load a flat file containing a list of values, keeping comments and whitespace.
+* 'binary' - load a binary file into a Buffer
 
 If your ini and json files have `.ini`, `.json` or `.yaml` suffixes,
 the `type` parameter can be omitted.  
@@ -41,7 +41,7 @@ var cfg;  // variable global to this plugin only
 
 exports.register = function () {
     var plugin = this;
-    plugin.loginfo('calling register function');
+    plugin.loginfo('register function called');
     cfg = plugin.config.get('my_plugin.ini', function () {
         // This closure will be run for each detected update of my_plugin.ini
         // Re-run the outer function again
@@ -57,16 +57,13 @@ exports.hook_connect = function (next, connection) {
 
 The optional `options` object can accepts the following keys:
 
-* `no_watch` (default: false) - this prevents Haraka from watching the file
-for updates.
-* `no_cache` (default: false) - this prevents Haraka from caching the file
-in the configuration cache which means that the file will be re-read on
-every call to `config.get`.  This is not recommended as configuration files
-are read using syncronous functions and will therefore block the event loop
-and slow down the operation of Haraka.
-* `booleans` (default: none) - for .ini file types, this allows you to specify
-keys that are boolean types and to default the boolean to true or falsae if 
-desired.  See below for details.
+* `no_watch` (default: false) - prevents Haraka from watching for updates.
+* `no_cache` (default: false) - prevents Haraka from caching the file. This
+means that the file will be re-read on every call to `config.get`.  This is
+not recommended as config files are read syncronously, will block the event
+loop, and will slow down Haraka.
+* `booleans` (default: none) - for .ini files, this allows specifying
+boolean type keys. Default true or false can be specified.
 
 <a name="file_formats">File Formats</a>
 ============


### PR DESCRIPTION
- moved json & yaml file type setting into config.arrange_args with the
  .ini setting.
- added binary type to type list in docs/Config.md
- adds yaml to the list of recognized fs_types
- line shortening (lint)
- replaced cascading if else’s with switch/case (2x)
- renamed configloader -> cfreader (consistent with use elsewhere)

The changes to a config.arrangeargs are well covered by the tests I wrote long ago and the changes in configfile.js are mostly covered by the tests added in #793. What I'm uncertain of is how this might affect the caching / watching of YAML files.
