### PR TITLE
show array when it has length

### DIFF
--- a/result_store.js
+++ b/result_store.js
@@ -178,10 +178,16 @@ ResultStore.prototype.private_collate = function (result, name) {
     // anything not predefined in the result was purposeful, show it first
     for (var key in result) {
         if (key[0] === '_') continue;  // ignore 'private' keys
-        if (all_opts.indexOf(key) !== -1) continue;
+        if (all_opts.indexOf(key) !== -1) continue;  // these get shown later.
         if (hide.length && hide.indexOf(key) !== -1) continue;
-        if (Array.isArray(result[key]) && result[key].length === 0) continue;
-        if (typeof result[key] === 'object') continue;
+        if (typeof result[key] === 'object') {
+            if (Array.isArray(result[key])) {
+                if (result[key].length === 0) continue;
+            }
+            else {
+                continue;
+            }
+        }
         r.push(key + ': ' + result[key]);
     }
 

--- a/tests/result_store.js
+++ b/tests/result_store.js
@@ -137,3 +137,16 @@ exports.has = {
         test.done();
     },
 };
+
+exports.private_collate = {
+    setUp : _set_up,
+    tearDown : _tear_down,
+    'collate, arrays are shown in output' : function (test) {
+        test.expect(2);
+        this.connection.results.push('test_plugin', { foo: 'bar' });
+        console.log(this.connection.results);
+        test.equal(true, this.connection.results.has('test_plugin', 'foo', /bar/));
+        test.ok(/bar/.test(this.connection.results.get('test_plugin').human));
+        test.done();
+    },
+};


### PR DESCRIPTION
```js
if (typeof result[key] === 'object') continue;
```

Because Array's are a type of object, that line was inadvertently suppressing the display of arrays with content. The line above makes it obvious Arrays with contents are supposed to be shown.