### PR TITLE
Allow for override for inbound/outbound

### DIFF
--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -40,9 +40,18 @@ Default: false. Switch to true to enable TLS for outbound mail when the
 remote end is capable.
 
 This uses the same `tls_key.pem` and `tls_cert.pem` files that the `tls`
-plugin uses. See the [tls plugin
+plugin uses, along with other values in `tls.ini`. See the [tls plugin
 docs](http://haraka.github.io/manual/plugins/tls.html) for information on generating those
 files.
+
+Within `tls.ini` you can specify global options for the values `ciphers`,
+`requestCert` and `rejectUnauthorized`, alternatively you can provide
+separate values by putting them under a key: `[outbound]`, such as:
+
+```
+[outbound]
+ciphers=!DES
+```
 
 * `ipv6_enabled`
 

--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -48,7 +48,8 @@ Configuration
 
   * enable\_tls=[true]
 
-    Enable TLS with the forward host (if supported)
+    Enable TLS with the forward host (if supported). TLS uses options
+    from the tls plugin.
 
   * auth\_type=[plain|login]
 

--- a/docs/plugins/queue/smtp_proxy.md
+++ b/docs/plugins/queue/smtp_proxy.md
@@ -49,7 +49,8 @@ Configuration
 
   * enable\_tls=[true|yes|1]
  
-    Enable TLS with the forward host (if supported)
+    Enable TLS with the forward host (if supported). TLS uses options from
+    the tls plugin.
 
   * auth\_type=[plain|login]
 

--- a/docs/plugins/tls.md
+++ b/docs/plugins/tls.md
@@ -71,3 +71,13 @@ Whether Haraka should request a certificate from a connecting client.
 Reject connections from clients without a CA validated TLS certificate.
 
     `rejectUnauthorized=[true|false]`  (default: false)
+
+## Inbound Specific Configuration
+
+By default the above options are shared with outbound mail (either
+using `smtp_forward`, `smtp_proxy` or plain outbound mail heading to
+an external destination). To make these options specific to inbound
+mail, put them under an `[inbound]` parameter group. Outbound options
+can go under an `[outbound]` parameter group, and plugins that use
+SMTP tls for queueing such as `smtp_proxy` and `smtp_forward` can
+use that plugin name for plugin specific options.

--- a/outbound.js
+++ b/outbound.js
@@ -1152,8 +1152,6 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
             !(host in tls_config.no_tls_hosts) &&
             smtp_properties.tls && cfg.enable_tls && !secured)
         {
-            console.log(tls_config.no_tls_hosts);
-            console.log("domain:", self.todo.domain, "host:", host);
             socket.on('secure', function () {
                 // Set this flag so we don't try STARTTLS again if it
                 // is incorrectly offered at EHLO once we are secured.
@@ -1414,6 +1412,14 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
                             var opt = config_options[i];
                             if (tls_config.main[opt] === undefined) { continue; }
                             tls_options[opt] = tls_config.main[opt];
+                        }
+
+                        if (tls_config.outbound) {
+                            for (var i = 0; i < config_options.length; i++) {
+                                var opt = config_options[i];
+                                if (tls_config.outbound[opt] === undefined) { continue; }
+                                tls_options[opt] = tls_config.outbound[opt];
+                            }
                         }
 
                         smtp_properties = {};

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -51,6 +51,14 @@ exports.load_tls_ini = function () {
         if (plugin.cfg.main[opt] === undefined) { continue; }
         plugin.tls_opts[opt] = plugin.cfg.main[opt];
     }
+
+    if (plugin.cfg.inbound) {
+        for (var i = 0; i < config_options.length; i++) {
+            var opt = config_options[i];
+            if (plugin.cfg.inbound[opt] === undefined) { continue; }
+            plugin.tls_opts[opt] = plugin.cfg.inbound[opt];
+        }
+    }
 };
 
 exports.tls_capabilities = function (next, connection) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Let's tls.ini have separate [inbound] and [outbound] sections for 'ciphers', 'requestCert', 'rejectUnauthorized' options
