### PR TITLE
refactor: auth_proxy

### DIFF
--- a/plugins/auth/auth_proxy.js
+++ b/plugins/auth/auth_proxy.js
@@ -88,127 +88,128 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
         response = [];
     };
     socket.on('line', function (line) {
-        var matches;
         connection.logprotocol(self, "S: " + line);
-        if (matches = smtp_regexp.exec(line)) {
-            var code = matches[1];
-            var cont = matches[2];
-            var rest = matches[3];
-            response.push(rest);
-            if (cont === ' ') {
-                connection.logdebug(self, 'command state: ' + command);
-                if (command === 'ehlo') {
-                    if (code.match(/^5/)) {
-                        // EHLO command rejected; we have to abort
-                        socket.send_command('QUIT');
-                        return;
-                    }
-                    // Parse CAPABILITIES
-                    var i;
-                    for (i in response) {
-                        if (!secure && response[i].match(/^STARTTLS/)) {
-                            var key = self.config.get('tls_key.pem', 'binary');
-                            var cert = self.config.get('tls_cert.pem', 'binary');
-                            // Use TLS opportunistically if we found the key and certificate
-                            if (key && cert) {
-                                this.on('secure', function () {
-                                    secure = true;
-                                    socket.send_command('EHLO', self.config.get('me'));
-                                });
-                                socket.send_command('STARTTLS');
-                                return;
-                            }
-                        }
-                        else if (response[i].match(/^AUTH /)) {
-                            // Parse supported AUTH methods
-                            var parse = /^AUTH (.+)$/.exec(response[i]);
-                            methods = parse[1].split(/\s+/);
-                            connection.logdebug(self, 'found supported AUTH methods: ' + methods);
-                            // Prefer PLAIN as it's easiest
-                            if (methods.indexOf('PLAIN') !== -1) {
-                                socket.send_command('AUTH','PLAIN ' + utils.base64("\0" + user + "\0" + passwd));
-                                return;
-                            }
-                            else if (methods.indexOf('LOGIN') !== -1) {
-                                socket.send_command('AUTH','LOGIN');
-                                return;
-                            }
-                            else {
-                                // No compatible methods; abort...
-                                connection.logdebug(self, 'no compatible AUTH methods');
-                                socket.send_command('QUIT');
-                                return;
-                            }
-                        }
-                    }
-                }
-                if (command === 'auth') {
-                    // Handle LOGIN
-                    if (code[0] === '3' && response[0] === 'VXNlcm5hbWU6') {
-                        // Write to the socket directly to keep the state at 'auth'
-                        this.write(utils.base64(user) + "\r\n");
-                        response = [];
-                        return;
-                    }
-                    else if (code[0] === '3' && response[0] === 'UGFzc3dvcmQ6') {
-                        this.write(utils.base64(passwd) + "\r\n");
-                        response = [];
-                        return;
-                    }
-                    if (code[0] === '5') {
-                        // Initial attempt failed; strip domain and retry.
-                        var u;
-                        if ((u = /^([^@]+)@.+$/.exec(user))) {
-                            user = u[1];
-                            if (methods.indexOf('PLAIN') !== -1) {
-                                socket.send_command('AUTH', 'PLAIN ' + utils.base64("\0" + user + "\0" + passwd));
-                            }
-                            else if (methods.indexOf('LOGIN') !== -1) {
-                                socket.send_command('AUTH', 'LOGIN');
-                            }
-                            return;
-                        }
-                        else {
-                            // Don't attempt any other hosts
-                            auth_complete = true;
-                        }
-                    }
-                }
-                if (/^[345]/.test(code)) {
-                    // Got an unhandled error
-                    connection.logdebug(self, 'error: ' + line);
-                    socket.send_command('QUIT');
-                    return;
-                }
-                switch (command) {
-                    case 'starttls':
-                        var tls_options = { key: key, cert: cert };
-                        this.upgrade(tls_options);
-                        break;
-                    case 'connect':
-                        socket.send_command('EHLO', self.config.get('me'));
-                        break;
-                    case 'auth':
-                        // AUTH was successful
-                        auth_complete = true;
-                        auth_success = true;
-                        socket.send_command('QUIT');
-                        break;
-                    case 'ehlo':
-                    case 'helo':
-                    case 'quit':
-                        socket.end();
-                        break;
-                    default:
-                        throw new Error("[auth/auth_proxy] unknown command: " + command);
-                }
-            }
-        }
-        else {
+        var matches = smtp_regexp.exec(line);
+        if (!matches) return;
+
+        var code = matches[1];
+        var cont = matches[2];
+        var rest = matches[3];
+        response.push(rest);
+
+        if (cont !== ' ') {
             // Unrecognised response.
             connection.logerror(self, "unrecognised response: " + line);
             socket.end();
             return;
+        }
+
+        connection.logdebug(self, 'command state: ' + command);
+        if (command === 'ehlo') {
+            if (code[0] === '5') {
+                // EHLO command rejected; abort
+                socket.send_command('QUIT');
+                return;
+            }
+            // Parse CAPABILITIES
+            var i;
+            for (i in response) {
+                if (/^STARTTLS/.test(response[i])) {
+                    if (secure) continue;    // silly remote, we've already upgraded
+                    var key = self.config.get('tls_key.pem', 'binary');
+                    var cert = self.config.get('tls_cert.pem', 'binary');
+                    // Use TLS opportunistically if we found the key and certificate
+                    if (key && cert) {
+                        this.on('secure', function () {
+                            secure = true;
+                            socket.send_command('EHLO', self.config.get('me'));
+                        });
+                        socket.send_command('STARTTLS');
+                        return;
+                    }
+                }
+                else if (/^AUTH /.test(response[i])) {
+                    // Parse supported AUTH methods
+                    var parse = /^AUTH (.+)$/.exec(response[i]);
+                    methods = parse[1].split(/\s+/);
+                    connection.logdebug(self, 'found supported AUTH methods: ' + methods);
+                    // Prefer PLAIN as it's easiest
+                    if (methods.indexOf('PLAIN') !== -1) {
+                        socket.send_command('AUTH','PLAIN ' + utils.base64("\0" + user + "\0" + passwd));
+                        return;
+                    }
+                    else if (methods.indexOf('LOGIN') !== -1) {
+                        socket.send_command('AUTH','LOGIN');
+                        return;
+                    }
+                    else {
+                        // No compatible methods; abort...
+                        connection.logdebug(self, 'no compatible AUTH methods');
+                        socket.send_command('QUIT');
+                        return;
+                    }
+                }
+            }
+        }
+        if (command === 'auth') {
+            // Handle LOGIN
+            if (code[0] === '3' && response[0] === 'VXNlcm5hbWU6') {
+                // Write to the socket directly to keep the state at 'auth'
+                this.write(utils.base64(user) + "\r\n");
+                response = [];
+                return;
+            }
+            else if (code[0] === '3' && response[0] === 'UGFzc3dvcmQ6') {
+                this.write(utils.base64(passwd) + "\r\n");
+                response = [];
+                return;
+            }
+            if (code[0] === '5') {
+                // Initial attempt failed; strip domain and retry.
+                var u;
+                if ((u = /^([^@]+)@.+$/.exec(user))) {
+                    user = u[1];
+                    if (methods.indexOf('PLAIN') !== -1) {
+                        socket.send_command('AUTH', 'PLAIN ' + utils.base64("\0" + user + "\0" + passwd));
+                    }
+                    else if (methods.indexOf('LOGIN') !== -1) {
+                        socket.send_command('AUTH', 'LOGIN');
+                    }
+                    return;
+                }
+                else {
+                    // Don't attempt any other hosts
+                    auth_complete = true;
+                }
+            }
+        }
+        if (/^[345]/.test(code)) {
+            // Got an unhandled error
+            connection.logdebug(self, 'error: ' + line);
+            socket.send_command('QUIT');
+            return;
+        }
+        switch (command) {
+            case 'starttls':
+                var tls_options = { key: key, cert: cert };
+                this.upgrade(tls_options);
+                break;
+            case 'connect':
+                socket.send_command('EHLO', self.config.get('me'));
+                break;
+            case 'auth':
+                // AUTH was successful
+                auth_complete = true;
+                auth_success = true;
+                socket.send_command('QUIT');
+                break;
+            case 'ehlo':
+            case 'helo':
+            case 'quit':
+                socket.end();
+                break;
+            default:
+                throw new Error("[auth/auth_proxy] unknown command: " + command);
         }
     });
 };


### PR DESCRIPTION

* use early exits instead of compound conditionals
* sheds a couple indention levels (see git diff -b below, easier to read vs github diff).
* replace a couple match without value tests with //.test()

Please review but don't merge. When it's merge-ready, I'll squash the commits.

```diff
diff --git a/plugins/auth/auth_proxy.js b/plugins/auth/auth_proxy.js
index 3d5cfbf..5356986 100644
--- a/plugins/auth/auth_proxy.js
+++ b/plugins/auth/auth_proxy.js
@@ -88,14 +88,22 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
         response = [];
     };
     socket.on('line', function (line) {
-        var matches;
         connection.logprotocol(self, "S: " + line);
-        if (matches = smtp_regexp.exec(line)) {
+        var matches = smtp_regexp.exec(line);
+        if (!matches) return;
+
         var code = matches[1];
         var cont = matches[2];
         var rest = matches[3];
         response.push(rest);
-            if (cont === ' ') {
+
+        if (cont !== ' ') {
+            // Unrecognised response.
+            connection.logerror(self, "unrecognised response: " + line);
+            socket.end();
+            return;
+        }
+
         connection.logdebug(self, 'command state: ' + command);
         if (command === 'ehlo') {
             if (code.match(/^5/)) {
@@ -203,13 +211,5 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
             default:
                 throw new Error("[auth/auth_proxy] unknown command: " + command);
         }
-            }
-        }
-        else {
-            // Unrecognised response.
-            connection.logerror(self, "unrecognised response: " + line);
-            socket.end();
-            return;
-        }
     });
 };
```