### PR TITLE
[DOCKER] Direct stdout/err to console, not file

### DIFF
--- a/haraka.sh
+++ b/haraka.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-exec haraka -c /usr/local/haraka >>/var/log/haraka.log 2>&1
-
+exec haraka -c /usr/local/haraka 2>&1


### PR DESCRIPTION
Came from this conversation: https://github.com/haraka/Haraka/commit/502ce35cc2fc5f6490041943cb6e9369981e48fc#commitcomment-14240118

The service [inside Docker]  isn't currently passing the logs to stdout, but to a file (`exec haraka -c /usr/local/haraka >>/var/log/haraka.log 2>&1`), which is also not a standard practice with Docker. Especially nowadays, since Docker natively supports various ways to log, including syslog, this doesn't seem like the right thing to do.