### PR TITLE
if rcpt_to returns DSN in msg, log it properly.

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -973,9 +973,15 @@ Connection.prototype.rcpt_incr = function(rcpt, action, msg, retval) {
         address: addr.substr(1, addr.length -2),
         action:  action
     };
+
     if (msg && action !== 'accept') {
-        recipient.msg  = msg;
-        recipient.code  = constants.translate(retval);
+        if (typeof msg === 'object' && msg.constructor.name === 'DSN') {
+            recipient.msg   = msg.reply;
+            recipient.code  = msg.code;
+        } else {
+            recipient.msg  = msg;
+            recipient.code  = constants.translate(retval);
+        }
     }
 
     this.transaction.results.push({name: 'rcpt_to'}, {


### PR DESCRIPTION
Otherwise we end up with DSN object in msg and not with a string.