### PR TITLE
Feature/improved exit logging

### DIFF
--- a/haraka.js
+++ b/haraka.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var path = require('path');
+var exit = require('exit');
 
 // this must be set before "server.js" is loaded
 process.env.HARAKA = process.env.HARAKA || path.resolve('.');
@@ -37,14 +38,15 @@ process.on('uncaughtException', function (err) {
         logger.logcrit('Caught exception: ' + JSON.stringify(err));
     }
     logger.dump_logs();
-    process.exit(1);
+    exit(1);
 });
 
 ['SIGTERM', 'SIGINT'].forEach(function (sig) {
     process.on(sig, function () {
         process.title = path.basename(process.argv[1], '.js');
         logger.lognotice(sig + ' received');
-        logger.dump_logs(1);
+        logger.dump_logs();
+        exit(1);
     });
 });
 
@@ -57,6 +59,7 @@ process.on('exit', function() {
     process.title = path.basename(process.argv[1], '.js');
     logger.lognotice('Shutting down');
     logger.dump_logs();
+    exit(0);
 });
 
 logger.log("NOTICE", "Starting up Haraka version " + exports.version);

--- a/logger.js
+++ b/logger.js
@@ -57,7 +57,7 @@ var loglevel = logger.LOGWARN;
 
 var deferred_logs = [];
 
-logger.dump_logs = function (exit) {
+logger.dump_logs = function () {
     while (logger.deferred_logs.length > 0) {
         var log_item = logger.deferred_logs.shift();
         var color = logger.colors[log_item.level];
@@ -67,9 +67,6 @@ logger.dump_logs = function (exit) {
         else {
             console.log(log_item.data);
         }
-    }
-    if (exit) {
-        process.exit(1);
     }
     return true;
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "nopt"                  : "~3.0.4",
     "npid"                  : "~0.4.0",
     "semver"                : "~5.0.3",
-    "sprintf-js"            : "~1.0.3"
+    "sprintf-js"            : "~1.0.3",
+    "exit"                  : "~0.1.2"
   },
   "optionalDependencies": {
     "elasticsearch"         : "*",

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ var cluster     = require('cluster');
 var async       = require('async');
 var daemon      = require('daemon');
 var path        = require('path');
+var exit        = require('exit');
 
 // Need these here so we can run hooks
 logger.add_log_methods(exports, 'server');
@@ -71,7 +72,7 @@ Server.daemonize = function () {
     }
     catch (err) {
         logger.logerror(err.message);
-        process.exit(1);
+        exit(1);
     }
 };
 
@@ -184,7 +185,8 @@ Server.setup_smtp_listeners = function (plugins, type, inactivity_timeout) {
     var runInitHooks = function (err) {
         if (err) {
             logger.logerror("Failed to setup listeners: " + err.message);
-            return process.exit(-1);
+            logger.dump_logs();
+            exit(-1);
         }
         Server.listening();
         plugins.run_hooks('init_' + type, Server);
@@ -292,7 +294,7 @@ Server.init_master_respond = function (retval, msg) {
     if (!(retval === constants.ok || retval === constants.cont)) {
         Server.logerror("init_master returned error" +
                 ((msg) ? ': ' + msg : ''));
-        process.exit(1);
+        exit(1);
     }
 
     var c = Server.cfg.main;
@@ -310,7 +312,7 @@ Server.init_master_respond = function (retval, msg) {
     out.scan_queue_pids(function (err, pids) {
         if (err) {
             Server.logcrit("Scanning queue failed. Shutting down.");
-            process.exit(1);
+            exit(1);
         }
         Server.daemonize();
         // Fork workers
@@ -372,7 +374,7 @@ Server.init_child_respond = function (retval, msg) {
     catch (err) {
         Server.logerror('Terminating child');
     }
-    process.exit(1);
+    exit(1);
 };
 
 Server.listening = function () {


### PR DESCRIPTION
As someone completely new to Haraka, i noticed that the console logging was partially broken on my environment (centos/node 5.4), such that error messages from the logger were being discarded as process.exit would simply dump the buffers. 
Instead of seeing an error for "Failed to setup listeners: listen EACCES" for port 25, i was left with debug info about connect hooks.

Hopefully this change will make the first time experience for people trying Haraka out a little easier.

Similarly if anything is out of line here please let me know as this is the first PR i've made for Haraka.

This PR changes a few small things:
- Cut over the existing process.exit calls to use exit() from the exit module, which addresses the buffering issue with the logger
- Remove the exit parameter from logger.dump_logs - i found it a bit strange that a logging module would be responsible for process termination