### PR TITLE
Pause connection for hook_reset_transaction.  Fixes #1235

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -572,6 +572,8 @@ Connection.prototype.tran_uuid = function () {
 
 Connection.prototype.reset_transaction = function(cb) {
     if (this.transaction && this.transaction.resetting === false) {
+        // Pause connection to allow the hook to complete
+        this.pause();
         this.transaction.resetting = true;
         plugins.run_hooks('reset_transaction', this, cb);
     }
@@ -587,6 +589,8 @@ Connection.prototype.reset_transaction_respond = function (retval, msg, cb) {
         this.transaction = null;
     }
     if (cb) cb();
+    // Allow the connection to continue
+    this.resume();
 };
 
 Connection.prototype.init_transaction = function(cb) {


### PR DESCRIPTION
hook_reset_transaction is a special case as it's the only hook that isn't tied to a command and therefore the client can pipeline other commands causing other hooks to run at the same time or for the transaction to disappear whilst the hook is running.

To prevent that - we pause the socket and our line read loop until the hook completes.