### PR TITLE
Improve handling of broken messages

### DIFF
--- a/mailheader.js
+++ b/mailheader.js
@@ -33,7 +33,7 @@ Header.prototype.parse = function (lines) {
     }
 
     for (var i=0,l=this.header_list.length; i < l; i++) {
-        var match = this.header_list[i].match(/^([^:]*):\s*([\s\S]*)$/);
+        var match = this.header_list[i].match(/^([^\s:]*):\s*([\s\S]*)$/);
         if (match) {
             var key = match[1].toLowerCase();
             var val = match[2];


### PR DESCRIPTION
I have an issue on a customer system whereby a Swedish telco (Telia) is sending messages that are broken and are missing a header/body line separator.

This causes the message that comes out of Haraka to be missing it's own Received header if any plugins have called `txn.add_leading_header()` (like spf) beforehand because the code in end_data() to handle broken messages isn't run because `this.header.header_list.length === 0` will always evaluate to false.

This patch improves the handling of this case.

NOTE: This doesn't fix the behaviour of message_stream for broken messages like this, because that seems to be impossible given it's a stream.