### PR TITLE
redis: make plugin match docs, fix bug

### DIFF
--- a/docs/plugins/redis.md
+++ b/docs/plugins/redis.md
@@ -9,7 +9,7 @@ The `redis.ini` file has two sections (defaults shown):
 
 ### [server]
 
-    host=127.0.0.1
+    ; host=127.0.0.1
     ; port=6379
     ; db=0
 

--- a/plugins/redis.js
+++ b/plugins/redis.js
@@ -19,7 +19,10 @@ exports.load_redis_ini = function () {
     });
 
     if (!plugin.cfg.server) plugin.cfg.server = {};
-    if (!plugin.cfg.server.ip) plugin.cfg.server.ip = '127.0.0.1';
+    if (plugin.cfg.server.ip && !plugin.cfg.server.host) {
+        plugin.cfg.server.host = plugin.cfg.server.ip;
+    }
+    if (!plugin.cfg.server.host) plugin.cfg.server.host = '127.0.0.1';
     if (!plugin.cfg.server.port) plugin.cfg.server.port = '6379';
 
     if (!plugin.cfg.redisOpts) plugin.cfg.redisOpts = {};
@@ -42,7 +45,7 @@ exports.init_redis_connection = function (next, server) {
 
     var cfg = plugin.cfg.server;
     var client = redis
-        .createClient(cfg.port, cfg.ip, plugin.cfg.redisOpts)
+        .createClient(cfg.port, cfg.host, plugin.cfg.redisOpts)
         .on('error', function (error) {
             plugin.logerror('Redis error: ' + error.message);
             callNext();
@@ -55,7 +58,7 @@ exports.init_redis_connection = function (next, server) {
                     );
             server.notes.redis = client;
             if (cfg.db) {
-                server.redis.select(cfg.db);
+                server.notes.redis.select(cfg.db);
                 plugin.loginfo('dbid ' + cfg.db + ' selected');
             }
             callNext();

--- a/tests/plugins/redis.js
+++ b/tests/plugins/redis.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var Plugin        = require('../fixtures/stub_plugin');
+var config        = require('../../config');
+
+var _set_up_redis = function (done) {
+
+    this.plugin = new Plugin('redis');
+    this.plugin.config = config;
+    this.plugin.register();
+
+    done();
+};
+
+exports.redis = {
+    setUp : _set_up_redis,
+    'loads' : function (test) {
+        test.expect(1);
+        test.equal(this.plugin.name, 'redis');
+        test.done();
+    },
+    'config defaults' : function (test) {
+        test.expect(2);
+        test.equal(this.plugin.cfg.server.host, '127.0.0.1');
+        test.equal(this.plugin.cfg.server.port, 6379);
+        test.done();
+    },
+    'pings' : function (test) {
+        test.expect(1);
+        var server = { notes: { } };
+        this.plugin.init_redis_connection(function () {
+            test.ok(server.notes.redis);
+            test.done();
+        }.bind(this), server);
+    },
+};
+


### PR DESCRIPTION
* use cfg.host (as shown in docs), with backwards compat
* the path to redis in the select call was invalid