### PR TITLE
DKIM: DKIMObject needs to have a copy of header_idx

### DIFF
--- a/dkim.js
+++ b/dkim.js
@@ -41,6 +41,9 @@ function Buf() {
     };
 }
 
+function cloneHack(object) {
+    return JSON.parse(JSON.stringify(object));
+}
 
 ////////////////
 // DKIMObject //
@@ -53,7 +56,7 @@ function DKIMObject (header, header_idx, cb, timeout) {
     this.sig = header;
     this.sig_md5 = md5(header);
     this.run_cb = false;
-    this.header_idx = header_idx;
+    this.header_idx = cloneHack(header_idx);
     this.timeout = timeout;
     this.fields = {};
     this.headercanon = this.bodycanon = 'simple';

--- a/dkim.js
+++ b/dkim.js
@@ -52,7 +52,7 @@ function DKIMObject (header, header_idx, cb, timeout) {
     this.sig = header;
     this.sig_md5 = md5(header);
     this.run_cb = false;
-    this.header_idx = JSON.parse(JSON.stringify((header_idx));
+    this.header_idx = JSON.parse(JSON.stringify(header_idx));
     this.timeout = timeout;
     this.fields = {};
     this.headercanon = this.bodycanon = 'simple';

--- a/dkim.js
+++ b/dkim.js
@@ -41,10 +41,6 @@ function Buf() {
     };
 }
 
-function cloneHack(object) {
-    return JSON.parse(JSON.stringify(object));
-}
-
 ////////////////
 // DKIMObject //
 ////////////////
@@ -56,7 +52,7 @@ function DKIMObject (header, header_idx, cb, timeout) {
     this.sig = header;
     this.sig_md5 = md5(header);
     this.run_cb = false;
-    this.header_idx = cloneHack(header_idx);
+    this.header_idx = JSON.parse(JSON.stringify((header_idx));
     this.timeout = timeout;
     this.fields = {};
     this.headercanon = this.bodycanon = 'simple';


### PR DESCRIPTION
Pass in a copy of header_idx to DKIMObject instead of header_idx directly.

Since DKIMObject mutates header_idx by using pop(), therefore, if the email has more than 1 DKIM-Signature, then the first DKIMObject will verify but then the later DKIMObject will not verify since there are no header_idx.