### PR TITLE
handle arrays in .ini files

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -8,7 +8,7 @@ var yaml = require('js-yaml');
 // for "ini" type files
 var regex = exports.regex = {
     section:        /^\s*\[\s*([^\]]*?)\s*\]\s*$/,
-    param:          /^\s*([\w@:\._\-\/]+)\s*(?:=\s*(.*?)\s*)?$/,
+    param:          /^\s*([\w@:\._\-\/\[\]]+)\s*(?:=\s*(.*?)\s*)?$/,
     comment:        /^\s*[;#].*$/,
     line:           /^\s*(.*?)\s*$/,
     blank:          /^\s*$/,
@@ -16,6 +16,7 @@ var regex = exports.regex = {
     is_integer:     /^-?\d+$/,
     is_float:       /^-?\d+\.\d+$/,
     is_truth:       /^(?:true|yes|ok|enabled|on|1)$/i,
+    is_array:       /(.+)\[\]$/,
 };
 
 var cfreader = exports;
@@ -408,6 +409,8 @@ cfreader.load_ini_config = function(name, options) {
         var data = fs.readFileSync(name, 'UTF-8');
         var lines = data.split(/\r\n|\r|\n/);
         var match;
+        var is_array_match;
+        var setter;
         var pre = '';
 
         lines.forEach(function(line) {
@@ -432,21 +435,31 @@ cfreader.load_ini_config = function(name, options) {
             pre = '';
             match = regex.param.exec(line);
             if (match) {
+                is_array_match = regex.is_array.exec(match[1]);
+                if (is_array_match){
+                    setter = function(key, value){
+                        key = key.replace('[]', '');
+                        if (! current_sect[key]) current_sect[key] = [];
+                        current_sect[key].push(value) };
+                }
+                else {
+                    setter = function(key, value) { current_sect[key] = value };
+                }
                 if (options && Array.isArray(options.booleans) &&
                     bool_matches.indexOf(current_sect_name + '.' + match[1]) !== -1)
                 {
-                    current_sect[match[1]] = regex.is_truth.test(match[2]);
+                    setter(match[1], regex.is_truth.test(match[2]));
                     logger.logdebug('Returning boolean ' + current_sect[match[1]] +
                                     ' for ' + current_sect_name + '.' + match[1] + '=' + match[2]);
                 }
                 else if (regex.is_integer.test(match[2])) {
-                    current_sect[match[1]] = parseInt(match[2], 10);
+                    setter(match[1], parseInt(match[2], 10));
                 }
                 else if (regex.is_float.test(match[2])) {
-                    current_sect[match[1]] = parseFloat(match[2]);
+                    setter(match[1], parseFloat(match[2]));
                 }
                 else {
-                    current_sect[match[1]] = match[2];
+                    setter(match[1], match[2]);
                 }
                 return;
             }

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -194,6 +194,16 @@ For completeness the inverse is also allowed:
 
     { booleans: [ '-reject' ] }
 
+Lists are supported using this syntax:
+
+    hosts[] = first_host
+    hosts[] = second_host
+    hosts[] = third_host
+
+which produces this javascript array:
+
+    ['first_host', 'second_host', 'third_host']
+
 
 Flat Files
 ----------

--- a/tests/config.js
+++ b/tests/config.js
@@ -169,7 +169,11 @@ exports.get = {
             whitespace: { str_no_trail: 'true', str_trail: 'true' },
             funnychars: { 'results.auth/auth_base.fail': 'fun' },
             empty_values: { first: undefined, second: undefined },
-            has_ipv6: { '2605:ae00:329::2': undefined }
+            has_ipv6: { '2605:ae00:329::2': undefined },
+            array_test: {
+                hostlist: [ 'first_host', 'second_host', 'third_host' ],
+                intlist: [ '123', '456', '789' ],
+            }
         });
     },
 

--- a/tests/config/test.ini
+++ b/tests/config/test.ini
@@ -25,3 +25,12 @@ second
 
 [has_ipv6]
 2605:ae00:329::2
+
+[array_test]
+hostlist[] = first_host
+hostlist[] = second_host
+hostlist[] = third_host
+
+intlist[] = 123
+intlist[] = 456
+intlist[] = 789

--- a/tests/configfile.js
+++ b/tests/configfile.js
@@ -135,6 +135,13 @@ exports.load_ini_config = {
         test.deepEqual({ first: undefined, second: undefined}, r.empty_values);
         test.done();
     },
+    'test.ini, array' : function(test){
+        test.expect(2);
+        var r = this.cfreader.load_ini_config('tests/config/test.ini');
+        test.deepEqual(['first_host', 'second_host', 'third_host'], r.array_test.hostlist);
+        test.deepEqual([123, 456, 789], r.array_test.intlist);
+        test.done();
+    },
 };
 
 exports.get_filetype_reader  = {


### PR DESCRIPTION
msimerson commented in a pull request https://github.com/haraka/Haraka/pull/1333#issuecomment-184313920

    One thing that might be worth changing is the way the host pool is
    configured. A method that already has widespread use is to specify an array
    for the host value instead of a string. This would necessitate extending our
    ini parser to recognize the array syntax.

The syntax looks like this. There is no "official" .ini syntax for arrays, but
this seems to be common.

    hosts[] = first_host
    hosts[] = second_host
    hosts[] = third_host

This is PR #1342 , rebased and squashed. Closes #1342 