### PR TITLE
Fix for host_pool test under high load

### DIFF
--- a/host_pool.js
+++ b/host_pool.js
@@ -64,14 +64,16 @@ HostPool.prototype.failed = function (host, port) {
         logger.logwarn("host " + key + " is still dead, will retry in " +
                         self.retry_secs + " secs");
         self.dead_hosts[key] = true;
+        console.log(1);
         setTimeout(function() {
             self.probe_dead_host(host, port, cb_if_still_dead, cb_if_alive);
         }, retry_msecs);
     };
 
     var cb_if_alive = function (){
+        console.log(2);
         logger.loginfo("host " + key + " is back! adding back into pool");
-        self.dead_hosts[key] = false;
+        delete self.dead_hosts[key];
     };
 
     setTimeout(function() {

--- a/tests/host_pool.js
+++ b/tests/host_pool.js
@@ -160,14 +160,21 @@ exports.HostPool = {
         test.ok(pool.dead_hosts["1.1.1.1:1111"], 'yes it was marked dead');
 
         // probe_dead_host() will hit two failures and one success (based on
-        // num_reqs above). So we wait 3xretry_secs and triple it for
-        // some headroom.
-        setTimeout(function(){
-            test.ok(! pool.dead_hosts["1.1.1.1:1111"],
-                    'timer un-deaded it'
-               );
+        // num_reqs above). So we wait at least 10s for that to happen:
+        var timer = setTimeout(function(){
+            clearInterval(interval);
+            test.ok(false, 'probe_dead_host failed');
             test.done();
-        }, retry_secs * 1000 * 3 * 3 );
+        }, 10 * 1000);
+
+        var interval = setInterval(function (){
+            if (!pool.dead_hosts["1.1.1.1:1111"]) {
+                clearTimeout(timer);
+                clearInterval(interval);
+                test.ok(true, 'timer un-deaded it');
+                test.done();
+            }
+        }, retry_secs * 1000 * 3 );
 
     }
 


### PR DESCRIPTION
Fixes failing tests

Changes proposed in this pull request:
- Waits for at least 10s for host_pool timer to fire.
- Also fixes a tiny memory leak in large host pools by deleting from the hash instead of setting false

Checklist:
- [ ] docs updated
- [X] tests updated

