### PR TITLE
ignore ENODATA DNS lookup err

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-#   - "0.8"     # no longer supported by iconv
 #   - "0.6"     # no longer supported by async
+#   - "0.8"     # no longer supported by iconv
     - "0.10"
     - "0.12"
     - "4.2"


### PR DESCRIPTION
* ignore the 'queryAaaa ENODATA' error.
    * corrects an error pointed out in the comments of #1140 
* better error handling, more DRY by reusing net_utils.get_ips_by_host (#1249)