### PR TITLE
Remove exit module

### DIFF
--- a/haraka.js
+++ b/haraka.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 
 'use strict';
-
 var path = require('path');
-var exit = require('exit');
 
 // this must be set before "server.js" is loaded
 process.env.HARAKA = process.env.HARAKA || path.resolve('.');
@@ -36,16 +34,14 @@ process.on('uncaughtException', function (err) {
     else {
         logger.logcrit('Caught exception: ' + JSON.stringify(err));
     }
-    logger.dump_logs();
-    exit(1);
+    logger.dump_and_exit(1);
 });
 
 ['SIGTERM', 'SIGINT'].forEach(function (sig) {
     process.on(sig, function () {
         process.title = path.basename(process.argv[1], '.js');
         logger.lognotice(sig + ' received');
-        logger.dump_logs();
-        exit(1);
+        logger.dump_and_exit(1);
     });
 });
 
@@ -58,7 +54,6 @@ process.on('exit', function(code) {
     process.title = path.basename(process.argv[1], '.js');
     logger.lognotice('Shutting down');
     logger.dump_logs();
-    exit(code);
 });
 
 logger.log("NOTICE", "Starting up Haraka version " + exports.version);

--- a/logger.js
+++ b/logger.js
@@ -54,7 +54,7 @@ logger.colorize = function (color, str) {
            '\u001b[' + util.inspect.colors[color][1] + 'm';
 };
 
-logger.dump_logs = function () {
+logger.dump_logs = function (cb) {
     while (logger.deferred_logs.length > 0) {
         var log_item = logger.deferred_logs.shift();
         var color = logger.colors[log_item.level];
@@ -65,8 +65,16 @@ logger.dump_logs = function () {
             console.log(log_item.data);
         }
     }
+    // Run callback after flush
+    if (cb) process.stdout.write('', cb);
     return true;
 };
+
+logger.dump_and_exit = function (code) {
+    this.dump_logs(function () {
+        process.exit(code);
+    });
+}
 
 logger.log = function (level, data) {
     if (level === 'PROTOCOL') {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "semver"                : "~5.0.3",
     "sprintf-js"            : "~1.0.3",
     "haraka-tld"            : "*",
-    "haraka-constants"      : "*",
-    "exit"                  : "~0.1.2"
+    "haraka-constants"      : "*"
   },
   "optionalDependencies": {
     "elasticsearch"         : "*",


### PR DESCRIPTION
Remove the exit module as it's caused me multiple nasty issues.

The latest issue I've had was extremely hard to diagnose (it required strace) which caused the cluster master to be unable to respawn a crashed child process:

````
write(2, "events.js:141
      throw er; // Unhandled 'error' event            
Error: This socket is closed.
    at Socket._writeGeneric (net.js:625:19)
    at Socket._write (net.js:678:8)
    at doWrite (_stream_writable.js:291:12)
    at writeOrBuffer (_stream_writable.js:278:5)
    at Socket.Writable.write (_stream_writable.js:206:11)
    at Socket.write (net.js:603:40)
    at /usr/lib/node_modules/Haraka/node_modules/exit/lib/exit.js:25:14
    at Array.forEach (native)
    at exit (/usr/lib/node_modules/Haraka/node_modules/exit/lib/exit.js:20:11)
    at process.<anonymous> (/usr/lib/node_modules/Haraka/haraka.js:41:5)
", 622) = -1 EPIPE (Broken pipe)
--- SIGPIPE {si_signo=SIGPIPE, si_code=SI_USER, si_pid=19697, si_uid=0} ---
````

It looks like what happened is that exit() somehow manages to close stdin/stdout/stderr in the master process when one of the children hit an unhandled exception and this prevented all future children spawned by master from inheriting them and therefore at start-up when they attempted to write to the console, they immediately hit an EPIPE exception and would then crash out again.   Rinse repeat.