### PR TITLE
Fix: auth_proxy upgrade loop if the server always includes STARTTLS

### DIFF
--- a/plugins/auth/auth_proxy.js
+++ b/plugins/auth/auth_proxy.js
@@ -50,6 +50,7 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
     var auth_success = false;
     var command = 'connect';
     var response = [];
+    var secure = false;
 
     var hostport = host.split(/:/);
     var socket = sock.connect(((hostport[1]) ? hostport[1] : 25), hostport[0]);
@@ -105,12 +106,13 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
                     // Parse CAPABILITIES
                     var i;
                     for (i in response) {
-                        if (response[i].match(/^STARTTLS/)) {
+                        if (!secure && response[i].match(/^STARTTLS/)) {
                             var key = self.config.get('tls_key.pem', 'binary');
                             var cert = self.config.get('tls_cert.pem', 'binary');
                             // Use TLS opportunistically if we found the key and certificate
                             if (key && cert) {
                                 this.on('secure', function () {
+                                    secure = true;
                                     socket.send_command('EHLO', self.config.get('me'));
                                 });
                                 socket.send_command('STARTTLS');


### PR DESCRIPTION
[SendGrid](https://sendgrid.com/) seems to always include `STARTTLS` in capabilities (even when the connection is already secure), which causes an `auth_proxy` plugin's upgrade loop:

```
[DEBUG] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] attempting connection to host=smtp.sendgrid.net port=587
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 220 SG ESMTP service ready at ismtpd0003p1lon1.sendgrid.net\r\n
[DEBUG] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] command state: connect
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] C: EHLO localhost
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-smtp.sendgrid.net\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-8BITMIME\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-PIPELINING\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-SIZE 31457280\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-STARTTLS\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-AUTH PLAIN LOGIN\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250 AUTH=PLAIN LOGIN\r\n
[DEBUG] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] command state: ehlo
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] C: STARTTLS
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 220 Begin TLS negotiation now\r\n
[DEBUG] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] command state: starttls
[DEBUG] [-] [core] client TLS upgrade in progress, awaiting secured.
[DEBUG] [-] [core] client TLS secured.
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] C: EHLO localhost
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-smtp.sendgrid.net\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-8BITMIME\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-PIPELINING\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-SIZE 31457280\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-STARTTLS\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250-AUTH PLAIN LOGIN\r\n
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 250 AUTH=PLAIN LOGIN\r\n
[DEBUG] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] command state: ehlo
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] C: STARTTLS
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] S: 503 TLS already negotiated\r\n
[DEBUG] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] command state: starttls
[DEBUG] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] error: 503 TLS already negotiated\r
[PROTOCOL] [2D9395D9-B82F-4D85-8259-106A7CE2EBED] [auth/auth_bridge] C: QUIT
```

This PR just adds a `secure` flag that ensures `auth_proxy` doesn't try to upgrade the connection twice.