### PR TITLE
Shut down redis properly.  Closes GH-1498

### DIFF
--- a/plugins/redis.js
+++ b/plugins/redis.js
@@ -86,7 +86,10 @@ exports.init_redis_plugin = function (next, server) {
 
 exports.shutdown = function () {
     if (this.db) {
-        this.db.end();
+        this.db.quit();
+    }
+    if (server.notes.redis) {
+        this server.notes.redis.quit();
     }
 }
 

--- a/plugins/redis.js
+++ b/plugins/redis.js
@@ -89,7 +89,7 @@ exports.shutdown = function () {
         this.db.quit();
     }
     if (server.notes.redis) {
-        this server.notes.redis.quit();
+        server.notes.redis.quit();
     }
 }
 


### PR DESCRIPTION
Fixes # 1498

Changes proposed in this pull request:
- Properly shut down redis by calling quit() instead of end()
- Also quit server.notes.redis