### PR TITLE
remove redis loading from karma

### DIFF
--- a/plugins/karma.js
+++ b/plugins/karma.js
@@ -1,8 +1,6 @@
 'use strict';
 // karma - reward good and penalize bad mail senders
 
-var redis  = require('redis');
-
 var utils  = require('./utils');
 
 var phase_prefixes = utils.to_object(

--- a/tests/plugins/karma.js
+++ b/tests/plugins/karma.js
@@ -6,14 +6,6 @@ var Plugin           = require('../fixtures/stub_plugin');
 var config           = require('../../config');
 var ResultStore      = require("../../result_store");
 
-try {
-    var redis = require('redis');
-}
-catch (e) {
-    console.log(e + "\nunable to load redis, skipping tests");
-    return;
-}
-
 var _set_up = function (done) {
 
     this.plugin = new Plugin('karma');


### PR DESCRIPTION
Not used since PR #1277, which switched to inheriting from the redis plugin 