### PR TITLE
remove dnsbl.zones, so overrides are better

### DIFF
--- a/config/dnsbl.ini
+++ b/config/dnsbl.ini
@@ -20,4 +20,4 @@ search=first
 
 ; zones: a comma separated list of DNSBL zones
 ;        or list DNSBL zones in config/dnsbl.zones
-;zones=zen.spamhaus.org
+zones=zen.spamhaus.org

--- a/config/dnsbl.zones
+++ b/config/dnsbl.zones
@@ -1,1 +1,0 @@
-zen.spamhaus.org


### PR DESCRIPTION
We need to think about the optimal default configuration for this plugin.

As it stands, if someone configures the plugin like this:

```sh
echo 'zones=b.barracudacentral.org, truncate.gbudb.net' >> config/dnsbl.ini
```

They'll also have zen.spamhaus.org configured as well, because it will be enabled in the invisible (to the user) config directory. This seems a POLA violation.

This PR isn't much better, in that if someone were to do this:

```sh
echo 'b.barracudacentral.org' > config/dnsbl.zones
```

They'd once again be surprised to find that zen.spamhaus.org is active. 

### suggestion #1

Remove the docs for dnsbl.zones and encourage everyone to use dnsbl.ini.

### suggestion #2

Now that we can have empty values in our .ini files, we could also deprecate both methods and replace them with an INI section:

```ini
[zones]
b.barracudacentral.org
truncate.gbudb.net
zen.spamhaus.org
```