### PR TITLE
Fix broken encoding on _char_to_qp

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -133,7 +133,7 @@ exports.decode_qp = function (line) {
 };
 
 function _char_to_qp (ch) {
-    var b = new Buffer(ch);
+    var b = new Buffer(ch, "binary");
     var r = '';
     for (var i=0; i<b.length; i++) {
         r = r + '=' + _pad(b[i].toString(16).toUpperCase(), 2);


### PR DESCRIPTION
Fixes #1417 .

Changes proposed in this pull request:
- Fix for the issue #1417, the encoding was broken on some frenchy characteres when add_filter was used, which seems to call this function.