### PR TITLE
Add missing dash to 'Final-Recipient' header name

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -1623,7 +1623,7 @@ HMailItem.prototype.populate_bounce_message_with_headers = function(from, to, re
     }
     self.todo.rcpt_to.forEach(function (rcpt_to) {
         bounce_body.push(CRLF);
-        bounce_body.push('Final recipient: rfc822;' + rcpt_to.address() + CRLF);
+        bounce_body.push('Final-Recipient: rfc822;' + rcpt_to.address() + CRLF);
         var dsn_action = null;
         if (rcpt_to.dsn_action) {
             dsn_action = rcpt_to.dsn_action;

--- a/tests/outbound_protocol/outbound_bounce_rfc3464.js
+++ b/tests/outbound_protocol/outbound_bounce_rfc3464.js
@@ -34,7 +34,7 @@ async.series(
                 exports.send_email = function (from, to, contents, cb, opts) {
                     test.ok(true, 'outbound.send_email called');
                     test.ok(contents.match(/^Content-type: message\/delivery-status/m), 'its a bounce report');
-                    test.ok(contents.match(/^Final recipient: rfc822;recipient@domain/m), 'bounce report contains final recipient');
+                    test.ok(contents.match(/^Final-Recipient: rfc822;recipient@domain/m), 'bounce report contains final recipient');
                     test.ok(contents.match(/^Action: failed/m), 'DATA-5XX: bounce report contains action field');
                     test.ok(contents.match(/^Status: 5\.0\.0/m), 'bounce report contains status field with our ext. smtp code');
                     test.ok(contents.match(/Absolutely not acceptable\. Basic Test Only\./), 'original upstream message available');
@@ -186,7 +186,7 @@ async.series(
                 exports.send_email = function (from, to, contents, cb, opts) {
                     test.ok(true, 'RCPT-TO-5XX: outbound.send_email called');
                     test.ok(contents.match(/^Content-type: message\/delivery-status/m), 'RCPT-TO-5XX: its a bounce report');
-                    test.ok(contents.match(/^Final recipient: rfc822;recipient@domain/m), 'RCPT-TO-5XX:  bounce report contains final recipient');
+                    test.ok(contents.match(/^Final-Recipient: rfc822;recipient@domain/m), 'RCPT-TO-5XX:  bounce report contains final recipient');
                     test.ok(contents.match(/^Action: failed/m), 'DATA-5XX: bounce report contains action field');
                     test.ok(contents.match(/^Status: 5\.1\.1/m), 'RCPT-TO-5XX: bounce report contains status field with our ext. smtp code');
                     test.ok(contents.match(/Not available and will not come back/), 'RCPT-TO-5XX: original upstream message available');
@@ -225,7 +225,7 @@ async.series(
                 exports.send_email = function (from, to, contents, cb, opts) {
                     test.ok(true, 'DATA-5XX: outbound.send_email called');
                     test.ok(contents.match(/^Content-type: message\/delivery-status/m), 'DATA-5XX: its a bounce report');
-                    test.ok(contents.match(/^Final recipient: rfc822;recipient@domain/m), 'DATA-5XX:  bounce report contains final recipient');
+                    test.ok(contents.match(/^Final-Recipient: rfc822;recipient@domain/m), 'DATA-5XX:  bounce report contains final recipient');
                     test.ok(contents.match(/^Action: failed/m), 'DATA-5XX: bounce report contains action field');
                     test.ok(contents.match(/^Status: 5\.6\.0/m), 'DATA-5XX: bounce report contains status field with our ext. smtp code');
                     test.ok(contents.match(/I never did and will like ascii art cats/), 'DATA-5XX: original upstream message available');


### PR DESCRIPTION
This fixes the "Final-Recipient" header in bounce messages sent by Haraka's outbound module by adding the missing dash ('-').   The standard specifies the header name with the dash (e.g., https://tools.ietf.org/html/rfc3798).  

(The missing dash was causing automated bounce message handling code to fail to properly handle bounces produced by Haraka's outbound module.)
