### PR TITLE
tests/access: make test a little safer

### DIFF
--- a/tests/plugins/access.js
+++ b/tests/plugins/access.js
@@ -259,9 +259,9 @@ exports.helo_access = {
         this.plugin.init_config();
         this.plugin.init_lists();
         var cb = function (rc) {
-            // console.log(this.connection.results.get('access'));
+            var r = this.connection.results.get('access');
             test.equal(undefined, rc);
-            test.ok(this.connection.results.get('access').pass.length);
+            test.ok(r && r.pass && r.pass.length);
             test.done();
         }.bind(this);
         this.plugin.cfg.check.helo=true;
@@ -273,12 +273,14 @@ exports.helo_access = {
         this.plugin.init_lists();
         var cb = function (rc) {
             test.equal(DENY, rc);
-            // console.log(this.connection.results.get('access'));
-            test.ok(this.connection.results.get('access').fail.length);
+            var r = this.connection.results.get('access');
+            test.ok(r && r.fail && r.fail.length);
             test.done();
         }.bind(this);
         var black = [ '.*spam.com' ];
-        this.plugin.list_re.black.helo = new RegExp('^(' + black.join('|') + ')$', 'i');
+        this.plugin.list_re.black.helo =
+            new RegExp('^(' + black.join('|') + ')$', 'i');
+        this.plugin.cfg.check.helo=true;
         this.plugin.helo_access(cb, this.connection, 'bad.spam.com');
     },
 };


### PR DESCRIPTION
so the test fails nicely, instead of with a:

```
TypeError: Cannot read property 'fail' of undefined
    at Object.<anonymous> (/Users/matt/Documents/git/haraka/tests/plugins/access.js:277:58)
    at Plugin.exports.helo_access (access:261:42)
    at Object.exports.helo_access.blacklisted regex (/Users/matt/Documents/git/haraka/tests/plugins/access.js:282:21)
```
