### PR TITLE
Match IPv6 literals in ehlo

### DIFF
--- a/net_utils.js
+++ b/net_utils.js
@@ -167,7 +167,7 @@ exports.is_private_ip = function (ip) {
 exports.is_rfc1918 = exports.is_private_ip;
 
 exports.is_ip_literal = function (host) {
-    return exports.get_ipany_re('^\\[','\\]$','').test(host) ? true : false;
+    return exports.get_ipany_re('^\\[(IPv6:)?','\\]$','').test(host) ? true : false;
 };
 
 exports.is_ipv4_literal = function (host) {

--- a/tests/net_utils.js
+++ b/tests/net_utils.js
@@ -197,10 +197,11 @@ exports.is_ip_literal = {
         test.done();
     },
     'ipv6 is_ip_literal': function (test) {
-        test.expect(6);
+        test.expect(7);
         test.equal(net_utils.is_ip_literal('[::5555:6666:7777:8888]'), true);
         test.equal(net_utils.is_ip_literal('[1111::4444:5555:6666:7777:8888]'), true);
         test.equal(net_utils.is_ip_literal('[2001:0:1234::C1C0:ABCD:876]'), true);
+        test.equal(net_utils.is_ip_literal('[IPv6:2607:fb90:4c28:f9e9:4ca2:2658:db85:f1a]'), true);
         test.equal(net_utils.is_ip_literal('::5555:6666:7777:8888'), false);
         test.equal(net_utils.is_ip_literal('1111::4444:5555:6666:7777:8888'), false);
         test.equal(net_utils.is_ip_literal('2001:0:1234::C1C0:ABCD:876'), false);


### PR DESCRIPTION
Changes proposed in this pull request:
- This check is per section 4.1.3 Address Literals of RFC 2821

Checklist:
- [ ] docs updated
- [X ] tests updated
