### PR TITLE
xclient plugin improvements

### DIFF
--- a/docs/plugins/xclient.md
+++ b/docs/plugins/xclient.md
@@ -5,6 +5,7 @@ Implements the [XCLIENT](http://www.postfix.org/XCLIENT_README.html) protocol.
 
 ## configuration
 
-* xclient.hosts.ini
+* xclient.hosts
 
-    A list of IP addresses that should be allowed to use the XCLIENT protocol.
+    A list of IP addresses, one per line that should be allowed to use the 
+    XCLIENT protocol.  Localhost (127.0.0.1 or ::1) is allowed implicitly.


### PR DESCRIPTION
- Only offer XCLIENT in capabilities for hosts that are allowed to use it.  This is to workaround a bug in some software called 'CoreMail' which is Chinese.  It always tries to use XCLIENT if it is offered, we returns a 'Not authorized' and it sends the mail successfully, then generates a bounce to the sender with the XCLIENT rejection in it :8ball: 
- Fix documentation
- Implicitly allow localhost
- Speed-up lookups