### PR TITLE
read file contents of plugin when plugin is a package

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -172,8 +172,9 @@ Plugin.prototype._make_custom_require = function () {
 
 Plugin.prototype._get_code = function (pp) {
     var plugin = this;
+
     if (plugin.hasPackageJson) {
-        return 'exports = require("' + path.dirname(pp) + '");';
+        return 'var _p = require("' + path.dirname(pp) + '"); for (var k in _p) { exports[k] = _p[k] }';
     }
 
     try {


### PR DESCRIPTION
Fixes #1513 

Changes proposed in this pull request:
- load the file contents of plugins-as-npm-package same as plugin.js file
