### PR TITLE
s/end/quit to properly shutdown redis client

### DIFF
--- a/plugins/dns_list_base.js
+++ b/plugins/dns_list_base.js
@@ -194,7 +194,7 @@ exports.check_zones = function (interval) {
 exports.shutdown = function () {
     clearInterval(this._interval);
     if (redis_client) {
-        redis_client.end();
+        redis_client.quit();
     }
 };
 

--- a/plugins/greylist.js
+++ b/plugins/greylist.js
@@ -139,7 +139,7 @@ exports.redis_onInit = function (next, server) {
 
 exports.shutdown = function () {
     if (this.redis) {
-        this.redis.end();
+        this.redis.quit();
     }
 }
 

--- a/plugins/rate_limit.js
+++ b/plugins/rate_limit.js
@@ -30,7 +30,7 @@ exports.register = function () {
 
 exports.shutdown = function () {
     if (client) {
-        client.end();
+        client.quit();
     }
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix a few additional places where the redis client was not being properly shut down