### PR TITLE
More graceful shutdown

### DIFF
--- a/config/smtp.ini
+++ b/config/smtp.ini
@@ -37,3 +37,9 @@
 ; Otherwise specify a size in bytes, once reached the
 ; message will be spooled to disk to save memory.
 ;spool_after=
+
+; Force Shutdown Timeout
+; - Haraka tries to close down gracefully, but if everything is shut down
+;   after this time it will hard close. 30s is usually long enough to
+;   wait for outbound connections to finish.
+;force_shutdown_timeout=30

--- a/configfile.js
+++ b/configfile.js
@@ -227,6 +227,14 @@ process.on('message', function (msg) {
     if (msg.event && msg.event == 'cfreader.shutdown') {
         logger.loginfo("[cfreader] Shutting down enoent timer");
         clearInterval(cfreader._enoent_timer);
+        logger.loginfo("[cfreader] Clearing any sedation timers");
+        for (var k in cfreader._sedation_timers) {
+            clearTimeout(cfreader._sedation_timers[k]);
+        }
+        logger.loginfo("[cfreader] Removing watchers");
+        for (var k2 in cfreader._watchers) {
+            cfreader._watchers[k2].close();
+        }
     }
 });
 

--- a/server.js
+++ b/server.js
@@ -31,7 +31,8 @@ Server.load_smtp_ini = function () {
     var defaults = {
         inactivity_timeout: 600,
         daemon_log_file: '/var/log/haraka.log',
-        daemon_pid_file: '/var/run/haraka.pid'
+        daemon_pid_file: '/var/run/haraka.pid',
+        force_shutdown_timeout: 30,
     };
 
     for (var key in defaults) {
@@ -94,6 +95,7 @@ Server.gracefulRestart = function () {
 
 Server.gracefulShutdown = function () {
     Server._graceful(function () {
+        logger.loginfo("Failed to shutdown naturally. Exiting.");
         process.exit(0);
     });
 }
@@ -104,7 +106,8 @@ Server._graceful = function (shutdown) {
             ['outbound', 'cfreader', 'plugins'].forEach(function (module) {
                 process.emit('message', {event: module + '.shutdown'});
             });
-            return setTimeout(shutdown, 5000);
+            var t = setTimeout(shutdown, Server.cfg.main.force_shutdown_timeout * 1000);
+            return t.unref();
         }
     }
 
@@ -165,7 +168,12 @@ Server._graceful = function (shutdown) {
         // err can basically never happen, but fuckit...
         if (err) logger.logerror(err);
         if (shutdown) {
-            return shutdown();
+            logger.loginfo("Workers closed. Shutting down master process subsystems");
+            ['outbound', 'cfreader', 'plugins'].forEach(function (module) {
+                process.emit('message', {event: module + '.shutdown'});
+            })
+            var t = setTimeout(shutdown, Server.cfg.main.force_shutdown_timeout * 1000);
+            return t.unref();
         }
         gracefull_in_progress = false;
         logger.lognotice("Reload complete, workers: " + JSON.stringify(Object.keys(cluster.workers)));
@@ -332,6 +340,8 @@ Server.setup_smtp_listeners = function (plugins2, type, inactivity_timeout) {
         var server = Server.get_smtp_server(host, port, inactivity_timeout);
         if (!server) return cb();
 
+        server.unref();
+
         server.notes = Server.notes;
         if (Server.cluster) server.cluster = Server.cluster;
 
@@ -389,6 +399,7 @@ Server.setup_http_listeners = function () {
         }
 
         Server.http.server = require('http').createServer(app);
+        Server.http.server.unref();
 
         Server.http.server.on('listening', function () {
             var addr = this.address();
@@ -540,6 +551,7 @@ Server.init_http_respond = function () {
     }
 
     Server.http.wss = new WebSocketServer({ server: Server.http.server });
+    Server.http.wss.unref();
     logger.loginfo('Server.http.wss loaded');
 
     plugins.run_hooks('init_wss', Server);

--- a/server.js
+++ b/server.js
@@ -172,8 +172,8 @@ Server._graceful = function (shutdown) {
             ['outbound', 'cfreader', 'plugins'].forEach(function (module) {
                 process.emit('message', {event: module + '.shutdown'});
             })
-            var t = setTimeout(shutdown, Server.cfg.main.force_shutdown_timeout * 1000);
-            return t.unref();
+            var t2 = setTimeout(shutdown, Server.cfg.main.force_shutdown_timeout * 1000);
+            return t2.unref();
         }
         gracefull_in_progress = false;
         logger.lognotice("Reload complete, workers: " + JSON.stringify(Object.keys(cluster.workers)));


### PR DESCRIPTION
Fixes no direct issues, but more cleanly shuts down everything.

Changes proposed in this pull request:
- unref all the servers (smtp and http)
- Adds an unref'd timer to full shutdown so we don't need to forcefully process.exit()
- Further cleanup of watched config

Checklist:
- [ ] docs updated
- [ ] tests updated

