### PR TITLE
Remove stray log error from list detection code

### DIFF
--- a/plugins/data.headers.js
+++ b/plugins/data.headers.js
@@ -367,7 +367,9 @@ exports.mailing_list = function (next, connection) {
                     found_mlm++;
                     continue;
                 }
-                connection.logerror(plugin, "mlm start miss: " + name + ': ' + header);
+                // NOTE: Unlike the next "j.match" code block, this condition alone
+                //       (Sender header != "owner-...") should not log an error
+                connection.logdebug(plugin, "mlm start miss: " + name + ': ' + header);
             }
             if (j.match) {
                 if (header.match(new RegExp(j.match,'i'))) {


### PR DESCRIPTION
Fixes 1.

Changes proposed in this pull request:
- Removal of incorrect log error from list detection code 

Checklist:
- [N/A] docs updated
- [N/A] tests updated

(Unless I'm overlooking something! ...) This removes an incorrect 
connection.logerror() from the (currently rudimentary) email
list detection code in the data.headers plugin.  As currently coded,
it would record an error to the log file for any email with a "Sender"
header that didn't start with "owner-".