### PR TITLE
spf: honour configuration for mfrom scope

### DIFF
--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -170,7 +170,7 @@ exports.hook_mail = function (next, connection, params) {
             domain: host,
             emit: true,
         });
-        return plugin.return_results(next, connection, spf, 'mail', result,
+        return plugin.return_results(next, connection, spf, 'mfrom', result,
             '<'+mfrom+'>');
     };
 


### PR DESCRIPTION
return_results was incorrectly being passed the scope 'mail' instead of 'mfrom', so the configuration checks all returned undefined.