### PR TITLE
logger: ignore empty/null/false arguments

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -171,10 +171,11 @@ logger.log_if_level = function (level, key, plugin) {
         var pluginstr = '[' + (plugin || 'core') + ']';
         for (var i=0; i < arguments.length; i++) {
             var data = arguments[i];
-            if (typeof(data) !== 'object') {
+            if (typeof data !== 'object') {
                 str += data;
                 continue;
             }
+            if (!data) continue;
 
             // if the object is a connection, add the connection id
             if (data instanceof connection.Connection) {
@@ -187,7 +188,7 @@ logger.log_if_level = function (level, key, plugin) {
             else if (data instanceof plugins.Plugin) {
                 pluginstr = '[' + data.name + ']';
             }
-            else if (typeof data === 'object' && data.name) {
+            else if (data.name) {
                 pluginstr = '[' + data.name + ']';
             }
             else if (data instanceof outbound.HMailItem) {

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -127,7 +127,7 @@ exports.log_if_level = {
     tearDown : _tear_down,
     'log_if_level is a function' : function (test) {
         test.expect(1);
-        test.ok('function' === typeof(this.logger.log_if_level));
+        test.ok('function' === typeof this.logger.log_if_level);
         test.done();
     },
     'log_if_level test log entry' : function (test) {
@@ -135,11 +135,35 @@ exports.log_if_level = {
         this.logger.loglevel = 9;
         var f = this.logger.log_if_level('INFO', 'LOGINFO');
         test.ok(f);
-        test.ok('function' === typeof(f));
-        test.ok(f("test info message"));
+        test.ok('function' === typeof f);
+        test.ok(f('test info message'));
         test.equal(1, this.logger.deferred_logs.length);
         // console.log(this.logger.deferred_logs[0]);
         test.equal('INFO', this.logger.deferred_logs[0].level);
+        test.done();
+    },
+    'log_if_level null case' : function (test) {
+        test.expect(2);
+        this.logger.loglevel = 9;
+        var f = this.logger.log_if_level('INFO', 'LOGINFO');
+        test.ok(f(null));
+        test.equal(2, this.logger.deferred_logs.length);
+        test.done();
+    },
+    'log_if_level false' : function (test) {
+        test.expect(2);
+        this.logger.loglevel = 9;
+        var f = this.logger.log_if_level('INFO', 'LOGINFO');
+        test.ok(f(false));
+        test.equal(3, this.logger.deferred_logs.length);
+        test.done();
+    },
+    'log_if_level 0' : function (test) {
+        test.expect(2);
+        this.logger.loglevel = 9;
+        var f = this.logger.log_if_level('INFO', 'LOGINFO');
+        test.ok(f(0));
+        test.equal(4, this.logger.deferred_logs.length);
         test.done();
     },
 };


### PR DESCRIPTION
* skip processing if typeof data !== object && !data
    * handles `null` case
    * guards against future false-like values that happen to be an object
* remove redundant typeof check

fixes #1298