### PR TITLE
Allow original email's Subject to be included in bounce message

### DIFF
--- a/config/outbound.bounce_message
+++ b/config/outbound.bounce_message
@@ -6,7 +6,9 @@ Subject: failure notice
 Message-Id: {msgid}
 
 Hi. This is the Haraka Mailer program at {me}.
-I'm afraid I wasn't able to deliver your message to the following addresses.
+I'm afraid I wasn't able to deliver your message
+    "{subject}"
+to the following addresses.
 This is a permanent error; I've given up. Sorry it didn't work out.
 
 Intended Recipients: {recipients}

--- a/outbound.js
+++ b/outbound.js
@@ -1709,6 +1709,7 @@ HMailItem.prototype.populate_bounce_message_with_headers = function(from, to, re
         me:   config.get('me'),
         from: from,
         to:   to,
+        subject: header.get_decoded('Subject').trim(),
         recipients: this.todo.rcpt_to.join(', '),
         reason: reason,
         extended_reason: this.todo.rcpt_to.map(function (recip) {


### PR DESCRIPTION
Add the original email's Subject to the set of values that can be used in the config/outbound.bounce_message template, for more informative bounce messages.