### PR TITLE
rcpt_to_ldap fixes

### DIFF
--- a/plugins/rcpt_to.ldap.js
+++ b/plugins/rcpt_to.ldap.js
@@ -66,6 +66,11 @@ exports.ldap_rcpt = function(next, connection, params) {
         return next();
     }
 
+    client.on('error', function (err) {
+        connection.loginfo(plugin, 'client error ' + err.message);
+        next();
+    });
+
     client.bind(cfg.binddn, cfg.bindpw, function(err) {
         connection.logerror(plugin, 'error: ' + err);
     });

--- a/plugins/rcpt_to.ldap.js
+++ b/plugins/rcpt_to.ldap.js
@@ -53,7 +53,7 @@ exports.ldap_rcpt = function(next, connection, params) {
 
     txn.results.add(plugin, { msg: 'connecting' });
 
-    var cfg = plugin.in_host_list(domain) ? plugin.cfg.main : plugin.cfg[domain];
+    var cfg = plugin.cfg[domain] || plugin.cfg.main;
     if (!cfg) {
         connection.logerror(plugin, 'no LDAP config for ' + domain);
         return next();

--- a/plugins/rcpt_to.ldap.js
+++ b/plugins/rcpt_to.ldap.js
@@ -68,7 +68,7 @@ exports.ldap_rcpt = function(next, connection, params) {
 
     client.on('error', function (err) {
         connection.loginfo(plugin, 'client error ' + err.message);
-        next();
+        next(DENYSOFT, 'Backend failure. Please, retry later');
     });
 
     client.bind(cfg.binddn, cfg.bindpw, function(err) {
@@ -81,6 +81,7 @@ exports.ldap_rcpt = function(next, connection, params) {
     var search_result = function(err, res) {
         if (err) {
             connection.logerror(plugin, 'LDAP search error: ' + err);
+            return next(DENYSOFT, 'Backend failure. Please, retry later');
         }
         var items = [];
         res.on('searchEntry', function(entry) {
@@ -88,8 +89,9 @@ exports.ldap_rcpt = function(next, connection, params) {
             items.push(entry.object);
         });
 
-        res.on('error', function(err2) {
+        res.on('error', function(err2) { // called for tcp (non-ldap) errors
             connection.logerror(plugin, 'LDAP search error: ' + err2);
+            next(DENYSOFT, 'Backend failure. Please, retry later');
         });
 
         res.on('end', function(result) {


### PR DESCRIPTION
Changes proposed in this pull request:
- rcpt_to.ldap: handle connection error:  without this haraka crashes if ldap server is down
- ~~ldapjs is a required dependacy: ldapjs is in package.json~~ (removed since it is an optional dep)
- pick up domain specific config correctly: code incorrectly uses setting based on host_list file
- soft deny on ldap client and search errors: code incorrectly allows rcpt to's if the ldap server is down or generated an error.

Checklist:
- [X ] docs updated
- [X ] tests updated
