### PR TITLE
fix out-of-range errors from banner insertion

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -129,6 +129,13 @@ Body.prototype.parse_start = function (line) {
 };
 
 function _get_html_insert_position (buf) {
+
+    // otherwise, if we return -1 then the buf.copy will die with
+    // RangeError: out of range index
+    if (buf.length === 0){
+        return 0;
+    }
+
     // TODO: consider re-writing this to go backwards from the end
     for (var i=0,l=buf.length; i<l; i++) {
         if (buf[i] === 60 && buf[i+1] === 47) { // found: "</"

--- a/tests/mailbody.js
+++ b/tests/mailbody.js
@@ -55,6 +55,70 @@ exports.banners = {
         test.ok(/<P>An HTML banner<\/P>$/.test(parts[1]));
         test.done();
     },
+
+    'insert_banner': function (test){
+        test.expect(2);
+
+        var content_type;
+        var buf;
+        var new_buf;
+        var enc = 'UTF-8';
+
+        var body = new Body();
+        var banners = [ 'textbanner', 'htmlbanner' ];
+
+        // this is a kind of roundabout way to get at the insert_banners code
+        body.set_banner(banners);
+        var insert_banners_fn = body.filters[0];
+
+        content_type = 'text/html';
+        buf = new Buffer("winter </html>");
+        new_buf = insert_banners_fn (content_type, enc, buf);
+        test.equal(new_buf.toString(), "winter <P>htmlbanner</P></html>",
+                "html banner looks ok");
+
+
+        content_type = 'text/plain';
+        buf = new Buffer("winter");
+        new_buf = insert_banners_fn (content_type, enc, buf);
+        test.equal(new_buf.toString(), "winter\ntextbanner\n",
+                "text banner looks ok");
+
+        test.done();
+    },
+
+
+    // found and fixed bug, if the buffer is empty this was throwing a:
+    // RangeError: out of range index
+    'insert_banner_empty_buffer': function (test){
+        test.expect(2);
+
+        var content_type;
+        var empty_buf;
+        var new_buf;
+        var enc = 'UTF-8';
+
+        var body = new Body();
+        var banners = [ 'textbanner', 'htmlbanner' ];
+
+        // this is a kind of roundabout way to get at the insert_banners code
+        body.set_banner(banners);
+        var insert_banners_fn = body.filters[0];
+
+
+        content_type = 'text/html';
+        empty_buf = new Buffer("");
+        new_buf = insert_banners_fn (content_type, enc, empty_buf);
+        test.equal(new_buf.toString(), "<P>htmlbanner</P>",
+                "empty html part gets a banner" );
+
+        content_type = 'text/plain';
+        new_buf = insert_banners_fn (content_type, enc, empty_buf);
+        test.equal(new_buf.toString(), "\ntextbanner\n",
+                "empty text part gets a banner");
+
+        test.done();
+    },
 };
 
 exports.filters = {
@@ -89,7 +153,8 @@ exports.filters = {
         test.done();
     },
 
-    'regression: duplicate multi-part preamble when filters added': function (test) {
+    'regression: duplicate multi-part preamble when filters added':
+    function (test) {
         test.expect(1);
 
         var body = new Body();


### PR DESCRIPTION
We're seeing these occasionally in production logs:

    RangeError: out of range index
        at RangeError (native)
        at insert_banner (mailbody.js:189:13)

It looks like an empty html part results in an insert-at index of -1, which
won't work with buf.copy. So fix it by returning 0 in that case.

That means that an empty html part will now be just the banner. That's the
current behavior for the text part though. And if the only thing we have is an
html part, I think we want to show the banner.