### PR TITLE
ignore SPF permerror when aexp.com fsck their SPF record

### DIFF
--- a/plugins/greylist.js
+++ b/plugins/greylist.js
@@ -1,6 +1,6 @@
 // Greylisting Haraka plugin
 
-var version = '0.1.3';
+// version 0.1.3
 
 var util = require('util');
 var redis = require('redis');
@@ -302,7 +302,6 @@ exports.process_tuple = function (connection, sender, rcpt, cb) {
 // Checks if host is _white_. Updates stats if so.
 exports.check_and_update_white = function (connection, cb) {
     var plugin = this;
-    var ctr = connection.transaction.results;
 
     var key = plugin.craft_white_key(connection);
 

--- a/plugins/queue/rabbitmq.js
+++ b/plugins/queue/rabbitmq.js
@@ -7,7 +7,6 @@ var queueName;
 var connExchange_;
 var connQueue_;
 var routing_;
-var deliveryMode;
 exports.exchangeMapping = {}
 
 //This method registers the hook and try to initialize the connection to rabbitmq server for later use.

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -1,6 +1,5 @@
 var constants    = require('haraka-constants');
 
-var logger       = require('../logger');
 var connection   = require('../connection');
 
 // huge hack here, but plugin tests need constants

--- a/tests/spf.js
+++ b/tests/spf.js
@@ -36,23 +36,32 @@ exports.SPF = {
         this.SPF.mod_redirect('example.com', cb);
     },
     'mod_redirect, false': function (test) {
-        if (process.version !== 'v0.10.26') {
-            test.expect(2);
-            // var outer = this;
-            var cb = function (err, rc) {
-                test.equal(null, err);
-                test.equal(3, rc);
-                test.done();
-                // console.log(arguments);
-            };
-            this.SPF.count=0;
-            this.SPF.ip='212.70.129.94';
-            this.SPF.mail_from='fraud@aexp.com';
-            this.SPF.mod_redirect('aexp.com', cb);
-        }
-        else {
+        if (process.version === 'v0.10.26') {
             test.expect(0);
             test.done();
+            return;
         }
+
+        test.expect(2);
+        // var outer = this;
+        var cb = function (err, rc) {
+            test.equal(null, err);
+            if (rc === 7) {
+                // from time to time (this is the third time we've seen it,
+                // American Express publishes an invalid SPF record which results
+                // in a PERMERROR. Ignore it.
+                console.error("aexp SPF record is broken again");
+                test.equal(7, rc);
+            }
+            else {
+                test.equal(3, rc);
+            }
+            test.done();
+            // console.log(arguments);
+        };
+        this.SPF.count=0;
+        this.SPF.ip='212.70.129.94';
+        this.SPF.mail_from='fraud@aexp.com';
+        this.SPF.mod_redirect('aexp.com', cb);
     },
 };

--- a/tests/transaction.js
+++ b/tests/transaction.js
@@ -1,4 +1,3 @@
-var logger       = require('../logger'); // prevent compile errors in transaction.js.
 var Transaction  = require('../transaction');
 
 function _set_up(done) {


### PR DESCRIPTION

Changes proposed in this pull request:
- removes a couple unused variable lint errors
- ignores SPF permerror for aexp.com (happens from time to time)

Checklist:
- [x] tests updated
