### PR TITLE
Fix error reporting

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -1414,10 +1414,10 @@ Connection.prototype.cmd_data = function(args) {
         return this.respond(503, "MAIL required first");
     }
     if (!this.transaction.rcpt_to.length) {
-        this.errors++;
         if (this.pipelining) {
             return this.respond(554, "No valid recipients");
         }
+        this.errors++;
         return this.respond(503, "RCPT required first");
     }
 


### PR DESCRIPTION
When a host is using the PIPELINING extension it will always send DATA as the last command in the pipeline sequence as it hasn't read our responses to the previous commands yet, so it will always hit the '554 No valid recipients' error, so this should not be counted as an error.