### PR TITLE
make smtp_forward auth settings match docs/ini

### DIFF
--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -15,30 +15,30 @@ Configuration
 -------------
 
 * smtp\_forward.ini
-  
+
   Configuration is stored in this file in the following keys:
-  
+
   * host=HOST
-    
+
     The host to connect to.
-    
+
   * port=PORT
-    
+
     The port to connect to. Default: 25
- 
+
   * connect\_timeout=SECONDS
 
     The maximum amount of time to wait when creating a new connection
     to the host.  Default: 30 seconds.
 
   * timeout=SECONDS
-    
+
     The amount of seconds to let a backend connection live idle in the
     connection pool.  This should always be less than the global plugin
     timeout, which should in turn be less than the connection timeout.
 
   * max\_connections=NUMBER
-   
+
     Maximum number of connections at any given time. Default: 1000
 
   * enable\_tls=[true]

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -51,29 +51,29 @@ exports.hook_queue = function (next, connection) {
     var smc_cb = function (err, smtp_client) {
         smtp_client.next = next;
 
-        var config = plugin.cfg;
-        if (config.auth.user) {
-            connection.loginfo(plugin, "Configuring authentication for SMTP server " + config.main.host + ":" + config.main.port);
+        if (cfg.auth_user) {
+            connection.loginfo(plugin, 'Configuring authentication for SMTP server ' + cfg.main.host + ':' + cfg.main.port);
             smtp_client.on('greeting', function() {
 
                 var base64 = function(str) {
-                    var buffer = new Buffer(str, "UTF-8");
-                    return buffer.toString("base64");
+                    var buffer = new Buffer(str, 'UTF-8');
+                    return buffer.toString('base64');
                 };
 
-                if (config.auth.type === 'plain') {
-                    connection.loginfo(plugin, "Authenticating with AUTH PLAIN " + config.auth.user);
-                    smtp_client.send_command('AUTH', 'PLAIN ' + base64("\0" + config.auth.user + "\0" + config.auth.pass));
-                } else if (config.auth.type === 'login') {
+                if (cfg.auth_type === 'plain') {
+                    connection.loginfo(plugin, 'Authenticating with AUTH PLAIN ' + cfg.auth_user);
+                    smtp_client.send_command('AUTH', 'PLAIN ' + base64('\0' + cfg.auth_user + '\0' + cfg.auth_pass));
+                }
+                else if (cfg.auth_type === 'login') {
                     smtp_client.send_command('AUTH', 'LOGIN');
                     smtp_client.on('auth', function() {
-                        connection.loginfo(plugin, "Authenticating with AUTH LOGIN " + config.auth.user);
+                        connection.loginfo(plugin, 'Authenticating with AUTH LOGIN ' + cfg.auth_user);
                     });
                     smtp_client.on('auth_username', function() {
-                        smtp_client.send_command(base64(config.auth.user) + "\r\n");
+                        smtp_client.send_command(base64(cfg.auth_user) + '\r\n');
                     });
                     smtp_client.on('auth_password', function() {
-                        smtp_client.send_command(base64(config.auth.pass) + "\r\n");
+                        smtp_client.send_command(base64(cfg.auth_pass) + '\r\n');
                     });
                 }
             });


### PR DESCRIPTION
I didn't notice this soon enough..

In the current plugin docs and ini are these style settings:

```ini
auth_type
auth_user
auth_pass
```

And the changes as contributed use auth.type and auth.user. Since smtp_forward has per-domain routing and having auth settings per-forward is desirable, make the plugin match the docs and sample .ini.

Also, update plugin to use the `cfg` that's already defined with per-domain route information, which post-dates this PR.