### PR TITLE
permit redis pub/sub to work when host != localhost

### DIFF
--- a/config/karma.ini
+++ b/config/karma.ini
@@ -3,9 +3,9 @@
 ; Redis: karma's high speed key/value store for concurrency, IP history,
 ;        and AS history
 [redis]
-server_ip   = 127.0.0.1
-server_port = 6379
-dbid        = 0
+; host   = 127.0.0.1
+; port   = 6379
+; db     = 0
 
 ; karma IP history is expired after this many days. This value is refreshed
 ;       at every connection. Frequent senders may never expire.

--- a/docs/Results.md
+++ b/docs/Results.md
@@ -180,7 +180,7 @@ human_html output, prefix the name of the key with an underscore.
 Example:
 
 ```js
-connection.results.add(plugin, { _hidden: "some data' });
+connection.results.add(plugin, { _hidden: 'some data' });
 ```
 
 ## Redis Pub/Sub
@@ -194,30 +194,26 @@ connection UUID.
 This is from the karma plugin, subscribing on the `connect_init` hook.
 
 ```js
-var redis = {
-    patt: 'result-' + connection.uuid + '*',
-    conn: require('redis').createClient(),
-};
-redis.conn.on('psubscribe', function (pattern, count) {
-    connection.loginfo(plugin, 'psubscribed to ' + pattern);
-    next();
-});
-redis.conn.on('pmessage', function (pattern, channel, message) {
-    // do fun stuff with messages that look like this
-    // {"plugin":"karma","result":{"fail":"spamassassin.hits"}}
-    // {"plugin":"connect.geoip","result":{"country":"CN"}}
-}); 
-redis.conn.on('punsubscribe', function (pattern, count) {
-    connection.loginfo(plugin, 'unsubsubscribed from ' + pattern);
-});
-redis.conn.psubscribe(redis.patt);
-connection.redis = redis;
+exports.register = function (next, server) {
+    this.inherits('redis');
+}
+exports.hook_connect_init = function (next, connection) {
+    var plugin = this;
+    plugin.redis_subscribe(connection, function () {
+        connection.notes.redis.on('pmessage', function (pattern, channel, message) {
+            // do fun stuff with messages that look like this
+            // {"plugin":"karma","result":{"fail":"spamassassin.hits"}}
+            // {"plugin":"connect.geoip","result":{"country":"CN"}}
+        });
+        next();
+    });
+}
 ```
 
 It's also wise to unsubscribe. It's easy to do on the `disconnect` hook:
 
 ```js
-if (connection.redis) {
-    connection.redis.conn.punsubscribe(connection.redis.patt);
-}
+    exports.hook_disconnect = function (next, connection) {
+        this.redis_unsubscribe(connection);
+    }
 ```

--- a/docs/plugins/redis.md
+++ b/docs/plugins/redis.md
@@ -5,7 +5,7 @@ connection handle at `server.notes.redis`.
 
 ## Config
 
-The `redis.ini` file has two sections (defaults shown):
+The `redis.ini` file has the following sections (defaults shown):
 
 ### [server]
 
@@ -13,7 +13,14 @@ The `redis.ini` file has two sections (defaults shown):
     ; port=6379
     ; db=0
 
-### [redisOpts]
+### [pubsub]
+
+    ; host=127.0.0.1
+    ; port=6379
+
+Publish & Subscribe are DB agnostic and thus have no db setting. If host and port and not defined, they default to the same as [server] settings.
+
+### [opts]
 
     ; see https://www.npmjs.com/package/redis#overloading
 
@@ -24,7 +31,23 @@ Use redis in your plugin like so:
 
     if (server.notes.redis) {
         server.notes.redis.hgetall(...);
-        server.notes.redis.publish(...);
             // or any other redis command
     }
 
+## Publish/Subscribe Usage
+
+In your plugin:
+
+    exports.results_init = function (next, connection) {
+        var plugin = this;
+        plugin.redis_subscribe(connection, function () {
+            connection.notes.redis.on('pmessage', function (pattern, channel, message) {
+                plugin.do_something_with_message(message, ...);
+            });
+            next();
+        });
+    }
+    // be nice to redis and disconnect
+    exports.hook_disconnect = function (next, connection) {
+        this.redis_unsubscribe(connection);
+    }

--- a/plugins/redis.js
+++ b/plugins/redis.js
@@ -14,18 +14,24 @@ exports.register = function () {
 exports.load_redis_ini = function () {
     var plugin = this;
 
-    plugin.cfg = plugin.config.get('redis.ini', function () {
+    plugin.redisCfg = plugin.config.get('redis.ini', function () {
         plugin.load_redis_ini();
     });
 
-    if (!plugin.cfg.server) plugin.cfg.server = {};
-    if (plugin.cfg.server.ip && !plugin.cfg.server.host) {
-        plugin.cfg.server.host = plugin.cfg.server.ip;
-    }
-    if (!plugin.cfg.server.host) plugin.cfg.server.host = '127.0.0.1';
-    if (!plugin.cfg.server.port) plugin.cfg.server.port = '6379';
+    if (!plugin.redisCfg.server) plugin.redisCfg.server = {};
+    var s = plugin.redisCfg.server;
+    if (s.ip && !s.host) s.host = s.ip;
+    if (!s.host) s.host = '127.0.0.1';
+    if (!s.port) s.port = '6379';
 
-    if (!plugin.cfg.redisOpts) plugin.cfg.redisOpts = {};
+    if (!plugin.redisCfg.pubsub) {
+        plugin.redisCfg.pubsub = JSON.parse(JSON.stringify(s));
+    }
+    var ps = plugin.redisCfg.pubsub;
+    if (!ps.host) ps.host = s.host;
+    if (!ps.port) ps.port = s.port;
+
+    if (!plugin.redisCfg.opts) plugin.redisCfg.opts = {};
 };
 
 exports.init_redis_connection = function (next, server) {
@@ -43,24 +49,71 @@ exports.init_redis_connection = function (next, server) {
         next();
     }
 
-    var cfg = plugin.cfg.server;
-    var client = redis
-        .createClient(cfg.port, cfg.host, plugin.cfg.redisOpts)
+    var opts = plugin.redisCfg.opts;
+    opts.host = plugin.redisCfg.server.host;
+    opts.port = plugin.redisCfg.server.port;
+    server.notes.redis = plugin.get_redis_client(opts, callNext);
+};
+
+exports.get_redis_client = function (opts, next) {
+    var plugin = this;
+    var db = 0;
+    if (opts.db !== undefined) {
+        db = opts.db;
+        delete opts.db;
+    }
+
+    var client = redis.createClient(opts)
         .on('error', function (error) {
             plugin.logerror('Redis error: ' + error.message);
-            callNext();
+            next();
         })
         .on('ready', function () {
-            plugin.loginfo(plugin, 'connected to ' + client.host +
-                    (client.port ? ':' + client.port : '') +
-                    (cfg.db ? '/' + cfg.db : '') +
-                    ' v' + client.server_info.redis_version
-                    );
-            server.notes.redis = client;
-            if (cfg.db) {
-                server.notes.redis.select(cfg.db);
-                plugin.loginfo('dbid ' + cfg.db + ' selected');
+            if (db) client.select(db);
+
+            var msg = 'connected to redis://' + opts.host + ':' + opts.port;
+            if (db) msg += '/' + db;
+            if (client.server_info && client.server_info.redis_version) {
+                msg += ' v' + client.server_info.redis_version;
             }
-            callNext();
+            plugin.loginfo(plugin, msg);
+            next();
         });
+
+    return client;
+};
+
+exports.get_redis_pub_channel = function (conn) {
+    return 'result-' + conn.transaction ? conn.transaction.uuid : conn.uuid;
+};
+
+exports.get_redis_sub_channel = function (conn) {
+    return 'result-' + conn.uuid + '*';
+};
+
+exports.redis_subscribe = function (connection, next) {
+    var plugin = this;
+
+    if (connection.notes.redis) {
+        // another plugin has already called this. Do nothing
+        return next();
+    }
+
+    connection.notes.redis = require('redis').createClient({
+        host: plugin.redisCfg.pubsub.host,
+        port: plugin.redisCfg.pubsub.port,
+    })
+    .on('psubscribe', function (pattern, count) {
+        connection.logdebug(plugin, 'psubscribed to ' + pattern);
+        next();
+    })
+    .on('punsubscribe', function (pattern, count) {
+        connection.logdebug(plugin, 'unsubsubscribed from ' + pattern);
+    });
+    connection.notes.redis.psubscribe(plugin.get_redis_sub_channel(connection));
+};
+
+exports.redis_unsubscribe = function (connection) {
+    if (!connection.notes.redis) return;
+    connection.notes.redis.punsubscribe(this.get_redis_sub_channel(connection));
 };

--- a/tests/plugins/redis.js
+++ b/tests/plugins/redis.js
@@ -21,8 +21,8 @@ exports.redis = {
     },
     'config defaults' : function (test) {
         test.expect(2);
-        test.equal(this.plugin.cfg.server.host, '127.0.0.1');
-        test.equal(this.plugin.cfg.server.port, 6379);
+        test.equal(this.plugin.redisCfg.server.host, '127.0.0.1');
+        test.equal(this.plugin.redisCfg.server.port, 6379);
         test.done();
     },
     'pings' : function (test) {


### PR DESCRIPTION
### it's complicated

Previously, the redis plugin worked well, except when the pub/sub channel was on a host other than 127.0.0.1. PR #1275 sorta fixed the karma plugin so that it could subscribe to a remote redis when the redis plugin (and by extension, result_store) could pub/sub to that remote redis host. It was not an optimal way to fix it though, because it duplicated the redis.ini parsing and connection logic.

With these changes, the redis connection and subscription functions are consolidated into the redis plugin, where they can be called by plugins that subscribe to result_store messages (currently karma & watch). Now the redis plugin has a config section for pubsub and all publishers and subscribers can use the same settings, without each subscriber having to duplicate the pubsub connection logic. That logic was complicated by the fact that subscribers *must* have a different redis client than the publisher.

### the changes

* redis.md: add Publish/Subscribe usage
* redis.js:
    * rename plugin.cfg -> plugin.redisCfg (make it safe to inherit redis.js)
    * refactored get_redis_client() so it can be reused
    * add channel naming logic consistent with result_store publishing (so subscribers don't have to specify)
    * cleaned up connection log messages (see below diff)
        * client.host and client.port aren't always defined
* karma.ini: rename redis config settings to match redis.ini (with backwards compatible shims)
* karma.js:
    * inherit redis
    * remove load_redis_ini()
    * move config defaults into config loading function
    * use inherited redis pub/sub for sub connection
    * use new redis.get_redis_client for getting client
* watch:
    * newer version that uses pub/sub instead of traversing connection object
    * inherits redis.js (so it too can subscribe to a remote redis)

### connection message

```diff
-Dec 23 14:12:00 node haraka[10834]: [INFO] [-] [redis] connected to undefined/3 v3.0.4
-Dec 23 14:59:12 node haraka[50398]: [INFO] [-] [redis] dbid 3 selected
+Dec 23 17:29:15 node haraka[84229]: [INFO] [-] [redis] connected to redis://172.16.15.16:6379 v3.0.4
```