### PR TITLE
version bump node.js 4.2 -> 4.3 (LTS)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+### General Guidelines
+
+* New features **must** be documented
+* Changes **must** pass integration tests.
+* Changes **should** increase overall test coverage.
+
+## Rebasing
+
+### When to Rebase
+
+On branches with more than a couple commits, it's usually best to squash the commits (condense them into one). Exceptions to the single commit guideline are:
+
+* multiple logical changes, put each in a commit (easier to review and revert)
+* whitespace changes belong in their own commit
+* no-op code refactoring is separate from functional changes
+
+### How to Rebase
+
+```sh
+git remote add haraka https://github.com/haraka/Haraka.git
+git remote update haraka
+git rebase -i haraka/master
+```
+
+Change all but the first "pick" lines to "s" and save your changes. Your $EDITOR will then present you with all of the commit messages. Edit them and save. Then force push your branch:
+
+`git push -f`
+
+
+### Style conventions
+
+* 4 space indentions (no tabs)
+* Semi-colons on the end of statements are preferred
+* Use underscores\_to\_separate\_names (yes this goes against JS conventions - it's the way it has always been done)
+* Do not [cuddle elses](http://c2.com/cgi/wiki?CuddledElseBlocks)
+* Use whitespace between operators - we prefer `if (foo > bar)` over `if(foo>bar)`
+* Don't comment out lines of code, remove them. They will be in the revision history.
+* Use boolean true/false instead of numeric 0/1
+* Use one `var` for each declared variable
+* See [Editor Settings](https://github.com/haraka/Haraka/wiki/Editor-Settings)
+
+## Tests
+
+* run all tests: ./run_tests  (or "npm test")
+* run tests for a single plugin: ./run_tests tests/plugins/bounce.js

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+### Haraka version
+
+### Expected behavior
+
+### Observed behavior
+
+### Steps to reproduce

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Fixes # .
+
+Changes proposed in this pull request:
+-
+-
+-
+
+Checklist:
+- [ ] docs updated
+- [ ] tests updated

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ node_js:
 #   - "0.6"     # no longer supported by async
 #   - "0.8"     # no longer supported by iconv
     - "0.10"
-    - "0.12"
-    - "4.2"
+    - "4.3"
+    - "5.6"
 
 services:
     - redis-server
     
-# these are required for building on node.js 4.0 / io.js v3
+# these are required for building on node.js v4
 addons:
   apt:
     sources:
@@ -18,7 +18,7 @@ addons:
       - g++-4.8
 env:
   - "CXX=g++-4.8"
-# end: these are required for building on node.js 4.0 / io.js v3
+# end: these are required for building on node.js v4
 
 before_script:
     - npm install -g grunt-cli


### PR DESCRIPTION
version bump node.js 4.2 -> 4.3 (LTS)
* add 5.6 testing (Stable)
* maintain 4.x (LTS) testing
* drop node 0.12 (LTS) testing, as its covered by 0.10
* maintain 0.10 (Maintenance)

This is [tracking the upstream](https://nodejs.org/en/blog/vulnerability/february-2016-security-releases/) node.js releases, where version 4.2 is dropped due to openssl updates included in 4.3.

### repo templates

Test drive the GitHub repo templates feature.