### PR TITLE
Graceful shutdown and restart

### DIFF
--- a/bin/haraka
+++ b/bin/haraka
@@ -9,6 +9,7 @@ var fs   = require('fs'),
     path = require('path'),
     nopt = require("nopt"),
     os   = require('os'),
+    async = require('async'),
     sprintf = require('sprintf-js').sprintf,
     path = require('path'),
     base = path.join(__dirname, '..'),
@@ -25,7 +26,8 @@ var fs   = require('fs'),
         "qlist":       Boolean,
         "qstat":       Boolean,
         "qempty":      Boolean,
-        "qunstick":    String,
+        "qunstick":    [String, null],
+        "graceful":    Boolean,
         "order":       Boolean,
         "test":        [String, Array],
         "ip":          String,
@@ -382,29 +384,36 @@ else if (parsed.qunstick) {
     var logger = require(path.join(base, "logger"));
     if (!parsed.verbose)
         logger.log = function () {} // disable logging for this
+    var cb = function () {
+        process.exit();
+    };
+    if (domain == 'true') {
+        send_internal_command('flushQueue', cb);
+    }
+    else {
+        send_internal_command('flushQueue ' + domain, cb);
+    }
+}
+else if (parsed.graceful) {
+    if (!parsed.configs) {
+        fail("graceful option requires config path");
+    }
+    process.env.HARAKA = parsed.configs;
+    var logger = require(path.join(base, "logger"));
+    if (!parsed.verbose)
+        logger.log = function () {} // disable logging for this
     var config = require(path.join(base, "config"));
     var key = config.get("internalcmd_key");
     var smtp_ini = config.get("smtp.ini");
-    var listen_addrs = require(path.join(base, "server")).get_listen_addrs(smtp_ini.main);
-    var hp = /^\[?([^\]]+)\]?:(\d+)$/.exec(listen_addrs[0]);
-    if (!hp) throw "No listen address in smtp.ini";
-    console.log("Connecting to " + listen_addrs[0]);
-    var sock = require('net').connect(hp[2], hp[1], function () {
-        sock.once('data', function (data) {
-            // this is the greeting. Ignore it...
-            sock.write('INTERNALCMD ' + (key ? ('key:' + key + ' ') : '') + 'flushQueue ' + domain + '\r\n');
-            sock.once('data', function (data) {
-                console.log(data.toString());
-                sock.write('QUIT\r\n');
-                sock.once('data', function (data) {
-                    sock.end();
-                })
-            });
-        });
-    });
-    sock.on('end', function () {
+    if (!smtp_ini.main.nodes) {
+        console.log("Graceful restart not possible without `nodes` value in smtp.ini");
         process.exit();
-    })
+    }
+    else {
+        send_internal_command('gracefulRestart', function () {
+            process.exit();
+        });
+    }
 }
 else if (parsed.qempty) {
     if (!parsed.configs) {
@@ -641,4 +650,28 @@ else if (parsed.install) {
 else {
     console.log("\033[31;40mError\033[0m: Undefined or erroneous arguments\n");
     console.log(usage);
+}
+
+function send_internal_command (cmd, cb) {
+    var config = require(path.join(base, "config"));
+    var key = config.get("internalcmd_key");
+    var smtp_ini = config.get("smtp.ini");
+    var listen_addrs = require(path.join(base, "server")).get_listen_addrs(smtp_ini.main);
+    var hp = /^\[?([^\]]+)\]?:(\d+)$/.exec(listen_addrs[0]);
+    if (!hp) throw "No listen address in smtp.ini";
+    // console.log("Connecting to " + listen_addrs[0]);
+    var sock = require('net').connect(hp[2], hp[1], function () {
+        sock.once('data', function (data) {
+            // this is the greeting. Ignore it...
+            sock.write('INTERNALCMD ' + (key ? ('key:' + key + ' ') : '') + cmd + '\r\n');
+            sock.once('data', function (data) {
+                console.log(data.toString().replace(/\r?\n$/, ''));
+                sock.write('QUIT\r\n');
+                sock.once('data', function (data) {
+                    sock.end();
+                })
+            });
+        });
+    });
+    sock.on('end', cb);
 }

--- a/configfile.js
+++ b/configfile.js
@@ -223,6 +223,13 @@ cfreader.ensure_enoent_timer = function () {
     }, 60 * 1000);
 };
 
+process.on('message', function (msg) {
+    if (msg.event && msg.event == 'cfreader.shutdown') {
+        logger.loginfo("[cfreader] Shutting down enoent timer");
+        clearInterval(cfreader._enoent_timer);
+    }
+});
+
 cfreader.empty_config = function(type) {
     if (type === 'ini') {
         return { main: {} };

--- a/connection.js
+++ b/connection.js
@@ -1177,7 +1177,7 @@ Connection.prototype.cmd_internalcmd = function (line) {
     }
 
     require('./server').sendToMaster(command, results);
-    return this.respond(250, "Command sent for execution. Check logs for results.");
+    return this.respond(250, "Command sent for execution. Check Haraka logs for results.");
 }
 
 Connection.prototype.cmd_helo = function(line) {

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -223,7 +223,7 @@ The Outbound hook ordering mirrors the Inbound hook order above until after `hoo
   - hook_deferred  (once per delivery domain where at least one recipient or connection was deferred)
   - hook_bounce  (once per delivery domain where the recipient(s) or message was rejected by the destination)
 
-# Plugin Run Order
+## Plugin Run Order
 
 Plugins are run on each hook in the order that they are specified in `config/plugins`. When a plugin returns anything other than `next()` on a hook, all subsequent plugins due to run on that hook are skipped (exceptions: connect_init, disconnect).
 
@@ -331,6 +331,25 @@ and provides a global `server` object. To access the `server` object, use
 
 Module plugins support default config in their local `config` directory. See the
 "Default Config and Overrides" section in [Config](Config.md).
+
+## Shutdown
+
+On shutdown and graceful reload, Haraka will call a plugin's `shutdown` method.
+
+This is so you can clear any timers or intervals, or shut down any connections
+to remote servers.
+
+e.g.
+
+    exports.shutdown = function () {
+        clearInterval(this._interval);
+    }
+
+If you don't implement this in your plugin and have a connection open or a
+timer running then Haraka will take 30 seconds to shut down and have to
+forcibly kill your process.
+
+Note: This only applies when running with a `nodes=...` value in smtp.ini.
 
 ## See also, [Results](Results.md)
 

--- a/haraka.js
+++ b/haraka.js
@@ -37,11 +37,18 @@ process.on('uncaughtException', function (err) {
     logger.dump_and_exit(1);
 });
 
+var shutting_down = false;
 ['SIGTERM', 'SIGINT'].forEach(function (sig) {
     process.on(sig, function () {
+        if (shutting_down) return process.exit(1);
+        shutting_down = true;
         process.title = path.basename(process.argv[1], '.js');
         logger.lognotice(sig + ' received');
-        logger.dump_and_exit(1);
+        logger.dump_and_exit(function () {
+            if (server.cluster && server.cluster.isMaster) {
+                server.gracefulShutdown();
+            }
+        });
     });
 });
 
@@ -51,6 +58,7 @@ process.on('SIGHUP', function () {
 });
 
 process.on('exit', function(code) {
+    if (shutting_down) return;
     process.title = path.basename(process.argv[1], '.js');
     logger.lognotice('Shutting down');
     logger.dump_logs();

--- a/logger.js
+++ b/logger.js
@@ -72,6 +72,7 @@ logger.dump_logs = function (cb) {
 
 logger.dump_and_exit = function (code) {
     this.dump_logs(function () {
+        if (util.isFunction(code)) return code();
         process.exit(code);
     });
 }

--- a/outbound.js
+++ b/outbound.js
@@ -155,6 +155,10 @@ process.on('message', function (msg) {
         exports.flush_queue(msg.domain, process.pid);
         return;
     }
+    if (msg.event && msg.event == 'outbound.shutdown') {
+        logger.loginfo("[outbound] Shutting down temp fail queue");
+        temp_fail_queue.shutdown();
+    }
     // ignores the message
 });
 

--- a/plugins.js
+++ b/plugins.js
@@ -30,6 +30,21 @@ function Plugin (name) {
     this.hooks = {};
 }
 
+exports.shutdown_plugins = function () {
+    for (var i in exports.registered_plugins) {
+        if (exports.registered_plugins[i].shutdown) {
+            exports.registered_plugins[i].shutdown();
+        }
+    }
+}
+
+process.on('message', function (msg) {
+    if (msg.event && msg.event == 'plugins.shutdown') {
+        logger.loginfo("[plugins] Shutting down plugins");
+        exports.shutdown_plugins();
+    }
+});
+
 Plugin.prototype.core_require = function (name) {
     return require('./' + name);
 };
@@ -136,6 +151,11 @@ Plugin.prototype.inherits = function (parent_name) {
         if (!this[method]) {
             this[method] = parent_plugin[method];
         }
+        // else if (method == 'shutdown') { // Method is in this module, so it exists in the plugin
+        //     if (!this.hasOwnProperty('shutdown')) {
+        //         this[method] = parent_plugin[method];
+        //     }
+        // }
     }
     if (parent_plugin.register) {
         parent_plugin.register.call(this);

--- a/plugins/connect.p0f.js
+++ b/plugins/connect.p0f.js
@@ -62,6 +62,12 @@ function P0FClient(path) {
     connect();
 }
 
+P0FClient.prototype.shutdown = function () {
+    if (self.restart_interval) {
+        clearInterval(self.restart_interval);
+    }
+}
+
 P0FClient.prototype.decode_response = function (data) {
     var decode_string = function (data2, start, end) {
         var str = '';

--- a/plugins/dns_list_base.js
+++ b/plugins/dns_list_base.js
@@ -192,8 +192,10 @@ exports.check_zones = function (interval) {
 };
 
 exports.shutdown = function () {
-    this.logdebug("Shutting down re-test interval");
     clearInterval(this._interval);
+    if (redis_client) {
+        redis_client.end();
+    }
 };
 
 exports.disable_zone = function (zone, result) {

--- a/plugins/dns_list_base.js
+++ b/plugins/dns_list_base.js
@@ -191,6 +191,11 @@ exports.check_zones = function (interval) {
     }
 };
 
+exports.shutdown = function () {
+    this.logdebug("Shutting down re-test interval");
+    clearInterval(this._interval);
+};
+
 exports.disable_zone = function (zone, result) {
     if (!zone) return false;
     if (!this.zones) return false;

--- a/plugins/greylist.js
+++ b/plugins/greylist.js
@@ -137,6 +137,12 @@ exports.redis_onInit = function (next, server) {
     });
 };
 
+exports.shutdown = function () {
+    if (this.redis) {
+        this.redis.end();
+    }
+}
+
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // We check for IP and envelope whitelist

--- a/plugins/process_title.js
+++ b/plugins/process_title.js
@@ -85,8 +85,12 @@ exports.hook_init_child = function (next, server) {
     server.notes.pt_mps_max = 0;
     var title = 'Haraka (worker)';
     process.title = title;
-    setupInterval(title, server);
+    this._interval = setupInterval(title, server);
     return next();
+};
+
+exports.shutdown = function () {
+    clearInterval(this._interval);
 };
 
 exports.hook_connect_init = function (next, connection) {
@@ -137,7 +141,7 @@ exports.hook_data = function (next, connection) {
 
 var setupInterval = function (title, server) {
     // Set up a timer to update title
-    setInterval(function () {
+    return setInterval(function () {
         // Connections per second
         var av_cps = Math.round((server.notes.pt_connections/process.uptime()*100))/100;
         var cps = server.notes.pt_connections - server.notes.pt_cps_diff;

--- a/plugins/rate_limit.js
+++ b/plugins/rate_limit.js
@@ -28,6 +28,12 @@ exports.register = function () {
     this.register_hook('disconnect',   'decr_concurrency');
 };
 
+exports.shutdown = function () {
+    if (client) {
+        client.end();
+    }
+}
+
 exports.lookup_host_key = function (type, args, cb) {
     var remote_ip = args[0];
     var remote_host = args[1];

--- a/plugins/redis.js
+++ b/plugins/redis.js
@@ -85,8 +85,8 @@ exports.init_redis_plugin = function (next, server) {
 };
 
 exports.shutdown = function () {
-    if (plugin.db) {
-        plugin.db.end();
+    if (this.db) {
+        this.db.end();
     }
 }
 

--- a/plugins/redis.js
+++ b/plugins/redis.js
@@ -84,6 +84,12 @@ exports.init_redis_plugin = function (next, server) {
     plugin.db = plugin.get_redis_client(plugin.cfg.redis, callNext);
 };
 
+exports.shutdown = function () {
+    if (plugin.db) {
+        plugin.db.end();
+    }
+}
+
 exports.redis_ping = function(done) {
     var plugin = this;
     var nope = function (err) {

--- a/timer_queue.js
+++ b/timer_queue.js
@@ -13,7 +13,7 @@ function TimerQueue (interval) {
     var self = this;
     interval = interval || 1000;
     this.queue = [];
-    setInterval(function () { self.fire(); }, interval);
+    this.interval_timer = setInterval(function () { self.fire(); }, interval);
 }
 
 module.exports = TimerQueue;
@@ -60,3 +60,7 @@ TimerQueue.prototype.drain = function () {
         if (to_run.cb) to_run.cb();
     }
 };
+
+TimerQueue.prototype.shutdown = function () {
+    clearInterval(this.interval_timer);
+}


### PR DESCRIPTION
Fixes (probably a number of tickets somewhere deep in the unknown)

Changes proposed in this pull request:
- Adds bin/haraka --graceful to reload child processes gracefully
- On SIGINT, will shutdown gracefully
- Adds plugin.shutdown() method so plugins can clearInterval() any timers they have setup

Will add docs in another commit.

Checklist:
- [ ] docs updated
- [ ] tests updated

