### PR TITLE
rcpt_to.routes: updated to work with redis plugin

### DIFF
--- a/docs/plugins/rcpt_to.routes.md
+++ b/docs/plugins/rcpt_to.routes.md
@@ -47,8 +47,8 @@ The following options can be specified in `config/rcpt_to.routes.ini`:
 The [redis] section has three optional settings (defaults shown):
 
     [redis]
-    server_ip=127.0.0.1
-    server_port=6379
+    host=127.0.0.1
+    port=6379
     db=0
 
 ### Routes

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ldapjs"                : "~0.7.1",
     "maxmind"               : "*",
     "modern-syslog"         : "~1.1.1",
-    "redis"                 : "~2.1.0",
+    "redis"                 : "~2.4.2",
     "tmp"                   : "~0.0.28",
     "vs-stun"               : "~0.0.7"
   },

--- a/plugins/karma.js
+++ b/plugins/karma.js
@@ -26,8 +26,8 @@ exports.register = function () {
     plugin.load_karma_ini();
     plugin.load_redis_ini();
 
-    plugin.register_hook('init_master',  'init_redis_karma');
-    plugin.register_hook('init_child',   'init_redis_karma');
+    plugin.register_hook('init_master',  'init_redis_plugin');
+    plugin.register_hook('init_child',   'init_redis_plugin');
 
     plugin.register_hook('connect_init', 'results_init');
     plugin.register_hook('connect_init', 'history_from_redis');
@@ -915,30 +915,6 @@ exports.check_asn = function (connection, asnkey) {
 };
 
 // Redis DB functions
-exports.init_redis_karma = function (next, server) {
-    var plugin = this;
-
-    // use existing redis connection only when using default DB id
-    if (!plugin.cfg.redis.dbid) {
-        if (server.notes.redis) {
-            server.loginfo(plugin, 'using server.notes.redis');
-            plugin.db = server.notes.redis;
-        }
-        if (plugin.db && plugin.db.ping()) {  // connection is good
-            return next();
-        }
-    }
-
-    var calledNext=false;
-    function callNext () {
-        if (calledNext) return;
-        calledNext = true;
-        next();
-    }
-
-    plugin.db = plugin.get_redis_client(plugin.cfg.redis, callNext);
-};
-
 exports.init_ip = function (dbkey, rip, expire) {
     var plugin = this;
     plugin.db.multi()


### PR DESCRIPTION
* inherits from plugins/redis
* rcpt_routes: removes redundant redis functions
* moves karma.init_redis_karma() -> redis.init_redis_plugin()
* moves rcpt_to.routes.redis_ping -> redis.redis_ping()
* when testing, fails fast if redis server not available (fixes #1290)
* passes tests when redis present.

fixes #1290 