### PR TITLE
tis: add basic tests, don't register unless certs

### DIFF
--- a/config/tls.ini
+++ b/config/tls.ini
@@ -5,5 +5,5 @@ ciphers=ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-G
 
 ; no_tls_hosts - if you find servers with broken TLS, add their IP to this
 ; section to disable TLS for them.
-; [no_tls_hosts]
+[no_tls_hosts]
 ; 192.168.1.1=true

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -10,27 +10,27 @@ var utils = require('./utils');
 exports.register = function () {
     var plugin = this;
 
+    // declare first, these opts might be updated by tls.ini
     plugin.tls_opts = {
-        key: false,
-        cert: false,
+        key: plugin.load_pem('tls_key.pem'),
+        cert: plugin.load_pem('tls_cert.pem'),
     };
 
-    var config_options = ['ciphers','requestCert','rejectUnauthorized'];
-
-    plugin.load_config();
-
-    plugin.tls_opts.key = plugin.load_pem('tls_key.pem');
-    if (!plugin.tls_opts.key) {
-        plugin.logcrit("config/tls_key.pem not loaded. See 'haraka -h tls'");
-    }
-
-    plugin.tls_opts.cert = plugin.load_pem('tls_cert.pem');
-
-    if (!plugin.tls_opts.cert) {
-        plugin.logcrit("config/tls_cert.pem not loaded. See 'haraka -h tls'");
-    }
+    plugin.load_tls_ini();
 
     plugin.logdebug(plugin.tls_opts);
+
+    if (!plugin.tls_opts.key) {
+        plugin.logcrit("config/tls_key.pem not loaded. See 'haraka -h tls'");
+        return;
+    }
+    if (!plugin.tls_opts.cert) {
+        plugin.logcrit("config/tls_cert.pem not loaded. See 'haraka -h tls'");
+        return;
+    }
+    
+    plugin.register_hook('capabilities', 'tls_capabilities');
+    plugin.register_hook('unrecognized_command', 'tls_unrecognized_command');
 };
 
 exports.load_pem = function (file) {
@@ -38,7 +38,7 @@ exports.load_pem = function (file) {
     return plugin.config.get(file, 'binary');
 };
 
-exports.load_config = function () {
+exports.load_tls_ini = function () {
     var plugin = this;
     plugin.cfg = plugin.config.get('tls.ini', {
         booleans: [
@@ -46,33 +46,29 @@ exports.load_config = function () {
             '-main.rejectUnauthorized',
         ]
     }, function () {
-        plugin.load_config();
+        plugin.load_tls_ini();
     });
 
-    for (var i in config_options) {
-        if (plugin.cfg.main[config_options[i]] === undefined) { continue; }
-        plugin.tls_opts[config_options[i]] = plugin.cfg.main[config_options[i]];
+    if (!plugin.cfg.no_tls_hosts) {
+        plugin.cfg.no_tls_hosts = {};
+    }
+
+    var config_options = ['ciphers','requestCert','rejectUnauthorized'];
+
+    for (var i = 0; i < config_options.length; i++) {
+        var opt = config_options[i];
+        if (plugin.cfg.main[opt] === undefined) { continue; }
+        plugin.tls_opts[opt] = plugin.cfg.main[opt];
     }
 };
 
-exports.hook_capabilities = function (next, connection) {
-    /* Caution: do not advertise STARTTLS if the upgrade has already been done. */
+exports.tls_capabilities = function (next, connection) {
+    /* Caution: do not advertise STARTTLS if already TLS upgraded */
     if (connection.using_tls) { return next(); }
 
     var plugin = this;
-    if (plugin.cfg.no_tls_hosts) {
-        if (plugin.cfg.no_tls_hosts[connection.remote_ip]) {
-            return next();
-        }
-    }
-
-    if (!plugin.tls_opts.key) {
-        connection.logcrit("No TLS key found. See 'harka -h tls'");
-        return next();
-    }
-
-    if (!plugin.tls_opts.cert) {
-        connection.logcrit("No TLS cert found. See 'harka -h tls'");
+    
+    if (plugin.cfg.no_tls_hosts[connection.remote_ip]) {
         return next();
     }
 
@@ -83,7 +79,7 @@ exports.hook_capabilities = function (next, connection) {
     next();
 };
 
-exports.hook_unrecognized_command = function (next, connection, params) {
+exports.tls_unrecognized_command = function (next, connection, params) {
     /* Watch for STARTTLS directive from client. */
     if (!connection.notes.tls_enabled) { return next(); }
     if (params[0].toUpperCase() !== 'STARTTLS') { return next(); }

--- a/tests/config/tls_cert.pem
+++ b/tests/config/tls_cert.pem
@@ -1,0 +1,1 @@
+-----BEGIN FAKE CERT ----

--- a/tests/config/tls_key.pem
+++ b/tests/config/tls_key.pem
@@ -1,0 +1,1 @@
+-----BEGIN FAKE KEY ----

--- a/tests/plugins/tls.js
+++ b/tests/plugins/tls.js
@@ -1,0 +1,105 @@
+'use strict';
+
+var fs           = require('fs');
+var Plugin       = require('../fixtures/stub_plugin');
+var Connection   = require('../fixtures/stub_connection');
+var config       = require('../../config');
+var ResultStore  = require('../../result_store');
+var utils        = require('../../utils');
+
+var _set_up = function (done) {
+
+    this.plugin = new Plugin('tls');
+    this.plugin.config = config;
+
+    this.connection = Connection.createConnection();
+    this.connection.transaction = {
+        results: new ResultStore(this.connection),
+    };
+
+    done();
+};
+
+exports.plugin = {
+    setUp : _set_up,
+    'should have function register' : function (test) {
+        test.expect(2);
+        test.isNotNull(this.plugin);
+        test.isFunction(this.plugin.register);
+        test.done();
+    },
+    'should have function tls_unrecognized_command' : function (test) {
+        test.expect(1);
+        test.isFunction(this.plugin.tls_unrecognized_command);
+        test.done();
+    },
+    'should have function tls_capabilities' : function (test) {
+        test.expect(1);
+        test.isFunction(this.plugin.tls_capabilities);
+        test.done();
+    },
+};
+
+exports.load_tls_ini = {
+    setUp: function(done) {
+        this.plugin = new Plugin('tls');
+        this.plugin.config = config;
+        this.plugin.tls_opts = {};
+        done();
+    },
+    'loads tls.ini' : function (test) {
+        test.expect(3);
+        this.plugin.load_tls_ini();
+        test.ok(this.plugin.cfg.main.requestCert);
+        test.ok(this.plugin.cfg.main.ciphers);
+        test.ok(this.plugin.cfg.no_tls_hosts);
+        // console.log(this.plugin.cfg);
+        test.done();
+    }
+};
+
+exports.register = {
+    setUp : function(done) {
+        this.plugin = new Plugin('tls');
+        this.plugin.config = config;
+
+        // overload load_pem to get files from tests/config
+        this.plugin.load_pem = function (file) {
+            return fs.readFileSync('./tests/config/' + file);
+        };
+
+        done();
+    },
+    'with certs, should call register_hook()' : function (test) {
+        test.expect(2);
+        this.plugin.register();
+        test.ok(this.plugin.cfg.main.requestCert);
+        test.ok(this.plugin.register_hook.called);
+        // console.log(this.plugin);
+        test.done();
+    },
+};
+
+exports.dont_register = {
+    setUp : function(done) {
+        this.plugin = new Plugin('tls');
+        this.plugin.config = config;
+
+        // overload load_pem to get files from tests/config
+        this.plugin.load_pem = function (file) {
+            try {
+                return fs.readFileSync('./non-exist/config/' + file);
+            }
+            catch (ignore) {}
+        };
+
+        done();
+    },
+    'w/o certs, should not call register_hook()' : function (test) {
+        test.expect(1);
+        this.plugin.register();
+        test.equal(this.plugin.register_hook.called, false);
+        // console.log(this.plugin);
+        test.done();
+    },
+};


### PR DESCRIPTION
- fixes a crasher bug (missing config_options in load_config)
- added test coverage for register() and set up
- don’t register hooks unless certs are present
