### PR TITLE
rspamd: add timeout error handling

### DIFF
--- a/docs/plugins/rspamd.md
+++ b/docs/plugins/rspamd.md
@@ -95,3 +95,9 @@ rspamd.ini
 
     Used as character for visual spam-level where score is zero.
 
+- timeout (in seconds)
+
+    Default: 29 seconds
+
+    How long to wait for a response from rspamd.
+


### PR DESCRIPTION
* emit a result_store error
* prevents Haraka from deferring all mail if rspamd is unavailable
* (uncovered in testing, when no rspamd was running)

````
[CRIT] [4D950DEC.1] [core] Plugin rspamd timed out on hook data_post - make sure it calls the callback
[INFO] [4D950DEC.1] [core] hook=data_post plugin=rspamd function=hook_data_post params="" retval=DENYSOFT msg="plugin timeout"
[INFO] [4D950DEC.1] [watch] watch deny saw: rspamd deny from data_post
[NOTICE] [4D950DEC.1] [core] message mid="" size=231 rcpts=1/0/0 delay=35.633 code=DENYSOFT msg="plugin timeout"
[ERROR] [4D950DEC.1] [rspamd] query failed: connect ETIMEDOUT 172.16.15.13:11333
````