### PR TITLE
outbound: Add results property to transaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 #   - "0.6"     # no longer supported by async
 #   - "0.8"     # no longer supported by iconv
-    - "0.10"
+#   - "0.10"
     - "4"
     - "5"
     - "6"

--- a/outbound.js
+++ b/outbound.js
@@ -27,6 +27,7 @@ var existsSync  = utils.existsSync;
 var FsyncWriteStream = require('./fsync_writestream');
 var generic_pool = require('generic-pool');
 var server      = require('./server');
+var ResultStore = require('./result_store');
 
 var core_consts = require('constants');
 var WRITE_EXCL  = core_consts.O_CREAT | core_consts.O_TRUNC | core_consts.O_WRONLY | core_consts.O_EXCL;
@@ -532,6 +533,7 @@ exports.send_trans_email = function (transaction, next) {
     };
 
     logger.add_log_methods(connection);
+    transaction.results = new ResultStore(connection);
 
     connection.pre_send_trans_email_respond = function (retval) {
         var deliveries = [];


### PR DESCRIPTION
transaction.results is used widely by many plugins to store results.
The code in connection.js creates this property in init_transaction
but similar logic is missing in outbound code.

In the future, results property should move to the transaction constructor.
But this is complicated by the fact that ResultStore requres a connection
object and doing this properly requires a (risky) refactor.

(The specific crash here was that the dkim plugin tries to sign a bounce
mail and crashes when doing a txn.results.add)