### PR TITLE
Fix DKIM verifier header handling

### DIFF
--- a/dkim.js
+++ b/dkim.js
@@ -5,7 +5,6 @@ var Stream = require('stream').Stream;
 var indexOfLF = require('./utils').indexOfLF;
 var util = require('util');
 var dns = require('dns');
-var fs = require('fs');
 
 //////////////////////
 // Common functions //


### PR DESCRIPTION
Fixes #989

Headers specified multiple times in the h= field were being incorrectly added twice and in the wrong order if multiple header fields were present.