### PR TITLE
rspamd: Fix undefined variable

### DIFF
--- a/plugins/rspamd.js
+++ b/plugins/rspamd.js
@@ -258,7 +258,7 @@ exports.add_headers = function (connection, data) {
             prettySymbols.join(' '));
     }
 
-    if (cfg.header.score) {
+    if (cfg.header && cfg.header.score) {
         connection.transaction.remove_header(cfg.header.score);
         connection.transaction.add_header(cfg.header.score, '' + data.score);
     }


### PR DESCRIPTION
Fixes:
`````
Mar 30 07:43:51 mail1-ewh haraka[25622]: [CRIT] [-] [core] TypeError: Cannot read property 'score' of undefined
Mar 30 07:43:51 mail1-ewh haraka[25622]: [CRIT] [-] [core]     at Plugin.exports.add_headers (/usr/lib/node_modules/Haraka/plugins/rspamd.js:261:19)
Mar 30 07:43:51 mail1-ewh haraka[25622]: [CRIT] [-] [core]     at no_reject (/usr/lib/node_modules/Haraka/plugins/rspamd.js:147:32)
Mar 30 07:43:51 mail1-ewh haraka[25622]: [CRIT] [-] [core]     at IncomingMessage.<anonymous> (/usr/lib/node_modules/Haraka/plugins/rspamd.js:152:54)
Mar 30 07:43:51 mail1-ewh haraka[25622]: [CRIT] [-] [core]     at emitNone (events.js:72:20)
Mar 30 07:43:51 mail1-ewh haraka[25622]: [CRIT] [-] [core]     at IncomingMessage.emit (events.js:163:7)
Mar 30 07:43:51 mail1-ewh haraka[25622]: [CRIT] [-] [core]     at endReadableNT (_stream_readable.js:890:12)
Mar 30 07:43:51 mail1-ewh haraka[25622]: [CRIT] [-] [core]     at process._tickCallback (node.js:343:24)
Mar 30 07:43:51 mail1-ewh haraka[25622]: [NOTICE] [-] [core] Shutting down
Mar 30 07:43:51 mail1-ewh haraka[25548]: [NOTICE] [-] [core] worker 1 exited with error code: 1
Mar 30 07:43:51 mail1-ewh haraka[25548]: [NOTICE] [-] [core] worker 3 started pid=28074
`````