### PR TITLE
ENODATA fix for helo.checks' parallel A record resolve

### DIFF
--- a/plugins/helo.checks.js
+++ b/plugins/helo.checks.js
@@ -527,7 +527,7 @@ exports.get_a_records = function (host, cb) {
     async.parallel([
         function(callback){
             dns.resolve4(host, function(err, ips_from_fwd) {
-                if (err.code === 'ENODATA') {
+                if (err !== null && err.code === 'ENODATA') {
                     callback(null, ips_from_fwd);
                 } else {
                     callback(err, ips_from_fwd);
@@ -536,7 +536,7 @@ exports.get_a_records = function (host, cb) {
         },
         function(callback){
             dns.resolve6(host, function(err, ips_from_fwd) {
-                if (err.code === 'ENODATA') {
+                if (err !== null && err.code === 'ENODATA') {
                     callback(null, ips_from_fwd);
                 } else {
                     callback(err, ips_from_fwd);

--- a/plugins/helo.checks.js
+++ b/plugins/helo.checks.js
@@ -527,12 +527,20 @@ exports.get_a_records = function (host, cb) {
     async.parallel([
         function(callback){
             dns.resolve4(host, function(err, ips_from_fwd) {
-                callback(err, ips_from_fwd);
+                if (err.code === 'ENODATA') {
+                    callback(null, ips_from_fwd);
+                } else {
+                    callback(err, ips_from_fwd);
+                }
             });
         },
         function(callback){
             dns.resolve6(host, function(err, ips_from_fwd) {
-                callback(err, ips_from_fwd);
+                if (err.code === 'ENODATA') {
+                    callback(null, ips_from_fwd);
+                } else {
+                    callback(err, ips_from_fwd);
+                }
             });
         }
     ],


### PR DESCRIPTION
This might not be the right or best solution, but the problem I described in https://github.com/haraka/Haraka/pull/1140#issuecomment-158628814 might be caused by async's parallel behaviour. If one of the dns.resolve calls returns an error, like ENODATA for ipv6, the main callback will be called with that error, leaving to time for the other dns.resolve call to finish and provide a valid IP address.