### PR TITLE
Fix on exit handlers

### DIFF
--- a/haraka.js
+++ b/haraka.js
@@ -54,11 +54,11 @@ process.on('SIGHUP', function () {
     server.flushQueue();
 });
 
-process.on('exit', function() {
+process.on('exit', function(code) {
     process.title = path.basename(process.argv[1], '.js');
     logger.lognotice('Shutting down');
     logger.dump_logs();
-    exit(0);
+    exit(code);
 });
 
 logger.log("NOTICE", "Starting up Haraka version " + exports.version);


### PR DESCRIPTION
This fixes a pretty serious bug.

Currently when running under 'cluster' (as everybody should be) and a plugin crashes the Haraka worker, the child will not be respawned by the master like it should be as the master thinks the child exited cleanly.

This patch passes back the original exit code so that the child is correctly respawned.

