### PR TITLE
Make rcpt_to.ldap work with aliases plugin

### DIFF
--- a/plugins/rcpt_to.ldap.js
+++ b/plugins/rcpt_to.ldap.js
@@ -33,7 +33,7 @@ exports.ldap_rcpt = function(next, connection, params) {
     var txn = connection.transaction;
     if (!txn) return next();
 
-    var rcpt = params[0];
+    var rcpt = txn.rcpt_to[txn.rcpt_to.length - 1];
     if (!rcpt.host) {
         txn.results.add(plugin, {fail: '!domain'});
         return next();

--- a/tests/plugins/rcpt_to.ldap.js
+++ b/tests/plugins/rcpt_to.ldap.js
@@ -18,6 +18,7 @@ var _set_up = function (done) {
     this.connection.transaction = {
         results: new ResultStore(this.connection),
         notes: {},
+        rcpt_to: [new Address('test@test.com')]
     };
 
     done();


### PR DESCRIPTION
Changes proposed in this pull request:
- Instead of performing an LDAP lookup on the e-mail address specified by the client in the RCPT TO command, look at the value in the rcpt_to array which may have been modified by the aliases plugin.
