### PR TITLE
Outbound pool support

### DIFF
--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -71,6 +71,20 @@ enables more flexibility in mail delivery and bounce handling.
 Default: "Haraka outbound". This text is attached as a `Received` header to
 all outbound mail just before it is queued.
 
+* `connect_timeout`
+
+Timeout for connecting to remote servers. Default: 30s
+
+* `pool_timeout`
+
+Outbound mail uses "pooled" connections. An unused pool connection will send
+a QUIT after this time. Default: 300s
+
+Pooled connections means that a mail to a particular IP address will hold that
+connection open and use it the next time it is requested. This helps with
+large scale outbound mail. If you don't send lots of mail it is advised to
+lower the `pool_timeout` value since it may upset receiving mail servers.
+
 ### outbound.bounce\_message
 
 See "Bounce Messages" below for details.

--- a/outbound.js
+++ b/outbound.js
@@ -25,6 +25,8 @@ var DSN         = require('./dsn');
 var date_to_str = utils.date_to_str;
 var existsSync  = utils.existsSync;
 var FsyncWriteStream = require('./fsync_writestream');
+var generic_pool = require('generic-pool');
+var server      = require('./server');
 
 var core_consts = require('constants');
 var WRITE_EXCL  = core_consts.O_CREAT | core_consts.O_TRUNC | core_consts.O_WRONLY | core_consts.O_EXCL;
@@ -65,6 +67,12 @@ exports.load_config = function () {
     }
     if (!cfg.concurrency_max) {
         cfg.concurrency_max = config.get('outbound.concurrency_max') || 100;
+    }
+    if (!cfg.connect_timeout) {
+        cfg.connect_timeout = 30;
+    }
+    if (!cfg.pool_timeout) {
+        cfg.pool_timeout = 300;
     }
     if (!cfg.ipv6_enabled && config.get('outbound.ipv6_enabled')) {
         cfg.ipv6_enabled = true;
@@ -157,10 +165,28 @@ process.on('message', function (msg) {
     }
     if (msg.event && msg.event == 'outbound.shutdown') {
         logger.loginfo("[outbound] Shutting down temp fail queue");
+        exports.drain_pools();
         temp_fail_queue.shutdown();
+        return;
+    }
+    if (msg.event && msg.event === 'outbound.drain_pools') {
+        exports.drain_pools();
+        return;
     }
     // ignores the message
 });
+
+exports.drain_pools = function () {
+    if (!server.notes.pool) {
+        return;
+    }
+    for (var p in server.notes.pool) {
+        logger.logdebug("Draining SMTP connection pool " + p);
+        server.notes.pool[p].drain(function() {
+            server.notes.pool[p].destroyAllNow();
+        });
+    }
+}
 
 exports.flush_queue = function (domain, pid) {
     if (domain) {
@@ -1073,70 +1099,170 @@ var cram_md5_response = function (username, password, challenge) {
     return utils.base64(username + ' ' + digest);
 }
 
+// Separate pools are kept for each set of server attributes.
+function get_pool (port, host, local_addr, connect_timeout, pool_timeout, max) {
+    port = port || 25;
+    host = host || 'localhost';
+    connect_timeout = (connect_timeout === undefined) ? 30 : connect_timeout;
+    pool_timeout = (pool_timeout === undefined) ? 300 : pool_timeout;
+    var name = 'outbound::' + port + ':' + host + ':' + local_addr + ':' + pool_timeout;
+    if (!server.notes.pool) {
+        server.notes.pool = {};
+    }
+    if (!server.notes.pool[name]) {
+        var pool = generic_pool.Pool({
+            name: name,
+            create: function (callback) {
+                var socket = sock.connect({port: port, host: host, localAddress: local_addr});
+                socket.setTimeout(connect_timeout * 1000);
+                logger.logdebug('[outbound] host=' +
+                    host + ' port=' + port + ' pool_timeout=' + pool_timeout + ' created');
+                socket.once('connect', function () {
+                    socket.removeAllListeners('error'); // these get added after callback
+                    callback(null, socket);
+                });
+                socket.once('error', function (err) {
+                    socket.end();
+                    callback("Outbound connection error: " + err, null);
+                });
+                socket.once('timeout', function () {
+                    socket.end();
+                    callback("Outbound connection timed out to " + host + ":" + port, null);
+                });
+            },
+            destroy: function(socket) {
+                logger.logdebug('[outbound] destroyed pool entry for ' + host + ':' + port);
+                socket.send_command('QUIT');
+                socket.once('line', function (line) {
+                    // Just assume this is a valid response
+                    logger.logprotocol("[outbound] S: " + line);
+                    socket.end();
+                });
+                // Remove pool object from server notes once empty
+                var size = pool.getPoolSize();
+                if (size === 0) {
+                    delete server.notes.pool[name];
+                }
+            },
+            max: max || 1000,
+            idleTimeoutMillis: pool_timeout * 1000,
+            log: function (str, level) {
+                if (/this._availableObjects.length=/.test(str)) return;
+                level = (level === 'verbose') ? 'debug' : level;
+                logger['log' + level]('[outbound] [' + name + '] ' + str);
+            }
+        });
+        server.notes.pool[name] = pool;
+    }
+    return server.notes.pool[name];
+};
+
+// Get a socket for the given attributes.
+function get_client (port, host, local_addr, callback) {
+    var pool = get_pool(port, host, local_addr, cfg.connect_timeout, cfg.pool_timeout, cfg.concurrency_max);
+    pool.acquire(callback);
+};
+
+function release_client (socket, port, host, local_addr) {
+    var pool_timeout = cfg.pool_timeout || 300;
+    var name = 'outbound::' + port + ':' + host + ':' + local_addr + ':' + pool_timeout;
+    if (!(server.notes && server.notes.pool)) {
+        logger.logcrit("[outbound] Releasing a pool (" + name + ") that doesn't exist!");
+        return;
+    }
+    var pool = server.notes.pool[name];
+    if (!pool) {
+        logger.logcrit("[outbound] Releasing a pool (" + name + ") that doesn't exist!");
+        return;
+    }
+
+    socket.removeAllListeners('close');
+    socket.removeAllListeners('error');
+    socket.removeAllListeners('close');
+    socket.removeAllListeners('timeout');
+    socket.removeAllListeners('line');
+
+    socket.once('error', function (err) {
+        logger.logerror("[outbound] Pooled connection dropped from " + host + ":" + port + " : " + err);
+        delete server.notes.pool[name];
+    });
+
+    socket.__fromPool = true;
+
+    pool.release(socket);
+}
+
 HMailItem.prototype.try_deliver_host = function (mx) {
-    if (this.hostlist.length === 0) {
-        return this.try_deliver(); // try next MX
+    var self = this;
+
+    if (self.hostlist.length === 0) {
+        return self.try_deliver(); // try next MX
     }
 
     // Allow transaction notes to set outbound IP
-    if (!mx.bind && this.todo.notes.outbound_ip) {
-        mx.bind = this.todo.notes.outbound_ip;
+    if (!mx.bind && self.todo.notes.outbound_ip) {
+        mx.bind = self.todo.notes.outbound_ip;
     }
 
     // Allow transaction notes to set outbound IP helo
     if (!mx.bind_helo){
-        if (this.todo.notes.outbound_helo) {
-            mx.bind_helo = this.todo.notes.outbound_helo;
+        if (self.todo.notes.outbound_helo) {
+            mx.bind_helo = self.todo.notes.outbound_helo;
         }
         else {
             mx.bind_helo = config.get('me');
         }
     }
 
-    var host = this.hostlist.shift();
-    var port            = mx.port || 25;
-    var socket;
+    var host = self.hostlist.shift();
+    var port = mx.port || 25;
+
     if (mx.path) {
-        socket = sock.connect({path: mx.path});
+        var socket = sock.connect({path: mx.path});
+
+        self.loginfo("Attempting to deliver to: " + mx.path +
+            (mx.using_lmtp ? " using LMTP" : "") + " (" + delivery_queue.length() +
+            ") (" + temp_fail_queue.length() + ")");
+
+        return self.try_deliver_host_on_socket(mx, mx.path, port, socket);
     }
-    else {
-        socket = sock.connect({port: port, host: host, localAddress: mx.bind});
-    }
-
-    this.try_deliver_host_on_socket(mx, host, port, socket);
-}
-
-// Introduced for testability
-HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socket) {
-    // Args host and port are the same as used for socket. However, can't get them back from socket right now.
-
-    var self            = this;
-    var processing_mail = true;
 
     this.loginfo("Attempting to deliver to: " + host + ":" + port +
         (mx.using_lmtp ? " using LMTP" : "") + " (" + delivery_queue.length() +
         ") (" + temp_fail_queue.length() + ")");
 
-    socket.on('error', function (err) {
+    get_client(port, host, mx.bind, function (err, socket) {
+        if (err) {
+            logger.logerror('[outbound] Failed to get pool entry: ' + err);
+            // try next host
+            return self.try_deliver_host(mx);
+        }
+        self.try_deliver_host_on_socket(mx, host, port, socket);
+    });
+}
+
+HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socket) {
+    var self            = this;
+    var processing_mail = true;
+
+    socket.removeAllListeners('error');
+
+    socket.once('error', function (err) {
         if (processing_mail) {
             self.logerror("Ongoing connection failed to " + host + ":" + port + " : " + err);
             processing_mail = false;
+            release_client(socket, port, host, mx.bind);
             // try the next MX
             self.try_deliver_host(mx);
         }
     });
 
-    socket.on('close', function () {
+    socket.once('close', function () {
         if (processing_mail) {
             processing_mail = false;
+            release_client(socket, port, host, mx.bind);
             return self.try_deliver_host(mx);
         }
-    });
-
-    socket.setTimeout(30 * 1000); // TODO: make this configurable
-
-    socket.on('connect', function () {
-        socket.setTimeout(300 * 1000); // TODO: make this configurable
     });
 
     var command = mx.using_lmtp ? 'connect_lmtp' : 'connect';
@@ -1163,7 +1289,7 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
 
     var tls_config = tls_socket.load_tls_ini();
 
-    var send_command = function (cmd, data) {
+    var send_command = socket.send_command = function (cmd, data) {
         if (!socket.writable) {
             self.logerror("Socket writability went away");
             if (processing_mail) {
@@ -1307,17 +1433,8 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
         else {
             self.discard();
         }
-        send_command('QUIT');
+        release_client(socket, port, host, mx.bind);
     };
-
-    socket.on('timeout', function () {
-        if (processing_mail) {
-            self.logerror("Outbound connection timed out to " + host + ":" + port);
-            processing_mail = false;
-            socket.end();
-            self.try_deliver_host(mx);
-        }
-    });
 
     socket.on('line', function (line) {
         if (!processing_mail) {
@@ -1370,8 +1487,9 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
                         rcpt.dsn_smtp_response = response.join(' ');
                         rcpt.dsn_remote_mta = mx.exchange;
                     });
-                    send_command('QUIT');
+                    send_command('RSET');
                     processing_mail = false;
+                    release_client(socket, port, host, mx.bind);
                     return self.temp_fail("Upstream error: " + code + " " + ((extc) ? extc + ' ' : '') + reason);
                 }
                 else if (code.match(/^4/)) {
@@ -1408,8 +1526,9 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
                             rcpt.dsn_smtp_response = response.join(' ');
                             rcpt.dsn_remote_mta = mx.exchange;
                         });
-                        send_command('QUIT');
+                        send_command('RSET');
                         processing_mail = false;
+                        release_client(socket, port, host, mx.bind);
                         return self.temp_fail("Upstream error: " + code + " " + ((extc) ? extc + ' ' : '') + reason);
                     }
                 }
@@ -1449,8 +1568,9 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
                             rcpt.dsn_smtp_response = response.join(' ');
                             rcpt.dsn_remote_mta = mx.exchange;
                         });
-                        send_command('QUIT');
+                        send_command('RSET');
                         processing_mail = false;
+                        release_client(socket, port, host, mx.bind);
                         return self.bounce(reason, { mx: mx });
                     }
                 }
@@ -1520,6 +1640,7 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
                                 send_command('DATA');
                             }
                             else {
+                                send_command('RSET');
                                 finish_processing_mail(false);
                             }
                         }
@@ -1552,7 +1673,9 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
                         }
                         break;
                     case 'quit':
-                        socket.end();
+                        self.logerror("We should NOT have sent QUIT from here...");
+                        break;
+                    case 'rset':
                         break;
                     default:
                         // should never get here - means we did something
@@ -1565,13 +1688,18 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
             // Unrecognized response.
             self.logerror("Unrecognized response from upstream server: " + line);
             processing_mail = false;
-            socket.end();
+            release_client(socket, port, host, mx.bind);
             self.todo.rcpt_to.forEach(function (rcpt) {
                 self.extend_rcpt_with_dsn(rcpt, DSN.proto_invalid_command("Unrecognized response from upstream server: " + line));
             });
             return self.bounce("Unrecognized response from upstream server: " + line, {mx: mx});
         }
     });
+
+    if (socket.__fromPool) {
+        logger.logdebug('[outbound] got pooled socket, trying to deliver');
+        send_command('MAIL', 'FROM:' + self.todo.mail_from);
+    }
 };
 
 HMailItem.prototype.extend_rcpt_with_dsn = function(rcpt, dsn) {
@@ -1910,6 +2038,7 @@ HMailItem.prototype.convert_temp_failed_to_bounce = function (err, extra) {
 }
 
 HMailItem.prototype.temp_fail = function (err, extra) {
+    logger.logdebug("Temp fail for: " + err);
     this.num_failures++;
 
     // Test for max failures which is configurable.

--- a/server.js
+++ b/server.js
@@ -167,6 +167,16 @@ Server._graceful = function (shutdown) {
     });
 }
 
+Server.drainPools = function () {
+    if (!Server.cluster) {
+        return out.drain_pools();
+    }
+
+    for (var id in cluster.workers) {
+        cluster.workers[id].send({event: 'outbound.drain_pools'});
+    }
+};
+
 Server.sendToMaster = function (command, params) {
     // console.log("Send to master: ", command);
     if (Server.cluster) {

--- a/tests/outbound_protocol/basic_outbound_trial_test.js
+++ b/tests/outbound_protocol/basic_outbound_trial_test.js
@@ -71,7 +71,7 @@ function _runBasicSmtpConversation(hmail) {
         { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
         { 'from': 'remote', 'line': '500 5.0.0 Absolutely not acceptable. Basic Test Only.' },
 
-        { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+        { 'from': 'haraka', 'test': 'RSET', end_test: true }, // this will trigger calling the callback
     ];
 
     util_hmailitem.playTestSmtpConversation(hmail, mock_socket, test, testPlaybook, function() {

--- a/tests/outbound_protocol/outbound_bounce_rfc3464.js
+++ b/tests/outbound_protocol/outbound_bounce_rfc3464.js
@@ -57,7 +57,7 @@ async.series(
                     { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
                     { 'from': 'remote', 'line': '500 5.0.0 Absolutely not acceptable. Basic Test Only.' },
 
-                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                    { 'from': 'haraka', 'test': 'RSET', end_test: true }, // this will trigger calling the callback
                 ];
 
                 util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
@@ -90,7 +90,7 @@ async.series(
                     { 'from': 'haraka', 'test': 'MAIL FROM:<sender@domain>' },
                     { 'from': 'remote', 'line': '300 3.0.0 No time for you right now' },
 
-                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                    { 'from': 'haraka', 'test': 'RSET', end_test: true }, // this will trigger calling the callback
                 ];
 
                 util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
@@ -126,7 +126,7 @@ async.series(
                     { 'from': 'haraka', 'test': 'RCPT TO:<recipient@domain>' },
                     { 'from': 'remote', 'line': '400 4.0.0 Currently not available. Try again later.' },
 
-                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                    { 'from': 'haraka', 'test': 'RSET', end_test: true }, // this will trigger calling the callback
                 ];
 
                 util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
@@ -167,7 +167,7 @@ async.series(
                     // haraka will send us more lines
                     { 'from': 'remote', 'line': '450 4.6.0 Currently I do not like ascii art cats.' },
 
-                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                    { 'from': 'haraka', 'test': 'RSET', end_test: true }, // this will trigger calling the callback
                 ];
 
                 util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
@@ -206,7 +206,7 @@ async.series(
                     { 'from': 'haraka', 'test': 'RCPT TO:<recipient@domain>' },
                     { 'from': 'remote', 'line': '550 5.1.1 Not available and will not come back' },
 
-                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                    { 'from': 'haraka', 'test': 'RSET', end_test: true }, // this will trigger calling the callback
                 ];
 
                 util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {
@@ -249,7 +249,7 @@ async.series(
                     // haraka will send us more lines
                     { 'from': 'remote', 'line': '550 5.6.0 I never did and will like ascii art cats.' },
 
-                    { 'from': 'haraka', 'test': 'QUIT', end_test: true }, // this will trigger calling the callback
+                    { 'from': 'haraka', 'test': 'RSET', end_test: true }, // this will trigger calling the callback
                 ];
 
                 util_hmailitem.playTestSmtpConversation(mock_hmail, mock_socket, test, testPlaybook, function() {


### PR DESCRIPTION
I'd probably suggest holding off merging this until after 2.8.1, but I'd also like it to be well examined, since it has a huge impact on anyone using outbound.

Please read the code and comment.

Changes proposed in this pull request:
- Uses generic-pool much like smtp_client does

Checklist:
- [x] docs updated
- [x] tests updated
