### PR TITLE
Don't unref wss server - it's already unref'd

### DIFF
--- a/server.js
+++ b/server.js
@@ -551,7 +551,6 @@ Server.init_http_respond = function () {
     }
 
     Server.http.wss = new WebSocketServer({ server: Server.http.server });
-    Server.http.wss.unref();
     logger.loginfo('Server.http.wss loaded');
 
     plugins.run_hooks('init_wss', Server);


### PR DESCRIPTION
Fixes #1520 .

Changes proposed in this pull request:
- Don't unref the wss object - the socket is already unref'd
