### PR TITLE
Call next only after message_stream ended

### DIFF
--- a/plugins/dkim_verify.js
+++ b/plugins/dkim_verify.js
@@ -19,7 +19,7 @@ exports.hook_data_post = function(next, connection) {
         if (err) {
             connection.logerror(self, 'error=' + err);
         }
-        if (!results) return next();
+        if (!results) return;
         results.forEach(function (res) {
             connection.auth_results(
               'dkim=' + res.result +
@@ -49,7 +49,7 @@ exports.hook_data_post = function(next, connection) {
         connection.logdebug(self, JSON.stringify(results));
         // Store results for other plugins
         txn.notes.dkim_results = results;
-        return next();
     }, ((plugin.timeout) ? plugin.timeout - 1 : 0));
+    txn.message_stream.once('end', next);
     txn.message_stream.pipe(verifier, { line_endings: '\r\n' });
 };


### PR DESCRIPTION
Fixes #1163.  Patch from @baudehlo.

With the way the plugin was written before, it was possible that a later plugin would also call connection.transaction.message_stream.pipe() before dkim_verify's pipe had ended, leading to an error.  This moves the next() call out of the DKIM callback and into the end handler on the stream to ensure that'll never happen.

I've been running this patch for a while and it does seem to fix the crash, but I haven't had time to dig in and verify it's behaving correctly everywhere.