### PR TITLE
add queue_outbound config option

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,11 @@
 
 2.N.N - Feb NN, 2016
 
-2.7.3 - Jan 16, 2016
+2.7.3 - Jan 22, 2016
+
+* Changes
+    * smtp_proxy & qmail-queue: default to enabled for outbound deliveries
+      (previously used Outbound), to better matches user expectations.
 
 * New Features
     * outbound: allow passing notes to send_email (#1295)

--- a/UPGRADE
+++ b/UPGRADE
@@ -1,9 +1,0 @@
-
-2013.12.27
-
-new plugin: data.headers
-   
-   deprecates data.rfc5322_header_checks.js
-   deprecates data.noreceived.js
-   deprecates data.nomsgid.js
-

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,15 @@
+
+# 2016.01.21
+
+* smtp\_proxy & qmail-queue: default to enabled for outbound deliveries
+  (previously used Outbound), to better matches user expectations. To get
+  previous behavior, add a config file with `enable_outbound=false`. 
+
+
+# 2013.12.27
+
+* new plugin: data.headers
+    * deprecates data.rfc5322_header_checks.js
+    * deprecates data.noreceived.js
+    * deprecates data.nomsgid.js
+

--- a/docs/plugins/queue/qmail-queue.md
+++ b/docs/plugins/queue/qmail-queue.md
@@ -10,3 +10,10 @@ Configuration
 * qmail-queue.path
 
   The path to the `qmail-queue` binary. Default: `/var/qmail/bin/qmail-queue`
+
+* qmail-queue.ini
+
+    * enable_outbound=true
+
+      Deliver outbound email to qmail. Set to false to use Haraka's
+      separate Outbound mail routing (MX based delivery)).

--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -18,6 +18,11 @@ Configuration
 
   Configuration is stored in this file in the following keys:
 
+  * enable\_outbound=[true]
+
+    SMTP forward outbound messages (set to false to enable Haraka's separate
+    Outbound mail routing (MX based delivery)).
+
   * host=HOST
 
     The host to connect to.

--- a/docs/plugins/queue/smtp_proxy.md
+++ b/docs/plugins/queue/smtp_proxy.md
@@ -18,7 +18,12 @@ Configuration
 * smtp\_proxy.ini
   
   Configuration is stored in this file in the following keys:
-  
+
+    * enable\_outbound=[true]
+
+    SMTP proxy outbound messages (set to false to enable Haraka's
+    separate Outbound mail routing (MX based delivery)).
+
   * host=HOST
     
     The host to connect to.

--- a/plugins/queue/qmail-queue.js
+++ b/plugins/queue/qmail-queue.js
@@ -4,10 +4,31 @@ var childproc = require('child_process');
 var existsSync = require('./utils').existsSync;
 
 exports.register = function () {
-    this.queue_exec = this.config.get('qmail-queue.path') || '/var/qmail/bin/qmail-queue';
-    if (!existsSync(this.queue_exec)) {
-        throw new Error("Cannot find qmail-queue binary (" + this.queue_exec + ")");
+    var plugin = this;
+
+    plugin.queue_exec = plugin.config.get('qmail-queue.path') || '/var/qmail/bin/qmail-queue';
+    if (!existsSync(plugin.queue_exec)) {
+        throw new Error("Cannot find qmail-queue binary (" + plugin.queue_exec + ")");
     }
+
+    plugin.load_qmail_queue_ini();
+
+    if (plugin.cfg.main.enable_outbound) {
+        plugin.register_hook('queue_outbound', 'hook_queue');
+    }
+};
+
+exports.load_qmail_queue_ini = function () {
+    var plugin = this;
+
+    plugin.cfg = plugin.config.get('qmail-queue.ini', {
+        booleans: [
+            '+main.enable_outbound',
+        ],
+    },
+    function () {
+        plugin.load_qmail_queue_ini();
+    });
 };
 
 exports.hook_queue = function (next, connection) {

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -8,15 +8,26 @@ var smtp_client_mod = require('./smtp_client');
 
 exports.register = function () {
     var plugin = this;
-    var load_config = function () {
-        plugin.cfg = plugin.config.get('smtp_forward.ini', {
-            booleans: [
-                '-main.enable_tls',
-            ],
-        },
-        load_config);
-    };
-    load_config();
+
+    plugin.load_smtp_forward_ini();
+
+    if (plugin.cfg.main.enable_outbound) {
+        plugin.register_hook('queue_outbound', 'hook_queue');
+    }
+};
+
+exports.load_smtp_forward_ini = function () {
+    var plugin = this;
+
+    plugin.cfg = plugin.config.get('smtp_forward.ini', {
+        booleans: [
+            '-main.enable_tls',
+            '+main.enable_outbound',
+        ],
+    },
+    function () {
+        plugin.load_smtp_forward_ini();
+    });
 };
 
 exports.get_config = function (connection) {
@@ -143,4 +154,3 @@ exports.hook_queue = function (next, connection) {
     smtp_client_mod.get_client_plugin(plugin, connection, cfg, smc_cb);
 };
 
-exports.hook_queue_outbound = exports.hook_queue;

--- a/plugins/queue/smtp_proxy.js
+++ b/plugins/queue/smtp_proxy.js
@@ -8,15 +8,26 @@ var smtp_client_mod = require('./smtp_client');
 
 exports.register = function () {
     var plugin = this;
-    var load_config = function () {
-        plugin.cfg = plugin.config.get('smtp_proxy.ini', {
-            booleans: [
-                '-main.enable_tls',
-            ],
-        },
-        load_config);
-    };
-    load_config();
+
+    plugin.load_smtp_proxy_ini();
+
+    if (plugin.cfg.main.enable_outbound) {
+        plugin.register_hook('queue_outbound', 'hook_queue');
+    }
+};
+
+exports.load_smtp_proxy_ini = function () {
+    var plugin = this;
+
+    plugin.cfg = plugin.config.get('smtp_proxy.ini', {
+        booleans: [
+            '-main.enable_tls',
+            '+main.enable_outbound',
+        ],
+    },
+    function () {
+        plugin.load_smtp_proxy_ini();
+    });
 };
 
 exports.hook_mail = function (next, connection, params) {


### PR DESCRIPTION
This is my answer to #1307, reflecting the way I think it ought to be.

Since this would change the default behavior of the smtp_proxy plugin, it may not be proper to make the code do this right away, and until a future version bump, perhaps smtp_proxy.enable_outbound should still default default to false?