### PR TITLE
Pass connection object to get_plain_password better

### DIFF
--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -22,7 +22,7 @@ exports.hook_capabilities = function (next, connection) {
 };
 
 // Override this at a minimum. Run cb(passwd) to provide a password.
-exports.get_plain_passwd = function (user, cb, connection) {
+exports.get_plain_passwd = function (user, connection, cb) {
     return cb();
 };
 
@@ -48,15 +48,24 @@ exports.hook_unrecognized_command = function (next, connection, params) {
 };
 
 exports.check_plain_passwd = function (connection, user, passwd, cb) {
-    this.get_plain_passwd(user, function (plain_pw) {
+    var callback = function (plain_pw) {
         if (plain_pw === null  ) { return cb(false); }
         if (plain_pw !== passwd) { return cb(false); }
         return cb(true);
-    }, connection);
+    }
+    if (this.get_plain_passwd.length == 2) {
+        this.get_plain_passwd(user, callback);
+    }
+    else if (this.get_plain_passwd.length == 3) {
+        this.get_plain_passwd(user, connection, callback);
+    }
+    else {
+        throw "Invalid number of arguments for get_plain_passwd";
+    }
 };
 
 exports.check_cram_md5_passwd = function (connection, user, passwd, cb) {
-    this.get_plain_passwd(user, function (plain_pw) {
+    var callback = function (plain_pw) {
         if (plain_pw == null) {
             return cb(false);
         }
@@ -68,7 +77,16 @@ exports.check_cram_md5_passwd = function (connection, user, passwd, cb) {
             return cb(true);
         }
         return cb(false);
-    }, connection);
+    };
+    if (this.get_plain_passwd.length == 2) {
+        this.get_plain_passwd(user, callback);
+    }
+    else if (this.get_plain_passwd.length == 3) {
+        this.get_plain_passwd(user, connection, callback);
+    }
+    else {
+        throw "Invalid number of arguments for get_plain_passwd";
+    }
 };
 
 exports.check_user = function (next, connection, credentials, method) {

--- a/plugins/auth/auth_vpopmaild.js
+++ b/plugins/auth/auth_vpopmaild.js
@@ -106,7 +106,7 @@ exports.get_vpopmaild_socket = function (user) {
     return socket;
 };
 
-exports.get_plain_passwd = function (user, cb, connection) {
+exports.get_plain_passwd = function (user, connection, cb) {
     var plugin = this;
 
     var socket = plugin.get_vpopmaild_socket(user);

--- a/plugins/auth/flat_file.js
+++ b/plugins/auth/flat_file.js
@@ -34,7 +34,7 @@ exports.hook_capabilities = function (next, connection) {
     next();
 };
 
-exports.get_plain_passwd = function (user, cb, connection) {
+exports.get_plain_passwd = function (user, connection, cb) {
     var plugin = this;
     if (plugin.cfg.users[user]) {
         return cb(plugin.cfg.users[user].toString());

--- a/tests/plugins/auth/auth_base.js
+++ b/tests/plugins/auth/auth_base.js
@@ -10,7 +10,22 @@ var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('auth/auth_base');
 
-    this.plugin.get_plain_passwd = function (user, cb, connection) {
+    this.plugin.get_plain_passwd = function (user, cb) {
+        if (user === 'test') return cb('testpass');
+        return cb(null);
+    };
+
+    this.connection = Connection.createConnection();
+    this.connection.capabilities=null;
+
+    done();
+};
+
+var _set_up_2 = function (done) {
+
+    this.plugin = new fixtures.plugin('auth/auth_base');
+
+    this.plugin.get_plain_passwd = function (user, connection, cb) {
         connection.notes.auth_custom_note = 'custom_note';
         if (user === 'test') return cb('testpass');
         return cb(null);
@@ -57,14 +72,14 @@ exports.get_plain_passwd = {
             test.expect(1);
             test.equal(pass, null);
             test.done();
-        }, this.connection);
+        });
     },
     'get_plain_passwd, test user': function (test) {
         this.plugin.get_plain_passwd('test', function (pass) {
             test.expect(1);
             test.equal(pass, 'testpass');
             test.done();
-        }, this.connection);
+        });
     },
 };
 
@@ -159,7 +174,7 @@ exports.auth_plain = {
 };
 
 exports.check_user = {
-    setUp : _set_up,
+    setUp : _set_up_2,
     'bad auth': function (test) {
         var next = function (code) {
             test.expect(3);


### PR DESCRIPTION
Replaces and closes #1447

Changes proposed in this pull request:
- Passes connection object when the function expects it, not if it doesn't
- Maintains parameter ordering with callback last

Checklist:
- [ ] docs updated
- [X] tests updated
