### PR TITLE
Now passing options parameter to MessageStream get_data

### DIFF
--- a/messagestream.js
+++ b/messagestream.js
@@ -403,11 +403,10 @@ MessageStream.prototype.destroy = function () {
     }
 };
 
-MessageStream.prototype.get_data = function (cb) { // Or: (options, cb)
-    var options = {};
-    if (arguments.length === 2) {
-        cb = arguments[1];
-        options = arguments[0];
+MessageStream.prototype.get_data = function (options, cb) { // Or: (cb)
+    if (arguments.length === 1) {
+        cb = arguments[0];
+        options = {};
     }
     var ws = new GetDataStream(cb);
     this.pipe(ws, options);


### PR DESCRIPTION
There is a bug in `get-data` of `messagestram`.

Currently if you pass the options parameter they are ignored. 

You can confirm it here, and test the pruposed fix https://repl.it/BgLr/0

So this PR fixes it. Tested for passing just the callback and the options and callback.
