### PR TITLE
Update SettingUpOutbound.md

### DIFF
--- a/docs/tutorials/SettingUpOutbound.md
+++ b/docs/tutorials/SettingUpOutbound.md
@@ -42,9 +42,10 @@ Let's create a new Haraka instance:
 
 Now edit config/smtp.ini - change the port to 587.
 
-Next we setup our plugins - all we need is the auth plugin:
+Next we setup our plugins. We need the tls and auth plugin. TLS is required, since auth does not advertise AUTH capability on unencrypted connections from other than localhost:
 
-    echo "auth/flat_file" > config/plugins
+    echo "tls
+    auth/flat_file" > config/plugins
 
 Now edit the flat file password file, and put in an appropriate username
 and password:

--- a/docs/tutorials/SettingUpOutbound.md
+++ b/docs/tutorials/SettingUpOutbound.md
@@ -42,7 +42,7 @@ Let's create a new Haraka instance:
 
 Now edit config/smtp.ini - change the port to 587.
 
-Next we setup our plugins. We need the tls and auth plugin. TLS is required, since auth does not advertise AUTH capability on unencrypted connections from other than localhost:
+Next we setup our plugins. We need the tls and auth plugin. AUTH capability is only advertised after TLS/SSL negotiation (except for connections from the local host):
 
     echo "tls
     auth/flat_file" > config/plugins


### PR DESCRIPTION
auth requires tls for obvious reasons. auth will not advertise AUTH before STARTTLS.
tls has to be run before auth/flat_file in config/plugins, otherwise neither STARTTLS nor AUTH will be working.
I am not a native speaker so someone might edit my suggestion for the TLS-AUTH explanation in this pull request....