### PR TITLE
pass connection object to get_plain_passwd

### DIFF
--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -22,7 +22,7 @@ exports.hook_capabilities = function (next, connection) {
 };
 
 // Override this at a minimum. Run cb(passwd) to provide a password.
-exports.get_plain_passwd = function (user, cb) {
+exports.get_plain_passwd = function (user, cb, connection) {
     return cb();
 };
 
@@ -52,7 +52,7 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
         if (plain_pw === null  ) { return cb(false); }
         if (plain_pw !== passwd) { return cb(false); }
         return cb(true);
-    });
+    }, connection);
 };
 
 exports.check_cram_md5_passwd = function (connection, user, passwd, cb) {
@@ -68,7 +68,7 @@ exports.check_cram_md5_passwd = function (connection, user, passwd, cb) {
             return cb(true);
         }
         return cb(false);
-    });
+    }, connection);
 };
 
 exports.check_user = function (next, connection, credentials, method) {

--- a/plugins/auth/auth_vpopmaild.js
+++ b/plugins/auth/auth_vpopmaild.js
@@ -106,7 +106,7 @@ exports.get_vpopmaild_socket = function (user) {
     return socket;
 };
 
-exports.get_plain_passwd = function (user, cb) {
+exports.get_plain_passwd = function (user, cb, connection) {
     var plugin = this;
 
     var socket = plugin.get_vpopmaild_socket(user);

--- a/plugins/auth/flat_file.js
+++ b/plugins/auth/flat_file.js
@@ -34,7 +34,7 @@ exports.hook_capabilities = function (next, connection) {
     next();
 };
 
-exports.get_plain_passwd = function (user, cb) {
+exports.get_plain_passwd = function (user, cb, connection) {
     var plugin = this;
     if (plugin.cfg.users[user]) {
         return cb(plugin.cfg.users[user].toString());

--- a/tests/plugins/auth/auth_base.js
+++ b/tests/plugins/auth/auth_base.js
@@ -10,7 +10,8 @@ var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('auth/auth_base');
 
-    this.plugin.get_plain_passwd = function (user, cb) {
+    this.plugin.get_plain_passwd = function (user, cb, connection) {
+        connection.notes.auth_custom_note = 'custom_note';
         if (user === 'test') return cb('testpass');
         return cb(null);
     };
@@ -56,14 +57,14 @@ exports.get_plain_passwd = {
             test.expect(1);
             test.equal(pass, null);
             test.done();
-        });
+        }, this.connection);
     },
     'get_plain_passwd, test user': function (test) {
         this.plugin.get_plain_passwd('test', function (pass) {
             test.expect(1);
             test.equal(pass, 'testpass');
             test.done();
-        });
+        }, this.connection);
     },
 };
 
@@ -161,9 +162,10 @@ exports.check_user = {
     setUp : _set_up,
     'bad auth': function (test) {
         var next = function (code) {
-            test.expect(2);
+            test.expect(3);
             test.equal(code, OK);
             test.equal(this.connection.relaying, false);
+            test.equal(this.connection.notes.auth_custom_note, 'custom_note');
             test.done();
         }.bind(this);
         var credentials = ['matt','ttam'];
@@ -171,9 +173,10 @@ exports.check_user = {
     },
     'good auth': function (test) {
         var next = function (code) {
-            test.expect(2);
+            test.expect(3);
             test.equal(code, OK);
             test.ok(this.connection.relaying);
+            test.equal(this.connection.notes.auth_custom_note, 'custom_note');
             test.done();
         }.bind(this);
         var credentials = ['test','testpass'];


### PR DESCRIPTION
Changes proposed in this pull request:
Make the `connection` object accessible when `get_plain_passwd()` is being called. To avoid backwards incompatibilities, this has been added as an additional 3rd parameter. The reasoning behind this change is that one might wants to push data to the `notes` object, in order to persist information about the user.

Checklist:
- [ ] docs updated
- [x] tests updated

