### PR TITLE
Allow pass notes to send_email

### DIFF
--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -283,3 +283,9 @@ see https://tools.ietf.org/html/rfc2821#section-4.5.2), you should pass the
 ```dot_stuffed: true``` option, like so:
     
     outbound.send_email(from, to, contents, outnext, { dot_stuffed: true });
+
+
+In case you need notes in the new transaction that `send_email()` creates, you should pass the
+```notes``` option, like so:
+
+    outbound.send_email(from, to, contents, outnext, { notes: transaction.notes });

--- a/outbound.js
+++ b/outbound.js
@@ -357,12 +357,18 @@ exports.send_email = function () {
     var options = arguments[4];
 
     var dot_stuffed = ((options && options.dot_stuffed) ? options.dot_stuffed : false);
+    var notes = ((options && options.notes) ? options.notes : null);
 
     this.loginfo("Sending email via params");
 
     var transaction = trans.createTransaction();
 
     this.loginfo("Created transaction: " + transaction.uuid);
+
+    //Adding notes passed as parameter
+    if (notes) {
+        transaction.notes = notes;
+    }
 
     // set MAIL FROM address, and parse if it's not an Address object
     if (from instanceof Address) {


### PR DESCRIPTION
When you create a new email using `send_email()` it creates a brand new transaction.
If you need some information in that transaction like notes filled in another hooks you cannot access to them.

This PR allows to pass a new option the `send_email()` to preserve the notes. It just adds another option to the options object that `send_email()` already receives.

Includes updated docs.
Fixes #1293 
