### PR TITLE
Haraka now takes a list of backend hosts to forward to

### DIFF
--- a/host_pool.js
+++ b/host_pool.js
@@ -1,0 +1,174 @@
+"use strict";
+
+var net = require('net');
+
+/* HostPool:
+ *
+ * Starts with a pool of backend hosts from a "forwarding_host_pool"
+ * configuration that looks like this:
+ *
+ *      1.1.1.1:11, 2.2.2.2:22, 3.3.3.3:33
+ *
+ * It randomizes the list and then gives then out sequentially (for
+ * predictability).
+ *
+ * If failed() is called with one of the hosts, we mark it down for retry_secs
+ * and don't give it out again until that period has passed.
+ *
+ * If *all* the hosts have been marked down, we ignore the marks and just give
+ * out the next host. That's too keep some random short-lived but widespread
+ * network failure from taking the whole system down.
+ */
+
+var logger = require('./logger');
+var utils  = require('./utils');
+
+// takes a comma/space-separated list if ip:ports
+//  1.1.1.1:22,  3.3.3.3:44
+function HostPool(hostports_str, retry_secs){
+    var self = this;
+
+    var hosts = (hostports_str || '')
+            .trim()
+            .split(/[\s,]+/)
+            .map(function(hostport){
+                var splithost = hostport.split(/:/);
+                return { host: splithost[0],
+                          port: splithost[1]
+                        };
+            });
+    self.hostports_str = hostports_str;
+    self.hosts = utils.shuffle(hosts);
+    self.dead_hosts = {};  // hostport => true/false
+    self.last_i = 0;  // the last one we checked
+    self.retry_secs = retry_secs || 10;
+}
+
+
+/* failed
+ *
+ * Part of the external API for this module. Call it when you see a failure to
+ * this backend host and it'll come out of the pool and put into the recheck
+ * timer.
+ */
+HostPool.prototype.failed = function (host, port) {
+    var self = this;
+    var key = host + ':' + port;
+    var retry_msecs = self.retry_secs * 1000;
+    self.dead_hosts[key] = true;
+
+    var cb_if_still_dead = function(){
+        logger.logwarn("host " + key + " is still dead, will retry in " +
+                        self.retry_secs + " secs");
+        self.dead_hosts[key] = true;
+        setTimeout(function() {
+            self.probe_dead_host(host, port, cb_if_still_dead, cb_if_alive);
+        }, retry_msecs);
+    };
+
+    var cb_if_alive = function (){
+        logger.loginfo("host " + key + " is back! adding back into pool");
+        self.dead_hosts[key] = false;
+    };
+
+    setTimeout(function() {
+        self.probe_dead_host(host, port, cb_if_still_dead, cb_if_alive);
+    }, retry_msecs);
+};
+
+/* probe_dead_host
+ *
+ * When the timer fires, we'll ping the host, and if it's still dead we'll
+ * update the dead_hosts list.  If it's back online, we just don't touch the
+ * dead_hosts lists, and the next time get_host() is called, it'll be in the
+ * mix.
+ */
+HostPool.prototype.probe_dead_host = function(
+            host, port, cb_if_still_dead, cb_if_alive
+        ){
+
+    var self = this;
+    logger.loginfo("probing dead host " + host + ":" + port);
+
+    var connect_timeout_ms = 200; // keep it snappy
+    var s;
+    try {
+        s = self.get_socket();
+        s.setTimeout(connect_timeout_ms, function() {
+            // nobody home, it's still dead
+            s.destroy();
+            cb_if_still_dead();
+        });
+        s.on('error', function(e) {
+            // silently catch all errors - assume the port is closed
+            s.destroy();
+            cb_if_still_dead();
+        });
+
+        s.connect(port, host, function() {
+            cb_if_alive();
+            s.destroy(); // will this conflict with setTimeout's s.destroy?
+        });
+    } catch (e){
+        // only way to catch run-time javascript errors in here;
+        console.log("ERROR in probe_dead_host, got error " + e);
+        throw e;
+    }
+};
+
+/* get_socket
+ *
+ * so we can override in unit test
+ */
+HostPool.prototype.get_socket = function() {
+    var s = new net.Socket();
+    return s;
+};
+
+
+/* get_host
+ *
+ * This approach borrowed from the danga mogilefs client code
+ *
+ * If all the hosts look dead, it returns the next one it would have tried
+ * anyway. That should make it more forgiving about transient but widespread
+ * network problems that make all the hosts look dead.
+ */
+HostPool.prototype.get_host = function (){
+    var host;
+    var found;
+
+    var first_i = this.last_i + 1;
+    if (first_i >= this.hosts.length){
+        first_i = 0;
+    }
+
+    for (var i = 0; i < this.hosts.length; ++i){
+        var j = i + first_i;
+        if (j >= this.hosts.length){
+            j = j - this.hosts.length;
+        }
+        host = this.hosts[j];
+        var key = host.host + ':' + host.port;
+        if (this.dead_hosts[key]){
+            continue;
+        }
+        this.last_i = j;
+        found = true;
+        break;
+    }
+    if (found){
+        return host;
+    }
+    else {
+        logger.logwarn(
+                "no working hosts found, retrying a dead one, config " +
+                "(probably from smtp_forward.forwarding_host_pool) is " +
+                "'" + this.hostports_str + "'"
+            );
+        this.last_i = first_i;
+        return this.hosts[ first_i ];
+    }
+};
+
+module.exports = HostPool;

--- a/host_pool.js
+++ b/host_pool.js
@@ -23,7 +23,7 @@ var net = require('net');
 var logger = require('./logger');
 var utils  = require('./utils');
 
-// takes a comma/space-separated list if ip:ports
+// takes a comma/space-separated list of ip:ports
 //  1.1.1.1:22,  3.3.3.3:44
 function HostPool(hostports_str, retry_secs){
     var self = this;

--- a/host_pool.js
+++ b/host_pool.js
@@ -5,7 +5,7 @@ var net = require('net');
 /* HostPool:
  *
  * Starts with a pool of backend hosts from a "forwarding_host_pool"
- * configuration that looks like this:
+ * configuration that looks like this (port defaults to 25 if not set):
  *
  *      1.1.1.1:11, 2.2.2.2:22, 3.3.3.3:33
  *
@@ -33,8 +33,11 @@ function HostPool(hostports_str, retry_secs){
             .split(/[\s,]+/)
             .map(function(hostport){
                 var splithost = hostport.split(/:/);
+                if (! splithost[1]){
+                    splithost[1] = 25;
+                }
                 return { host: splithost[0],
-                          port: splithost[1]
+                         port: splithost[1]
                         };
             });
     self.hostports_str = hostports_str;

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -57,7 +57,9 @@ exports.hook_queue = function (next, connection) {
     var cfg = plugin.get_config(connection);
     var txn = connection.transaction;
 
-    connection.loginfo(plugin, 'forwarding to ' + cfg.host + ':' + cfg.port);
+    connection.loginfo(plugin, 'forwarding to ' +
+            (cfg.forwarding_host_pool ? "configured forwarding_host_pool" : cfg.host + ':' + cfg.port)
+        );
 
     var smc_cb = function (err, smtp_client) {
         smtp_client.next = next;

--- a/plugins/queue/smtp_proxy.js
+++ b/plugins/queue/smtp_proxy.js
@@ -33,7 +33,9 @@ exports.load_smtp_proxy_ini = function () {
 exports.hook_mail = function (next, connection, params) {
     var plugin = this;
     var c = plugin.cfg.main;
-    connection.loginfo(this, "proxying to " + c.host + ":" + c.port);
+    connection.loginfo(plugin, 'forwarding to ' +
+            (c.forwarding_host_pool ? "configured forwarding_host_pool" : c.host + ':' + c.port)
+        );
     smtp_client_mod.get_client_plugin(plugin, connection, c, function (err, smtp_client) {
         connection.notes.smtp_client = smtp_client;
         smtp_client.next = next;

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -496,9 +496,9 @@ exports.get_client_plugin = function (plugin, connection, c, callback) {
     });
 };
 
-function get_hostport (connection, server_notes, config) {
+function get_hostport (connection, server_notes, config_arg) {
 
-    var c = config;
+    var c = config_arg;
     if (c.forwarding_host_pool){
         if (! server_notes.host_pool){
             connection.logwarn("creating a new host_pool from " + c.forwarding_host_pool);

--- a/tests/configfile.js
+++ b/tests/configfile.js
@@ -153,6 +153,45 @@ exports.load_ini_config = {
     },
 };
 
+exports.get_filetype_reader  = {
+    setUp: _set_up,
+    'binary': function (test) {
+        test.expect(2);
+        var reader = this.cfreader.get_filetype_reader('binary');
+        test.equal(typeof reader.load, 'function');
+        test.equal(typeof reader.empty, 'function');
+        test.done();
+    },
+    'flat': function (test) {
+        test.expect(2);
+        var reader = this.cfreader.get_filetype_reader('flat');
+        test.equal(typeof reader.load, 'function');
+        test.equal(typeof reader.empty, 'function');
+        test.done();
+    },
+    'json': function (test) {
+        test.expect(2);
+        var reader = this.cfreader.get_filetype_reader('json');
+        test.equal(typeof reader.load, 'function');
+        test.equal(typeof reader.empty, 'function');
+        test.done();
+    },
+    'ini': function (test) {
+        test.expect(2);
+        var reader = this.cfreader.get_filetype_reader('ini');
+        test.equal(typeof reader.load, 'function');
+        test.equal(typeof reader.empty, 'function');
+        test.done();
+    },
+    'yaml': function (test) {
+        test.expect(2);
+        var r = this.cfreader.load_ini_config('tests/config/test.ini');
+        test.deepEqual(['first_host', 'second_host', 'third_host'], r.array_test.hostlist);
+        test.deepEqual([123, 456, 789], r.array_test.intlist);
+        test.done();
+    },
+};
+
 exports.non_existing = {
     setUp: _set_up,
 

--- a/tests/configfile.js
+++ b/tests/configfile.js
@@ -153,44 +153,6 @@ exports.load_ini_config = {
     },
 };
 
-exports.get_filetype_reader  = {
-    setUp: _set_up,
-    'binary': function (test) {
-        test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('binary');
-        test.equal(typeof reader.load, 'function');
-        test.equal(typeof reader.empty, 'function');
-        test.done();
-    },
-    'flat': function (test) {
-        test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('flat');
-        test.equal(typeof reader.load, 'function');
-        test.equal(typeof reader.empty, 'function');
-        test.done();
-    },
-    'json': function (test) {
-        test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('json');
-        test.equal(typeof reader.load, 'function');
-        test.equal(typeof reader.empty, 'function');
-        test.done();
-    },
-    'ini': function (test) {
-        test.expect(2);
-        var reader = this.cfreader.get_filetype_reader('ini');
-        test.equal(typeof reader.load, 'function');
-        test.equal(typeof reader.empty, 'function');
-        test.done();
-    },
-    'yaml': function (test) {
-        test.expect(2);
-        var r = this.cfreader.load_ini_config('tests/config/test.ini');
-        test.deepEqual(['first_host', 'second_host', 'third_host'], r.array_test.hostlist);
-        test.deepEqual([123, 456, 789], r.array_test.intlist);
-        test.done();
-    },
-};
 
 exports.non_existing = {
     setUp: _set_up,

--- a/tests/host_pool.js
+++ b/tests/host_pool.js
@@ -1,0 +1,161 @@
+"use strict";
+
+var HostPool = require('../host_pool');
+
+exports.HostPool = {
+    "get a host": function (test) {
+        test.expect(2);
+
+        var pool = new HostPool('1.1.1.1:1111, 2.2.2.2:2222');
+
+        var host = pool.get_host();
+
+        test.ok( /\d\.\d\.\d\.\d/.test(host.host),
+                "'" + host.host + "' looks like a IP");
+        test.ok( /\d\d\d\d/.test(host.port),
+                "'" + host.port + "' looks like a port");
+
+        test.done();
+    },
+    "uses all the list": function (test) {
+        test.expect(3);
+
+        var pool = new HostPool('1.1.1.1:1111, 2.2.2.2:2222');
+
+        var host1 = pool.get_host();
+        var host2 = pool.get_host();
+        var host3 = pool.get_host();
+
+        test.notEqual(host1.host, host2.host);
+        test.notEqual(host3.host, host2.host);
+        test.equal(host3.host, host1.host);
+
+        test.done();
+    },
+
+    "dead host": function(test){
+        test.expect(3);
+
+        var pool = new HostPool('1.1.1.1:1111, 2.2.2.2:2222');
+
+        pool.failed('1.1.1.1', '1111');
+
+        var host;
+
+        host = pool.get_host();
+        test.equal(host.host, '2.2.2.2', 'dead host is not returned');
+        host = pool.get_host();
+        test.equal(host.host, '2.2.2.2', 'dead host is not returned');
+        host = pool.get_host();
+        test.equal(host.host, '2.2.2.2', 'dead host is not returned');
+
+        test.done();
+    },
+
+    // if they're *all* dead, we return a host to try anyway, to keep from
+    // accidentally DOS'ing ourselves if there's a transient but widespread
+    // network outage
+    "they're all dead": function(test){
+        test.expect(6);
+
+        var host1;
+        var host2;
+
+        var pool = new HostPool('1.1.1.1:1111, 2.2.2.2:2222');
+
+        host1 = pool.get_host();
+
+        pool.failed('1.1.1.1', '1111');
+        pool.failed('2.2.2.2', '2222');
+
+        host2 = pool.get_host();
+        test.ok (host2, "if they're all dead, try one anyway");
+        test.notEqual(host1.host, host2.host, "rotation continues");
+
+        host1 = pool.get_host();
+        test.ok (host1, "if they're all dead, try one anyway");
+        test.notEqual(host1.host, host2.host, "rotation continues");
+
+        host2 = pool.get_host();
+        test.ok (host2, "if they're all dead, try one anyway");
+        test.notEqual(host1.host, host2.host, "rotation continues");
+
+        test.done();
+    },
+
+
+    // after .01 secs the timer to retry the dead host will fire, and then
+    // we connect using this mock socket, whose "connect" always succeeds
+    // so the code brings the dead host back to life
+    "host dead checking timer": function (test){
+        test.expect(2);
+
+        var num_reqs = 0;
+        var MockSocket = function MockSocket(pool) {
+            var self = this;
+
+            // these are the methods called from probe_dead_host
+
+            // setTimeout on the socket
+            self.pretendTimeout = function(){};
+            self.setTimeout = function(ms, cb){
+                self.pretendTimeout = cb;
+            };
+            // handle socket.on('error', ....
+            self.listeners = {};
+            self.on = function(eventname, cb){
+                self.listeners[eventname] = cb;
+            };
+            self.emit = function(eventname){
+                self.listeners[eventname]();
+            };
+            // handle socket.connect(...
+            self.connected = function() {};
+            self.connect = function(port, host, cb){
+                switch (++num_reqs){
+                    case 1:
+                        // the first time through we pretend it timed out
+                        self.pretendTimeout();
+                        break;
+                    case 2:
+                        // the second time through, pretend socket error
+                        self.emit('error');
+                        break;
+                    case 3:
+                        // the third time around, the socket connected
+                        cb();
+                        break;
+                    default:
+                        // failsafe
+                        console.log("num_reqs hit " + num_reqs + ", wtf?");
+                        process.exit(1);
+                }
+            };
+            self.destroy = function(){};
+
+        };
+
+        var retry_secs = 0.001; // 1ms
+        var pool = new HostPool('1.1.1.1:1111, 2.2.2.2:2222', retry_secs);
+
+        // override the pool's get_socket method to return our mock
+        pool.get_socket = function(){ return new MockSocket(pool); };
+
+        // mark the host as failed and start up the retry timers
+        pool.failed('1.1.1.1', '1111');
+
+        test.ok(pool.dead_hosts["1.1.1.1:1111"], 'yes it was marked dead');
+
+        // probe_dead_host() will hit two failures and one success (based on
+        // num_reqs above). So we wait 3xretry_secs and triple it for
+        // some headroom.
+        setTimeout(function(){
+            test.ok(! pool.dead_hosts["1.1.1.1:1111"],
+                    'timer un-deaded it'
+               );
+            test.done();
+        }, retry_secs * 1000 * 3 * 3 );
+
+    }
+
+};

--- a/tests/host_pool.js
+++ b/tests/host_pool.js
@@ -32,6 +32,19 @@ exports.HostPool = {
 
         test.done();
     },
+    "default port 25 ": function (test) {
+        test.expect(2);
+
+        var pool = new HostPool('1.1.1.1, 2.2.2.2');
+
+        var host1 = pool.get_host();
+        var host2 = pool.get_host();
+
+        test.equal(host1.port, 25, "is port 25: " + host1.port);
+        test.equal(host2.port, 25, "is port 25: " + host2.port);
+
+        test.done();
+    },
 
     "dead host": function(test){
         test.expect(3);


### PR DESCRIPTION
The original config for Haraka took a single host and port in the
smtp_forward.ini config to connect to. If that host was a CNAME with a
bunch of possible hosts it could resolve to, Haraka would have no way of
knowing if say just one of the hosts was down.

Now we can have the pool listed explicitly in the config like this:

    forwarding_host_pool=1.1.1.1:1111, 2.2.2.2:2222, 3.3.3.3.:3333....

If that's not in the config, then smtp_client will continue to use the
old host and port settings.

When a host in the pool goes down, we remove it from the pool of available
hosts and we set a timer to check it periodically to see if it looks like
it's come back online.

The first attempted delivery to a failed backend will result in the mail
being rejected back to the originating MTA, who is responsible for
resending it to Haraka.