### PR TITLE
Bind maxmind version to ignore API change

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "elasticsearch"         : "*",
     "haraka-nosql"          : "*",
     "ldapjs"                : "~1.0.0",
-    "maxmind"               : "*",
+    "maxmind"               : "0.6",
     "modern-syslog"         : "~1.1.1",
     "redis"                 : "~2.5.3",
     "tmp"                   : "~0.0.28",


### PR DESCRIPTION
Fixes #1490 

Changes proposed in this pull request:
- Bind to maxmind 0.6 - we can fix it to the new API later.
