### PR TITLE
bounce: skip single_recipient check for relays/private_ips

### DIFF
--- a/docs/plugins/bounce.md
+++ b/docs/plugins/bounce.md
@@ -38,6 +38,11 @@ for mail servers at domains with frequent spoofing and few or no human users.
 Valid bounces have a single recipient. Assure that the message really is a
 bounce by enforcing bounces to be addressed to a single recipient.
 
+This check is skipped for relays or hosts with a private IP, this is because
+Microsoft Exchange distribution lists will send messages to list members with
+a null return-path when the 'Do not send delivery reports' option is enabled
+(yes, really...).
+
 ### empty\_return\_path
 
 Valid bounces should have an empty return path. Test for the presence of the

--- a/plugins/bounce.js
+++ b/plugins/bounce.js
@@ -100,6 +100,22 @@ exports.single_recipient = function(next, connection) {
         return next();
     }
 
+    // Skip this check for relays or private_ips
+    // This is because Microsoft Exchange will send mail
+    // to distribution groups using the null-sender if
+    // the option 'Do not send delivery reports' is
+    // checked (not sure if this is default or not)
+    if (connection.relaying) {
+        transaction.results.add(plugin,
+                {skip: 'single_recipient(relay)', emit: true });
+        return next();
+    }
+    if (net_utils.is_private_ip(connection.remote_ip)) {
+        transaction.results.add(plugin,
+                {skip: 'single_recipient(private_ip)', emit: true });
+        return next();
+    }
+
     connection.loginfo(plugin, "bounce with too many recipients to: " +
         connection.transaction.rcpt_to.join(','));
 


### PR DESCRIPTION
Skip the single recipient check for relays or hosts with a private IP.

This is because Microsoft Exchange will send messages with a null return-path to distribution list members in certain circumstances (yes, really....).
