### PR TITLE
Fix encoding when banners are used

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -282,7 +282,7 @@ Body.prototype.parse_end = function (line) {
 
         // convert back to base_64 or QP if required:
         if (this.decode_function === this.decode_qp) {
-            line = utils.encode_qp(new_buf.toString("utf8")) + "\n" + line;
+            line = utils.encode_qp(new_buf) + "\n" + line;
         }
         else if (this.decode_function === this.decode_base64) {
             line = new_buf.toString("base64").replace(/(.{1,76})/g, "$1\n") + line;

--- a/utils.js
+++ b/utils.js
@@ -134,16 +134,27 @@ exports.decode_qp = function (line) {
 
 function _char_to_qp (ch) {
     var b = new Buffer(ch);
+    return _buf_to_qp(b);
+}
+
+function _buf_to_qp (b) {
     var r = '';
     for (var i=0; i<b.length; i++) {
-        r = r + '=' + _pad(b[i].toString(16).toUpperCase(), 2);
+        if ((b[i] >= 32 && b[i] <= 126) || b[i] == 9 || b[i] == 10 || b[i] == 13) {
+            // printable range
+            r = r + String.fromCharCode(b[i]);
+        }
+        else {
+            r = r + '=' + _pad(b[i].toString(16).toUpperCase(), 2);
+        }
     }
     return r;
 }
 
 // Shameless attempt to copy from Perl's MIME::QuotedPrint::Perl code.
 exports.encode_qp = function (str) {
-    str = str.replace(
+    str = Buffer.isBuffer(str) ? _buf_to_qp(str)
+        : str.replace(
         /([^\ \t\n!"#\$%&'()*+,\-.\/0-9:;<>?\@A-Z\[\\\]^_`a-z{|}~])/g,
         function (orig, p1) {
             return _char_to_qp(p1);

--- a/utils.js
+++ b/utils.js
@@ -140,7 +140,7 @@ function _char_to_qp (ch) {
 function _buf_to_qp (b) {
     var r = '';
     for (var i=0; i<b.length; i++) {
-        if ((b[i] >= 32 && b[i] <= 126) || b[i] == 9 || b[i] == 10 || b[i] == 13) {
+        if ((b[i] != 61) && ((b[i] > 32 && b[i] <= 126) || b[i] == 10 || b[i] == 13)) {
             // printable range
             r = r + String.fromCharCode(b[i]);
         }


### PR DESCRIPTION
Fixes #1477  .

Changes proposed in this pull request:
- Allows encode_qp to take a buffer, and encodes it as bytes
- Use bytes when re-encoding a banner
