### PR TITLE
Fix caching of STUN results

### DIFF
--- a/net_utils.js
+++ b/net_utils.js
@@ -199,7 +199,7 @@ exports.same_ipv4_network = function (ip, ipList) {
 
 exports.get_public_ip = function (cb) {
     var nu = this;
-    if (nu.public_ip) {
+    if (nu.public_ip !== undefined) {
         return cb(null, nu.public_ip);  // cache
     }
 
@@ -209,6 +209,10 @@ exports.get_public_ip = function (cb) {
         nu.public_ip = smtpIni.public_ip;
         return cb(null, nu.public_ip);
     }
+
+    // Initialise cache value to null to prevent running 
+    // should we hit a timeout or the module isn't installed.
+    nu.public_ip = null;
 
     try {
         nu.stun = require('vs-stun');
@@ -238,6 +242,7 @@ exports.get_public_ip = function (cb) {
         if (!socket.stun.public) {
             return cb(new Error('invalid STUN result'));
         }
+        nu.public_ip = socket.stun.public.host;
         return cb(null, socket.stun.public.host);
     };
 


### PR DESCRIPTION
Caching of the public IP was only implemented if the value was manually set in smtp.ini (which has limited value being as it is cached itself by the configuration loader).

This caches the STUN result (or lack of result), so that the STUN server is not endlessly queried for the same result.

I noticed the issue when I ran this up on a host which STUN failed to traverse the firewall - it caused connect.geoip to get a STUN timeout on every connection.