### PR TITLE
auth_ldap fixes

### DIFF
--- a/docs/plugins/auth/auth_ldap.md
+++ b/docs/plugins/auth/auth_ldap.md
@@ -5,6 +5,11 @@ The `auth/auth_ldap` plugin uses an LDAP bind to authenticate a user. Currently
 only one server and multiple DNs can be configured. If any of the DN binds succeed, 
 the user is authenticated. 
 
+**IMPORANT NOTE** - this plugin requires that STARTTLS be used via the tls plugin
+before it will advertise AUTH capabilities by the EHLO command.  This is to
+improve security out-of-the-box.   Localhost and any IP in RFC1918 ranges
+are automatically exempt from this rule.
+
 Configuration
 -------------
 

--- a/plugins/auth/auth_ldap.js
+++ b/plugins/auth/auth_ldap.js
@@ -2,10 +2,11 @@
 
 var ldap  = require('ldapjs');
 var async = require('async');
+var net_utils = require('./net_utils');
 
 exports.hook_capabilities = function (next, connection) {
-    // Don't offer AUTH capabilities by default unless session is encrypted
-    if (connection.using_tls) {
+    // Don't offer AUTH capabilities by default unless private ip or session is encrypted
+    if (net_utils.is_private_ip(connection.remote_ip) || connection.using_tls) {
         var methods = [ 'LOGIN' ];
         connection.capabilities.push('AUTH ' + methods.join(' '));
         connection.notes.allowed_auth_methods = methods;

--- a/plugins/auth/auth_ldap.js
+++ b/plugins/auth/auth_ldap.js
@@ -36,6 +36,11 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
         }
     });
 
+    client.on('error', function (err) {
+        connection.loginfo('auth_ldap: client error ' + err.message);
+        cb(false);
+    });
+
     config.dns = Object.keys(config.dns).map(function (v) {
         return config.dns[v];
     })


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Advertise AUTH without TLS for private ips in auth_ldap . This is similar to auth_flat.
- Handle LDAP client connection failure. When the LDAP server is down, haraka crashes because of missing error handler.

Checklist:
- [X ] docs updated
- [X ] tests updated
