### PR TITLE
Fix quit when running without nodes=

### DIFF
--- a/haraka.js
+++ b/haraka.js
@@ -52,6 +52,9 @@ var shutting_down = false;
             if (server.cluster && server.cluster.isMaster) {
                 server.gracefulShutdown();
             }
+            else if (!server.cluster) {
+                server.gracefulShutdown();
+            }
         });
     });
 });

--- a/server.js
+++ b/server.js
@@ -100,7 +100,12 @@ Server.gracefulShutdown = function () {
 
 Server._graceful = function (shutdown) {
     if (!Server.cluster) {
-        return;
+        if (shutdown) {
+            ['outbound', 'cfreader', 'plugins'].forEach(function (module) {
+                process.emit('message', {event: module + '.shutdown'});
+            });
+            return setTimeout(shutdown, 5000);
+        }
     }
 
     if (gracefull_in_progress) {


### PR DESCRIPTION
Fixes #1498 (hopefully)

Changes proposed in this pull request:
- Runs quit routines when not running under nodes=
- Waits 5s when done, as we have no other reliable way to stop node

Checklist:
- [ ] docs updated
- [ ] tests updated

