### PR TITLE
Add IP whitelisting to early_talker

### DIFF
--- a/config/early_talker.ini
+++ b/config/early_talker.ini
@@ -4,3 +4,8 @@ pause=5
 
 ; terminate the connection? (default: true)
 ; reject=false
+
+; Whitelist of client IP ranges to skip delay on
+[ip_whitelist]
+::1
+127.0.0.1

--- a/docs/plugins/early_talker.md
+++ b/docs/plugins/early_talker.md
@@ -18,3 +18,5 @@ The config file early\_talker.ini has two options:
 - pause: the delay in seconds before each SMTP command. Default is no pause.
 
 - reject: whether or not to reject for early talkers. Default is true;
+
+- [ip_whitelist]: list of IP addresses and/or subnets to whitelist

--- a/plugins/early_talker.js
+++ b/plugins/early_talker.js
@@ -48,7 +48,7 @@ exports.early_talker = function(next, connection) {
     }
 
     // Don't delay whitelisted IPs
-    if (plugin.whitelist && plugin.ip_in_list(plugin.whitelist, connection.remote_ip)) { // check connecting IP
+    if (plugin.ip_in_list(connection.remote_ip)) { // check connecting IP
         connection.results.add(plugin, { skip: 'whitelist' });
         return next();
     }
@@ -79,21 +79,25 @@ exports.early_talker = function(next, connection) {
 
 
 /**
- * Check if the ip is whitelisted
+ * Check if an ip is whitelisted
  *
- * @param  {Array} whitelist A list of ipaddr objects
  * @param  {String} ip       The remote IP to verify
  * @return {Boolean}         True if is whitelisted
  */
-exports.ip_in_list = function (whitelist, ip) {
+exports.ip_in_list = function (ip) {
+    var plugin = this;
     var ipobj = ipaddr.parse(ip);
 
-    for (var i = 0; i < whitelist.length; i++) {
+    if (!plugin.whitelist) {
+        return false;
+    }
+
+    for (var i = 0; i < plugin.whitelist.length; i++) {
         try {
-            if (ipobj.match(whitelist[i])) {
+            if (ipobj.match(plugin.whitelist[i])) {
                 return true;
             }
-        } catch (e) {
+        } catch (ignore) {
         }
     }
     return false;
@@ -120,8 +124,8 @@ exports.load_ip_list = function(list) {
             }
 
             whitelist.push(addr);
-        } catch (e) {
+        } catch (ignore) {
         }
     }
     return whitelist;
-}
+};

--- a/plugins/early_talker.js
+++ b/plugins/early_talker.js
@@ -86,11 +86,12 @@ exports.early_talker = function(next, connection) {
  */
 exports.ip_in_list = function (ip) {
     var plugin = this;
-    var ipobj = ipaddr.parse(ip);
 
     if (!plugin.whitelist) {
         return false;
     }
+
+    var ipobj = ipaddr.parse(ip);
 
     for (var i = 0; i < plugin.whitelist.length; i++) {
         try {

--- a/tests/plugins/early_talker.js
+++ b/tests/plugins/early_talker.js
@@ -64,4 +64,39 @@ exports.early_talker = {
         this.connection.early_talker = true;
         this.plugin.early_talker(next, this.connection);
     },
+    'relay whitelisted ip': function (test) {
+        test.expect(3);
+        var next = function (rc, msg) {
+            test.equal(undefined, rc);
+            test.equal(undefined, msg);
+            test.ok(this.connection.results.has('early_talker', 'skip', 'whitelist'));
+            test.done();
+        }.bind(this);
+        this.plugin.pause = 1000;
+        this.plugin.whitelist = this.plugin.load_ip_list(['127.0.0.1']);
+        this.connection.remote_ip = '127.0.0.1';
+        this.connection.early_talker = true;
+        this.plugin.early_talker(next, this.connection);
+    },
+    'relay whitelisted subnet': function (test) {
+        test.expect(3);
+        var next = function (rc, msg) {
+            test.equal(undefined, rc);
+            test.equal(undefined, msg);
+            test.ok(this.connection.results.has('early_talker', 'skip', 'whitelist'));
+            test.done();
+        }.bind(this);
+        this.plugin.pause = 1000;
+        this.plugin.whitelist = this.plugin.load_ip_list(['127.0.0.0/16']);
+        this.connection.remote_ip = '127.0.0.88';
+        this.connection.early_talker = true;
+        this.plugin.early_talker(next, this.connection);
+    },
+    'test loading ip list': function (test) {
+        var whitelist = this.plugin.load_ip_list(['123.123.123.123', '127.0.0.0/16']);
+        test.expect(2);
+        test.equal(whitelist[0][1], 32);
+        test.equal(whitelist[1][1], 16);
+        test.done();
+    },
 };


### PR DESCRIPTION
The early_talker plugin currently causes delays even when submitting from localhost, which is quite unnecessary. The additional delay at DATA makes things even worse.

This change adds an ip_whitelist to the early talker plugin, based on the pattern used by the greylisting and xclient plugins. By default it includes 127.0.0.1 and ::1.

Includes tests and docs.