### PR TITLE
outbound: Return DENYSOFT and not DENY on queue error

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -475,7 +475,7 @@ exports.send_trans_email = function (transaction, next) {
             for (var i=0,l=ok_paths.length; i<l; i++) {
                 fs.unlink(ok_paths[i], function () {});
             }
-            if (next) next(constants.deny, err);
+            if (next) next(constants.denysoft, err);
             return;
         }
 


### PR DESCRIPTION
Currently on a queue error e.g. out-of-disk space or queue directory permissions issue causes Haraka to return a DENY which is incorrect - it should be a DENYSOFT so that the messages are recoverable.

Fixes #1263 