### PR TITLE
Support for unix domain sockets in lmtp

### DIFF
--- a/docs/plugins/queue/lmtp.md
+++ b/docs/plugins/queue/lmtp.md
@@ -9,7 +9,7 @@ Configuration
 * `config/lmtp.ini`
     This config file provides server address and port of LMTP server to deliver for different inbound domains.
     Syntax is equal to that used in the config of the queue/smtp_forward plugin.
-    
+
     Example:
 
     ; defaults
@@ -20,5 +20,7 @@ Configuration
     ; Goes elsewhere
     host=10.1.1.1
     port=2400
-    
-    
+
+    [blah.com]
+    ; Using unix domain sockets
+    path = /tmp/blah_com_socket

--- a/outbound.js
+++ b/outbound.js
@@ -1091,7 +1091,13 @@ HMailItem.prototype.try_deliver_host = function (mx) {
 
     var host = this.hostlist.shift();
     var port            = mx.port || 25;
-    var socket          = sock.connect({port: port, host: host, localAddress: mx.bind});
+    var socket;
+    if (mx.path) {
+        socket = sock.connect({path: mx.path});
+    }
+    else {
+        socket = sock.connect({port: port, host: host, localAddress: mx.bind});
+    }
 
     this.try_deliver_host_on_socket(mx, host, port, socket);
 }

--- a/plugins/queue/lmtp.js
+++ b/plugins/queue/lmtp.js
@@ -8,12 +8,23 @@ exports.hook_get_mx = function (next, hmail, domain) {
     if (!hmail.todo.notes.using_lmtp) return next();
     var config = this.config.get('lmtp.ini', 'ini');
     var section = config[domain] || config.main;
-    var mx = {
-        priority: 0,
-        exchange: section.host || '127.0.0.1',
-        port: section.port || 24,
-        using_lmtp: true
-    };
+    var mx;
+    if (section.path) {
+        mx = {
+            priority: 0,
+            exchange: '127.0.0.1', // here to just pass dns lookups
+            path: section.path,
+            using_lmtp: true
+        };
+    }
+    else {
+        mx = {
+            priority: 0,
+            exchange: section.host || '127.0.0.1',
+            port: section.port || 24,
+            using_lmtp: true
+        };
+    }
     return next(OK, mx);
 }
 


### PR DESCRIPTION
Fixes #1215 .

Changes proposed in this pull request:
- Allows lmtp.ini to set path= to use unix domain sockets

Checklist:
- [X] docs updated
- [ ] tests updated

