### PR TITLE
normalized connection properties

### DIFF
--- a/bin/haraka
+++ b/bin/haraka
@@ -537,7 +537,7 @@ else if (parsed.test) {
             helo = parsed.helo;
             mode = 'helo';
         }
-        connection.hello_host = helo;
+        connection.hello.host = helo;
         run_next_hook(arguments[0], mode, connection, helo);
     }
     connection.helo_respond = connection.ehlo_respond = function () {

--- a/connection.js
+++ b/connection.js
@@ -24,6 +24,7 @@ var outbound    = require('./outbound');
 var date_to_str = require('./utils').date_to_str;
 var indexOfLF   = require('./utils').indexOfLF;
 var ResultStore = require('./result_store');
+// var net_utils   = require('./net_utils');
 
 var hostname    = (os.hostname().split(/\./))[0];
 var version     = JSON.parse(

--- a/connection.js
+++ b/connection.js
@@ -24,7 +24,6 @@ var outbound    = require('./outbound');
 var date_to_str = require('./utils').date_to_str;
 var indexOfLF   = require('./utils').indexOfLF;
 var ResultStore = require('./result_store');
-// var net_utils   = require('./net_utils');
 
 var hostname    = (os.hostname().split(/\./))[0];
 var version     = JSON.parse(
@@ -157,41 +156,32 @@ function setupClient (self) {
 function Connection (client, server) {
     this.client = client;
     this.server = server;
-    this.local = {
-        ip: null,
+    this.local = {           // legacy property locations
+        ip: null,            // c.local_ip
         proxy: null,
-        port: null,
+        port: null,          // c.local_port
         host: null,
     };
     this.remote = {
-        ip:   null,
-        port: null,
-        host: null,
-        info: null,
-        closed: false,
+        ip:   null,          // c.remote_ip
+        port: null,          // c.remote_port
+        host: null,          // c.remote_host
+        info: null,          // c.remote_info
+        closed: false,       // c.remote_closed
         is_private: false,
     };
     this.hello = {
-        host: null,
-        verb: null,
+        host: null,          // c.hello_host
+        verb: null,          // c.greeting
     };
     this.tls = {
+        enabled: false,      // c.using_tls
+        advertised: false,   // c.notes.tls_enabled
         verified: false,
         cipher: {},
         authorized: null,
     };
     this.set('tls', 'enabled', (server.has_tls ? true : false));
-
-    // sunset 3.0.0
-    // this.local_ip = null;
-    // this.local_port = null;
-    // this.remote_ip = null;
-    // this.remote_host = null;
-    // this.remote_port = null;
-    // this.remote_info = null;
-    // this.remote_closed = false;
-    // this.greeting = null;
-    // this.hello_host = null;
 
     this.current_data = null;
     this.current_line = null;

--- a/docs/Connection.md
+++ b/docs/Connection.md
@@ -10,19 +10,19 @@ API
 
 A unique UUID for this connection.
 
-* connection.remote\_ip
+* connection.remote.ip
 
 The remote IP address
 
-* connection.remote\_host
+* connection.remote.host
 
 The rDNS of the remote IP
 
-* connection.local\_ip
+* connection.local.ip
 
 The bound IP address of the server as reported by the OS
 
-* connection.local\_port
+* connection.local.port
 
 The bound port number of the server which is handling the connection.
 If you have specified multiple listen= ports this variable is useful
@@ -34,11 +34,11 @@ port
 If the connection is being proxied by HAProxy, this variable will
 contain the remote IP address of the HAProxy host.
 
-* connection.greeting
+* connection.hello.verb
 
 Either 'EHLO' or 'HELO' whichever the remote end used
 
-* connection.hello\_host
+* connection.hello.host
 
 The hostname given to HELO or EHLO
 
@@ -67,7 +67,7 @@ verbatim as it was sent. Can be useful in certain botnet detection techniques.
 
 Contains the last SMTP response sent to the client.
 
-* connection.remote\_close
+* connection.remote\_closed
 
 For low level use.  This value is set when the remote host drops the connection.
 

--- a/net_utils.js
+++ b/net_utils.js
@@ -10,9 +10,9 @@ var config = require('./config');
 
 // npm modules
 var async    = require('async');
-var ipaddr    = require('ipaddr.js');
-var sprintf   = require('sprintf-js').sprintf;
-var tlds      = require('haraka-tld');
+var ipaddr   = require('ipaddr.js');
+var sprintf  = require('sprintf-js').sprintf;
+var tlds     = require('haraka-tld');
 
 exports.long_to_ip = function (n) {
     var d = n%256;
@@ -119,7 +119,7 @@ exports.is_local_ipv4 = function (ip) {
     // 127/8 (loopback)   # RFC 1122
     if (re_ipv4.loopback.test(ip)) return true;
 
-    // link local: 169.254/16) RFC 3927
+    // link local: 169.254/16 RFC 3927
     if (re_ipv4.link_local.test(ip)) return true;
 
     return false;

--- a/plugins/access.js
+++ b/plugins/access.js
@@ -135,10 +135,10 @@ exports.get_domain = function (hook, connection, params) {
 
     switch (hook) {
         case 'connect':
-            if (!connection.remote_host) return;
-            if (connection.remote_host === 'DNSERROR') return;
-            if (connection.remote_host === 'Unknown') return;
-            return connection.remote_host;
+            if (!connection.remote.host) return;
+            if (connection.remote.host === 'DNSERROR') return;
+            if (connection.remote.host === 'Unknown') return;
+            return connection.remote.host;
         case 'helo':
         case 'ehlo':
             if (net_utils.is_ip_literal(params)) return;
@@ -217,13 +217,13 @@ exports.rdns_access = function(next, connection) {
     var plugin = this;
     if (!plugin.cfg.check.conn) { return next(); }
 
-    if (!connection.remote_ip) {
+    if (!connection.remote.ip) {
         connection.results.add(plugin, {err: 'no IP?!' });
         return next();
     }
 
-    var r_ip = connection.remote_ip;
-    var host = connection.remote_host;
+    var r_ip = connection.remote.ip;
+    var host = connection.remote.host;
 
     var addr;
     var file;

--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -13,7 +13,7 @@ var LOGIN_STRING2 = 'UGFzc3dvcmQ6'; //Password: base64 coded
 
 exports.hook_capabilities = function (next, connection) {
     // Don't offer AUTH capabilities unless session is encrypted
-    if (!connection.using_tls) { return next(); }
+    if (!connection.tls.enabled) { return next(); }
 
     var methods = [ 'PLAIN', 'LOGIN', 'CRAM-MD5' ];
     connection.capabilities.push('AUTH ' + methods.join(' '));

--- a/plugins/auth/auth_ldap.js
+++ b/plugins/auth/auth_ldap.js
@@ -5,7 +5,7 @@ var async = require('async');
 
 exports.hook_capabilities = function (next, connection) {
     // Don't offer AUTH capabilities by default unless session is encrypted
-    if (connection.using_tls) {
+    if (connection.tls.enabled) {
         var methods = [ 'LOGIN' ];
         connection.capabilities.push('AUTH ' + methods.join(' '));
         connection.notes.allowed_auth_methods = methods;

--- a/plugins/auth/auth_proxy.js
+++ b/plugins/auth/auth_proxy.js
@@ -8,7 +8,7 @@ exports.register = function () {
 };
 
 exports.hook_capabilities = function (next, connection) {
-    if (connection.using_tls) {
+    if (connection.tls.enabled) {
         var methods = [ 'PLAIN', 'LOGIN' ];
         connection.capabilities.push('AUTH ' + methods.join(' '));
         connection.notes.allowed_auth_methods = methods;

--- a/plugins/auth/auth_vpopmaild.js
+++ b/plugins/auth/auth_vpopmaild.js
@@ -16,7 +16,7 @@ exports.load_vpop_ini = function () {
 };
 
 exports.hook_capabilities = function (next, connection) {
-    if (!connection.using_tls) { return next(); }
+    if (!connection.tls.enabled) { return next(); }
     var plugin = this;
 
     var methods = [ 'PLAIN', 'LOGIN' ];

--- a/plugins/auth/flat_file.js
+++ b/plugins/auth/flat_file.js
@@ -17,7 +17,7 @@ exports.load_flat_ini = function () {
 exports.hook_capabilities = function (next, connection) {
     var plugin = this;
     // don't allow AUTH unless private IP or encrypted
-    if (!net_utils.is_private_ip(connection.remote_ip) && !connection.using_tls) {
+    if (!net_utils.is_private_ip(connection.remote.ip) && !connection.tls.enabled) {
         connection.logdebug(plugin,
                 "Auth disabled for insecure public connection");
         return next();

--- a/plugins/backscatterer.js
+++ b/plugins/backscatterer.js
@@ -17,11 +17,11 @@ exports.hook_mail = function (next, connection, params) {
             return next();
         }
         if (!a) return next();
-        var msg = 'Host ' + connection.remote_host +
-                  ' [' + connection.remote_ip + ']' +
+        var msg = 'Host ' + connection.remote.host +
+                  ' [' + connection.remote.ip + ']' +
                   ' is blacklisted by ' + zone;
         return next(DENY, msg);
     }
 
-    this.first(connection.remote_ip, [ 'ips.backscatterer.org' ], resultCb);
+    this.first(connection.remote.ip, [ 'ips.backscatterer.org' ], resultCb);
 };

--- a/plugins/bounce.js
+++ b/plugins/bounce.js
@@ -110,7 +110,7 @@ exports.single_recipient = function(next, connection) {
                 {skip: 'single_recipient(relay)', emit: true });
         return next();
     }
-    if (net_utils.is_private_ip(connection.remote_ip)) {
+    if (net_utils.is_private_ip(connection.remote.ip)) {
         transaction.results.add(plugin,
                 {skip: 'single_recipient(private_ip)', emit: true });
         return next();

--- a/plugins/connect.asn.js
+++ b/plugins/connect.asn.js
@@ -115,7 +115,7 @@ exports.get_dns_results = function (zone, ip, done) {
 
 exports.lookup_asn = function (next, connection) {
     var plugin = this;
-    var ip = connection.remote_ip;
+    var ip = connection.remote.ip;
     if (net_utils.is_private_ip(ip)) return next();
 
     function provIter (zone, done) {

--- a/plugins/connect.geoip.js
+++ b/plugins/connect.geoip.js
@@ -97,7 +97,7 @@ exports.load_geoip_lite = function () {
 exports.get_maxmind_asn = function (connection) {
     var plugin = this;
 
-    var asn = plugin.maxmind.getAsn(connection.remote_ip);
+    var asn = plugin.maxmind.getAsn(connection.remote.ip);
     if (!asn) return;
 
     var match = asn.match(/^(?:AS)([0-9]+)\s+(.*)$/);
@@ -124,7 +124,7 @@ exports.lookup_maxmind = function (next, connection) {
 
     plugin.get_maxmind_asn(connection);
 
-    var loc = plugin.get_geoip_maxmind(connection.remote_ip);
+    var loc = plugin.get_geoip_maxmind(connection.remote.ip);
     if (!loc) return next();
 
     if (loc.continentCode && loc.continentCode !== '--') {
@@ -186,7 +186,7 @@ exports.lookup_geoip = function (next, connection) {
         return next();
     }
 
-    var r = plugin.get_geoip_lite(connection.remote_ip);
+    var r = plugin.get_geoip_lite(connection.remote.ip);
     if (!r) { return next(); }
 
     connection.results.add(plugin, r);

--- a/plugins/connect.p0f.js
+++ b/plugins/connect.p0f.js
@@ -196,7 +196,7 @@ exports.hook_lookup_rdns = function onLookup(next, connection) {
         return next();
     }
     var p0f_client = server.notes.p0f_client;
-    p0f_client.query(connection.remote_ip, function (err, result) {
+    p0f_client.query(connection.remote.ip, function (err, result) {
         if (err) {
             connection.results.add(plugin, {err: err.message});
             return next();

--- a/plugins/connect.rdns_access.js
+++ b/plugins/connect.rdns_access.js
@@ -30,54 +30,54 @@ exports.rdns_access = function(next, connection) {
     var plugin = this;
 
     // IP whitelist checks
-    if (connection.remote_ip) {
-        connection.logdebug(plugin, 'checking ' + connection.remote_ip +
+    if (connection.remote.ip) {
+        connection.logdebug(plugin, 'checking ' + connection.remote.ip +
             ' against connect.rdns_access.whitelist');
 
-        if (_in_whitelist(connection, plugin, connection.remote_ip)) {
-            connection.logdebug(plugin, "Allowing " + connection.remote_ip);
+        if (_in_whitelist(connection, plugin, connection.remote.ip)) {
+            connection.logdebug(plugin, "Allowing " + connection.remote.ip);
             connection.notes.rdns_access = 'white';
             return next();
         }
     }
 
     // hostname whitelist checks
-    if (connection.remote_host) {
-        connection.logdebug(plugin, 'checking ' + connection.remote_host +
+    if (connection.remote.host) {
+        connection.logdebug(plugin, 'checking ' + connection.remote.host +
             ' against connect.rdns_access.whitelist');
 
-        if (_in_whitelist(connection, plugin, connection.remote_host.toLowerCase())) {
-            connection.logdebug(plugin, "Allowing " + connection.remote_host);
+        if (_in_whitelist(connection, plugin, connection.remote.host.toLowerCase())) {
+            connection.logdebug(plugin, "Allowing " + connection.remote.host);
             connection.notes.rdns_access = 'white';
             return next();
         }
     }
 
     // IP blacklist checks
-    if (connection.remote_ip) {
-        connection.logdebug(plugin, 'checking ' + connection.remote_ip +
+    if (connection.remote.ip) {
+        connection.logdebug(plugin, 'checking ' + connection.remote.ip +
             ' against connect.rdns_access.blacklist');
 
-        if (_in_blacklist(connection, plugin, connection.remote_ip)) {
+        if (_in_blacklist(connection, plugin, connection.remote.ip)) {
             connection.logdebug(plugin, "Rejecting, matched: " +
-                connection.remote_ip);
+                connection.remote.ip);
             connection.notes.rdns_access = 'black';
-            return next(DENYDISCONNECT, connection.remote_host.toLowerCase() +
-                ' [' + connection.remote_ip + '] ' + plugin.deny_msg);
+            return next(DENYDISCONNECT, connection.remote.host.toLowerCase() +
+                ' [' + connection.remote.ip + '] ' + plugin.deny_msg);
         }
     }
 
     // hostname blacklist checks
-    if (connection.remote_host) {
-        connection.logdebug(plugin, 'checking ' + connection.remote_host +
+    if (connection.remote.host) {
+        connection.logdebug(plugin, 'checking ' + connection.remote.host +
             ' against connect.rdns_access.blacklist');
 
-        if (_in_blacklist(connection, plugin, connection.remote_host.toLowerCase())) {
+        if (_in_blacklist(connection, plugin, connection.remote.host.toLowerCase())) {
             connection.logdebug(plugin, "Rejecting, matched: " +
-               connection.remote_host);
+               connection.remote.host);
             connection.notes.rdns_access = 'black';
-            return next(DENYDISCONNECT, connection.remote_host.toLowerCase() +
-                ' [' + connection.remote_ip + '] ' + plugin.deny_msg);
+            return next(DENYDISCONNECT, connection.remote.host.toLowerCase() +
+                ' [' + connection.remote.ip + '] ' + plugin.deny_msg);
         }
     }
 

--- a/plugins/data.uribl.js
+++ b/plugins/data.uribl.js
@@ -282,7 +282,7 @@ exports.do_lookups = function (connection, next, hosts, type) {
 exports.hook_lookup_rdns = function (next, connection) {
     this.load_uri_config(next);
     var plugin = this;
-    dns.reverse(connection.remote_ip, function (err, rdns) {
+    dns.reverse(connection.remote.ip, function (err, rdns) {
         if (err) {
             if (err.code) {
                 if (err.code === dns.NXDOMAIN) return next();

--- a/plugins/dcc.js
+++ b/plugins/dcc.js
@@ -8,14 +8,14 @@ exports.hook_data_post = function (next, connection) {
 
     // Fix-up rDNS for DCC
     var host;
-    switch (connection.remote_host) {
+    switch (connection.remote.host) {
         case 'Unknown':
         case 'NXDOMAIN':
         case 'DNSERROR':
         case undefined:
             break;
         default:
-            host = connection.remote_host;
+            host = connection.remote.host;
             break;
     }
 
@@ -30,8 +30,8 @@ exports.hook_data_post = function (next, connection) {
         connection.logdebug(self, 'connected to dcc');
         var protocol_headers = [
             'header' + ((training) ? ' spam' : ''),
-            connection.remote_ip + ((host) ? '\r' + host : ''),
-            connection.hello_host,
+            connection.remote.ip + ((host) ? '\r' + host : ''),
+            connection.hello.host,
             txn.mail_from.address(),
             rcpts.join('\r'),
         ].join('\n');

--- a/plugins/dnsbl.js
+++ b/plugins/dnsbl.js
@@ -73,7 +73,7 @@ exports.should_skip = function (connection) {
     var plugin = this;
 
     if (!connection) { return true; }
-    var rip = connection.remote_ip;
+    var rip = connection.remote.ip;
 
     if (net_utils.is_private_ip(rip)) {
         connection.logdebug(plugin, 'skipping private IP: ' + rip);
@@ -90,7 +90,7 @@ exports.should_skip = function (connection) {
 
 exports.connect_first = function(next, connection) {
     var plugin = this;
-    var remote_ip = connection.remote_ip;
+    var remote_ip = connection.remote.ip;
 
     if (plugin.should_skip(connection)) { return next(); }
 
@@ -115,7 +115,7 @@ exports.connect_first = function(next, connection) {
 
 exports.connect_multi = function(next, connection) {
     var plugin = this;
-    var remote_ip = connection.remote_ip;
+    var remote_ip = connection.remote.ip;
 
     if (plugin.should_skip(connection)) { return next(); }
 

--- a/plugins/dnswl.js
+++ b/plugins/dnswl.js
@@ -51,9 +51,9 @@ exports.hook_connect = function (next, connection) {
         connection.logerror(plugin, 'no zones');
         return next();
     }
-    plugin.first(connection.remote_ip, plugin.zones, function (err, zone, a) {
+    plugin.first(connection.remote.ip, plugin.zones, function (err, zone, a) {
         if (!a) return next();
-        connection.loginfo(plugin, connection.remote_ip +
+        connection.loginfo(plugin, connection.remote.ip +
             ' is whitelisted by ' + zone + ': ' + a);
         connection.notes.dnswl = true;
         return next(OK);

--- a/plugins/early_talker.js
+++ b/plugins/early_talker.js
@@ -48,7 +48,7 @@ exports.early_talker = function(next, connection) {
     }
 
     // Don't delay whitelisted IPs
-    if (plugin.ip_in_list(connection.remote_ip)) { // check connecting IP
+    if (plugin.ip_in_list(connection.remote.ip)) { // check connecting IP
         connection.results.add(plugin, { skip: 'whitelist' });
         return next();
     }

--- a/plugins/greylist.js
+++ b/plugins/greylist.js
@@ -151,7 +151,7 @@ exports.hook_mail = function (next, connection, params) {
     var mail_from = params[0];
 
     // whitelist checks
-    if (plugin.ip_in_list(connection.remote_ip)) { // check connecting IP
+    if (plugin.ip_in_list(connection.remote.ip)) { // check connecting IP
 
         plugin.loginfo(connection, 'Connecting IP was whitelisted via config');
         connection.transaction.results.add(plugin, {
@@ -356,8 +356,8 @@ exports.should_skip_check = function (connection) {
         return true;
     }
 
-    if (net_utils.is_private_ip(connection.remote_ip)) {
-        connection.logdebug(plugin, 'skipping private IP: ' + connection.remote_ip);
+    if (net_utils.is_private_ip(connection.remote.ip)) {
+        connection.logdebug(plugin, 'skipping private IP: ' + connection.remote.ip);
         ctr.add(plugin, {
             skip : 'private-ip'
         });
@@ -429,8 +429,8 @@ exports.craft_hostid = function (connection) {
     if (trx.notes.greylist && trx.notes.greylist.hostid)
         return trx.notes.greylist.hostid; // "caching"
 
-    var ip = connection.remote_ip;
-    var rdns = connection.remote_host;
+    var ip = connection.remote.ip;
+    var rdns = connection.remote.host;
 
     var chsit = function (value, reason) { // cache the return value
         if (!value)

--- a/plugins/helo.checks.js
+++ b/plugins/helo.checks.js
@@ -124,7 +124,7 @@ exports.should_skip = function (connection, test_name) {
         return true;
     }
 
-    if (plugin.cfg.skip.private_ip && net_utils.is_private_ip(connection.remote_ip)) {
+    if (plugin.cfg.skip.private_ip && net_utils.is_private_ip(connection.remote.ip)) {
         connection.results.add(plugin, {skip: test_name + '(private)'});
         return true;
     }
@@ -225,7 +225,7 @@ exports.rdns_match = function (next, connection, helo) {
         return next();
     }
 
-    var r_host = connection.remote_host;
+    var r_host = connection.remote.host;
     if (r_host && helo === r_host) {
         connection.results.add(plugin, {pass: 'rdns_match'});
         return next();
@@ -279,7 +279,7 @@ exports.dynamic = function (next, connection, helo) {
         return next();
     }
 
-    if (net_utils.is_ip_in_str(connection.remote_ip, helo)) {
+    if (net_utils.is_ip_in_str(connection.remote.ip, helo)) {
         connection.results.add(plugin, {fail: 'dynamic'});
         if (plugin.cfg.reject.dynamic) {
             return next(DENY, 'HELO is dynamic');
@@ -311,7 +311,7 @@ exports.big_company = function (next, connection, helo) {
         return next();
     }
 
-    var rdns = connection.remote_host;
+    var rdns = connection.remote.host;
     if (!rdns || rdns === 'Unknown' || rdns === 'DNSERROR') {
         connection.results.add(plugin, {fail: 'big_co(rDNS)'});
         if (plugin.cfg.reject.big_company) {
@@ -355,7 +355,7 @@ exports.literal_mismatch = function (next, connection, helo) {
     }
 
     if (lmm_mode > 1) {
-        if (net_utils.same_ipv4_network(connection.remote_ip, [helo_ip])) {
+        if (net_utils.same_ipv4_network(connection.remote.ip, [helo_ip])) {
             connection.results.add(plugin, {pass: 'literal_mismatch'});
             return next();
         }
@@ -367,7 +367,7 @@ exports.literal_mismatch = function (next, connection, helo) {
         return next();
     }
 
-    if (helo_ip === connection.remote_ip) {
+    if (helo_ip === connection.remote.ip) {
         connection.results.add(plugin, {pass: 'literal_mismatch'});
         return next();
     }
@@ -421,7 +421,7 @@ exports.forward_dns = function (next, connection, helo) {
         }
         connection.results.add(plugin, {ips: ips});
 
-        if (ips.indexOf(connection.remote_ip) !== -1) {
+        if (ips.indexOf(connection.remote.ip) !== -1) {
             connection.results.add(plugin, {pass: 'forward_dns'});
             return next();
         }
@@ -432,7 +432,7 @@ exports.forward_dns = function (next, connection, helo) {
         // the same domain, consider it close enough.
         if (connection.results.has('helo.checks', 'pass', /^rdns_match/)) {
             var helo_od = tlds.get_organizational_domain(helo);
-            var rdns_od = tlds.get_organizational_domain(connection.remote_host);
+            var rdns_od = tlds.get_organizational_domain(connection.remote.host);
             if (helo_od && helo_od === rdns_od) {
                 connection.results.add(plugin, {pass: 'forward_dns(domain)'});
                 return next();

--- a/plugins/karma.js
+++ b/plugins/karma.js
@@ -300,7 +300,7 @@ exports.tarpit_delay = function (score, connection, hook, k) {
     var delay = score * -1;   // progressive tarpit
 
     // detect roaming users based on MSA ports that require auth
-    if (utils.in_array(connection.local_port, [587,465]) &&
+    if (utils.in_array(connection.local.port, [587,465]) &&
         utils.in_array(hook, ['ehlo','connect'])) {
         return plugin.tarpit_delay_msa(connection, delay, k);
     }
@@ -472,7 +472,7 @@ exports.history_from_redis = function (next, connection) {
     var plugin = this;
 
     var expire = (plugin.cfg.redis.expire_days || 60) * 86400; // to days
-    var dbkey  = 'karma|' + connection.remote_ip;
+    var dbkey  = 'karma|' + connection.remote.ip;
 
     plugin.db.hgetall(dbkey, function (err, dbr) {
         if (err) {
@@ -481,7 +481,7 @@ exports.history_from_redis = function (next, connection) {
         }
 
         if (dbr === null) {
-            plugin.init_ip(dbkey, connection.remote_ip, expire);
+            plugin.init_ip(dbkey, connection.remote.ip, expire);
             return next();
         }
 
@@ -579,7 +579,7 @@ exports.hook_data_post = function (next, connection) {
 exports.increment = function (connection, key, val) {
     var plugin = this;
 
-    plugin.db.hincrby('karma|' + connection.remote_ip, key, 1);
+    plugin.db.hincrby('karma|' + connection.remote.ip, key, 1);
 
     var asnkey = plugin.get_asn_key(connection);
     if (asnkey) plugin.db.hincrby(asnkey, key, 1);

--- a/plugins/limit.js
+++ b/plugins/limit.js
@@ -159,7 +159,7 @@ exports.incr_concurrency = function (next, connection) {
 };
 
 exports.get_key = function (connection) {
-    return 'concurrency|' + connection.remote_ip;
+    return 'concurrency|' + connection.remote.ip;
 };
 
 exports.check_concurrency = function (next, connection) {

--- a/plugins/log.elasticsearch.js
+++ b/plugins/log.elasticsearch.js
@@ -72,8 +72,7 @@ exports.load_es_ini = function () {
         ['From', 'To', 'Subject'];
 
     plugin.cfg.conn_props = plugin.cfg.connection_properties ||
-        {   using_tls:undefined,
-            relaying:undefined,
+        {   relaying:undefined,
             totalbytes:undefined,
             pipelining:undefined,
             early_talker:undefined,
@@ -212,18 +211,21 @@ exports.populate_conn_properties = function (conn, res) {
     }
 
     conn_res.local = {
-        ip:   conn.local_ip,
-        port: conn.local_port,
+        ip:   conn.local.ip,
+        port: conn.local.port,
         host: plugin.cfg.hostname || require('os').hostname(),
     };
     conn_res.remote = {
-        ip:   conn.remote_ip,
-        host: conn.remote_host,
-        port: conn.remote_port,
+        ip:   conn.remote.ip,
+        host: conn.remote.host,
+        port: conn.remote.port,
     };
     conn_res.hello = {
-        host: conn.hello_host,
-        verb: conn.greeting,
+        host: conn.hello.host,
+        verb: conn.hello.verb,
+    };
+    conn_res.tls = {
+        enabled: conn.tls.enabled,
     };
 
     if (!conn_res.auth) {

--- a/plugins/lookup_rdns.strict.js
+++ b/plugins/lookup_rdns.strict.js
@@ -87,9 +87,9 @@ exports.hook_lookup_rdns = function (next, connection) {
     var timeout      = config.general && (config.general.timeout     || 60);
     var timeout_msg  = config.general && (config.general.timeout_msg || '');
 
-    if (_in_whitelist(connection, plugin, connection.remote_ip)) {
+    if (_in_whitelist(connection, plugin, connection.remote.ip)) {
         called_next++;
-        return next(OK, connection.remote_ip);
+        return next(OK, connection.remote.ip);
     }
 
     var call_next = function (code, msg) {
@@ -101,16 +101,16 @@ exports.hook_lookup_rdns = function (next, connection) {
 
     timeout_id = setTimeout(function () {
         connection.loginfo(plugin, 'timed out when looking up ' +
-            connection.remote_ip + '. Disconnecting.');
+            connection.remote.ip + '. Disconnecting.');
         call_next(DENYDISCONNECT,
-            '[' + connection.remote_ip + '] ' + timeout_msg);
+            '[' + connection.remote.ip + '] ' + timeout_msg);
     }, timeout * 1000);
 
-    dns.reverse(connection.remote_ip, function (err, domains) {
+    dns.reverse(connection.remote.ip, function (err, domains) {
         if (err) {
             if (!called_next) {
                 connection.auth_results("iprev=permerror");
-                _dns_error(connection, call_next, err, connection.remote_ip,
+                _dns_error(connection, call_next, err, connection.remote.ip,
                     plugin, rev_nxdomain, rev_dnserror);
             }
             return;
@@ -148,7 +148,7 @@ exports.hook_lookup_rdns = function (next, connection) {
                     return;
                 }
                 for (var j = 0; j < addresses.length ; j++) {
-                    if (addresses[j] === connection.remote_ip) {
+                    if (addresses[j] === connection.remote.ip) {
                         // We found a match, call next() and return
                         if (!called_next) {
                             connection.auth_results("iprev=pass");
@@ -159,7 +159,7 @@ exports.hook_lookup_rdns = function (next, connection) {
 
                 if (!called_next && !total_checks) {
                     call_next(DENYDISCONNECT, rdns2 + ' [' +
-                        connection.remote_ip + '] ' + nomatch);
+                        connection.remote.ip + '] ' + nomatch);
                 }
             });
         });

--- a/plugins/profile.js
+++ b/plugins/profile.js
@@ -1,11 +1,11 @@
 var prof = require('v8-profiler');
 
 exports.hook_connect_init = function (next, conn) {
-    prof.startProfiling("Connection from: " + conn.remote_ip);
+    prof.startProfiling("Connection from: " + conn.remote.ip);
     next();
 };
 
 exports.hook_disconnect = function (next, conn) {
-    prof.stopProfiling("Connection from: " + conn.remote_ip);
+    prof.stopProfiling("Connection from: " + conn.remote.ip);
     next();
 };

--- a/plugins/rate_limit.js
+++ b/plugins/rate_limit.js
@@ -228,7 +228,7 @@ exports.incr_concurrency = function (next, connection) {
 
     // Concurrency
     this.lookup_host_key('concurrency',
-        [connection.remote_ip, connection.remote_host],
+        [connection.remote.ip, connection.remote.host],
         lookup_cb);
 };
 
@@ -237,7 +237,7 @@ exports.decr_concurrency = function (next, connection) {
     var snotes = connection.server.notes;
 
     // Concurrency
-    this.lookup_host_key('concurrency', [connection.remote_ip, connection.remote_host], function (err, key, value) {
+    this.lookup_host_key('concurrency', [connection.remote.ip, connection.remote.host], function (err, key, value) {
         if (err) {
             connection.logerror(self, err);
             return next();
@@ -260,7 +260,7 @@ exports.hook_connect = function (next, connection) {
     var self = this;
     var config = this.config.get('rate_limit.ini');
 
-    this.lookup_host_key('rate_conn', [connection.remote_ip, connection.remote_host], function (err, key, value) {
+    this.lookup_host_key('rate_conn', [connection.remote.ip, connection.remote.host], function (err, key, value) {
         if (err) {
             connection.logerror(self, err);
             return next();
@@ -281,7 +281,7 @@ exports.hook_connect = function (next, connection) {
             }
             // See if we need to tarpit rate_rcpt_host
             if (config.main.tarpit_delay) {
-                self.lookup_host_key('rate_rcpt_host', [connection.remote_ip, connection.remote_host], function (err3, key2, value2) {
+                self.lookup_host_key('rate_rcpt_host', [connection.remote.ip, connection.remote.host], function (err3, key2, value2) {
                     if (!err3 && key2 && value2) {
                         var match = /^(\d+)/.exec(value2);
                         var limit = match[0];
@@ -316,7 +316,7 @@ exports.hook_rcpt = function (next, connection, params) {
         {
             name:           'rate_rcpt_host',
             lookup_func:    'lookup_host_key',
-            lookup_args:    [connection.remote_ip, connection.remote_host],
+            lookup_args:    [connection.remote.ip, connection.remote.host],
         },
         {
             name:           'rate_rcpt_sender',

--- a/plugins/rdns.regexp.js
+++ b/plugins/rdns.regexp.js
@@ -14,10 +14,10 @@ exports.hook_connect = function (next, connection) {
 
     for (var i=0,l=deny_list.length; i < l; i++) {
         var re = new RegExp(deny_list[i]);
-        if (re.test(connection.remote_host)) {
+        if (re.test(connection.remote.host)) {
             for (var i=0,l=allow_list.length; i < l; i++) {
                 var re = new RegExp(allow_list[i]);
-                if (re.test(connection.remote_host)) {
+                if (re.test(connection.remote.host)) {
                     connection.loginfo(this, "rdns matched: " + allow_list[i] +
                         ", allowing");
                     return next();

--- a/plugins/relay.js
+++ b/plugins/relay.js
@@ -80,7 +80,7 @@ exports.acl = function (next, connection) {
     var plugin = this;
     if (!plugin.cfg.relay.acl) { return next(); }
 
-    connection.logdebug(this, 'checking ' + connection.remote_ip + ' in relay_acl_allow');
+    connection.logdebug(this, 'checking ' + connection.remote.ip + ' in relay_acl_allow');
 
     if (!plugin.is_acl_allowed(connection)) {
         connection.results.add(plugin, {skip: 'acl(unlisted)'});
@@ -97,7 +97,7 @@ exports.is_acl_allowed = function (connection) {
     if (!plugin.acl_allow) { return false; }
     if (!plugin.acl_allow.length) { return false; }
 
-    var ip = connection.remote_ip;
+    var ip = connection.remote.ip;
 
     for (var i=0; i < plugin.acl_allow.length; i++) {
         var item = plugin.acl_allow[i];

--- a/plugins/rspamd.js
+++ b/plugins/rspamd.js
@@ -68,19 +68,19 @@ exports.get_options = function (connection) {
         options.headers.User = connection.notes.auth_user;
     }
 
-    if (connection.remote_ip) options.headers.IP = connection.remote_ip;
+    if (connection.remote.ip) options.headers.IP = connection.remote.ip;
 
     var fcrdns = connection.results.get('connect.fcrdns');
     if (fcrdns && fcrdns.fcrdns && fcrdns.fcrdns[0]) {
         options.headers.Hostname = fcrdns.fcrdns[0];
     }
     else {
-        if (connection.remote_host) {
-            options.headers.Hostname = connection.remote_host;
+        if (connection.remote.host) {
+            options.headers.Hostname = connection.remote.host;
         }
     }
 
-    if (connection.hello_host) options.headers.Helo = connection.hello_host;
+    if (connection.hello.host) options.headers.Helo = connection.hello.host;
 
     if (connection.transaction.mail_from) {
         var mfaddr = connection.transaction.mail_from.address().toString();
@@ -117,7 +117,7 @@ exports.hook_data_post = function (next, connection) {
     var authed = connection.notes.auth_user;
     if (authed && !cfg.check.authenticated) return next();
     if (!cfg.check.private_ip &&
-        net_utils.is_private_ip(connection.remote_ip)) {
+        net_utils.is_private_ip(connection.remote.ip)) {
         return next();
     }
 

--- a/plugins/watch/index.js
+++ b/plugins/watch/index.js
@@ -433,7 +433,7 @@ function get_local_port (connection) {
     if (!connection) return {
         classy: 'bg_white', newval: '25', title: 'disconnected'
     };
-    var p = connection.local_port || '25';
+    var p = connection.local.port || '25';
     if (!p || isNaN(p)) return {
         classy: 'black', newval: '25', title: 'disconnected'
     };
@@ -443,8 +443,8 @@ function get_local_port (connection) {
 }
 
 function get_remote_host (connection) {
-    var host  = connection.remote_host || '';
-    var ip    = connection.remote_ip || '';
+    var host  = connection.remote.host || '';
+    var ip    = connection.remote.ip || '';
     var hostShort = host;
 
     if (host) {
@@ -466,14 +466,14 @@ function get_remote_host (connection) {
 }
 
 function get_helo(connection) {
-    var helo = connection.hello_host;
+    var helo = connection.hello.host;
     if (!helo) return {};
     var r = {
         newval: helo.length > 22 ? '...'+helo.substring(helo.length -22) : helo,
         title:  helo,
     };
-    if (connection.remote_host &&
-        connection.remote_host.toLowerCase() === helo.toLowerCase()) {
+    if (connection.remote.host &&
+        connection.remote.host.toLowerCase() === helo.toLowerCase()) {
         r.classy = 'green';  // matches rDNS
     }
     else {
@@ -528,7 +528,7 @@ function get_early (connection) {
 }
 
 function get_tls (connection) {
-    if (!connection.using_tls) return {};
+    if (!connection.tls.enabled) return {};
     var tls = connection.notes.tls;
     if (!tls) { return { classy: 'bg_lgreen' }; }
     return {

--- a/plugins/xclient.js
+++ b/plugins/xclient.js
@@ -30,7 +30,7 @@ function xclient_allowed(ip) {
 }
 
 exports.hook_capabilities = function (next, connection) {
-    if (xclient_allowed(connection.remote_ip)) {
+    if (xclient_allowed(connection.remote.ip)) {
         connection.capabilities.push('XCLIENT NAME ADDR PROTO HELO LOGIN');
     }
     next();
@@ -47,7 +47,7 @@ exports.hook_unrecognized_command = function (next, connection, params) {
             DSN.proto_unspecified('Mail transaction in progress', 503));
     }
 
-    if (!(xclient_allowed(connection.remote_ip))) {
+    if (!(xclient_allowed(connection.remote.ip))) {
         return next(DENY, DSN.proto_unspecified('Not authorized', 550));
     }
 
@@ -111,12 +111,12 @@ exports.hook_unrecognized_command = function (next, connection, params) {
     connection.uuid = new_uuid;
     connection.reset_transaction();
     connection.relaying = false;
-    connection.remote_ip = xclient.addr;
-    connection.remote_host = (xclient.name) ? xclient.name : undefined;
-    connection.remote_login = (xclient.login) ? xclient.login : undefined;
-    connection.hello_host = (xclient.helo) ? xclient.helo : undefined;
+    connection.set('remote', 'ip', xclient.addr);
+    connection.set('remote', 'host', ((xclient.name) ? xclient.name : undefined));
+    connection.set('remote', 'login', ((xclient.login) ? xclient.login : undefined));
+    connection.set('hello', 'host', ((xclient.helo) ? xclient.helo : undefined));
     if (xclient.proto) {
-        connection.greeting = (xclient.proto === 'esmtp') ? 'EHLO' : 'HELO';
+        connection.set('hello', 'verb', ((xclient.proto === 'esmtp') ? 'EHLO' : 'HELO'));
     }
     connection.esmtp = (xclient.proto === 'esmtp') ? true : false;
     connection.xclient = true;

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -383,7 +383,7 @@ exports.get_client_plugin = function (plugin, connection, c, callback) {
 
         var helo = function (command) {
             if (smtp_client.xclient) {
-                smtp_client.send_command(command, connection.hello_host);
+                smtp_client.send_command(command, connection.hello.host);
             }
             else {
                 smtp_client.send_command(command, plugin.config.get('me'));
@@ -400,7 +400,7 @@ exports.get_client_plugin = function (plugin, connection, c, callback) {
             for (var line in smtp_client.response) {
                 if (smtp_client.response[line].match(/^XCLIENT/)) {
                     if (!smtp_client.xclient) {
-                        smtp_client.send_command('XCLIENT', 'ADDR=' + connection.remote_ip);
+                        smtp_client.send_command('XCLIENT', 'ADDR=' + connection.remote.ip);
                         return;
                     }
                 }
@@ -485,7 +485,7 @@ exports.get_client_plugin = function (plugin, connection, c, callback) {
 
         if (smtp_client.connected) {
             if (smtp_client.xclient) {
-                smtp_client.send_command('XCLIENT', 'ADDR=' + connection.remote_ip);
+                smtp_client.send_command('XCLIENT', 'ADDR=' + connection.remote.ip);
             }
             else {
                 smtp_client.emit('helo');

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -22,6 +22,48 @@ function _tear_down (callback) {
 exports.connection = {
     setUp : _set_up,
     tearDown : _tear_down,
+    'has remote object': function (test) {
+        test.expect(5);
+        test.deepEqual(this.connection.remote, {
+            ip: null,
+            port: null,
+            host: null,
+            info: null,
+            closed: false,
+            is_private: false
+        });
+        // backwards compat, sunset v3.0.0
+        test.equal(this.connection.remote_ip, null);
+        test.equal(this.connection.remote_port, null);
+        test.equal(this.connection.remote_host, null);
+        test.equal(this.connection.remote_info, null);
+        test.done();
+    },
+    'has local object': function (test) {
+        test.expect(3);
+        test.deepEqual(this.connection.local, {
+            ip: null,
+            port: null,
+            proxy: null,
+            host: null,
+        });
+        // backwards compat, sunset v3.0.0
+        test.equal(this.connection.local_ip, null);
+        test.equal(this.connection.local_port, null);
+        test.done();
+    },
+    'has tls object': function (test) {
+        test.expect(2);
+        test.deepEqual(this.connection.tls, {
+            enabled: false,
+            verified: false,
+            cipher: {},
+            authorized: null,
+        });
+        // backwards compat, sunset v3.0.0
+        test.equal(this.connection.using_tls, false);
+        test.done();
+    },
     'get_capabilities' : function (test) {
         test.expect(1);
 // console.log(this);

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -1,5 +1,6 @@
 var constants    = require('haraka-constants');
 
+/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "config" }]*/
 var config      = require('./config');
 var connection   = require('../connection');
 
@@ -56,6 +57,7 @@ exports.connection = {
         test.expect(2);
         test.deepEqual(this.connection.tls, {
             enabled: false,
+            advertised: false,
             verified: false,
             cipher: {},
             authorized: null,

--- a/tests/plugins/access.js
+++ b/tests/plugins/access.js
@@ -195,8 +195,8 @@ exports.rdns_access = {
             test.ok(this.connection.results.get('access').msg.length);
             test.done();
         }.bind(this);
-        this.connection.remote_ip='1.1.1.1';
-        this.connection.remote_host='host.example.com';
+        this.connection.remote.ip='1.1.1.1';
+        this.connection.remote.host='host.example.com';
         this.plugin.rdns_access(cb, this.connection);
     },
     'whitelist': function (test) {
@@ -208,8 +208,8 @@ exports.rdns_access = {
             // test.ok(this.connection.results.has('access', 'pass', /white/));
             test.done();
         }.bind(this);
-        this.connection.remote_ip='1.1.1.1';
-        this.connection.remote_host='host.example.com';
+        this.connection.remote.ip='1.1.1.1';
+        this.connection.remote.host='host.example.com';
         this.plugin.list.white.conn['host.example.com']=true;
         this.plugin.rdns_access(cb, this.connection);
     },
@@ -222,8 +222,8 @@ exports.rdns_access = {
             test.ok(this.connection.results.get('access').fail.length);
             test.done();
         }.bind(this);
-        this.connection.remote_ip='1.1.1.1';
-        this.connection.remote_host='host.example.com';
+        this.connection.remote.ip='1.1.1.1';
+        this.connection.remote.host='host.example.com';
         this.plugin.list.black.conn['host.example.com']=true;
         this.plugin.rdns_access(cb, this.connection);
     },
@@ -236,8 +236,8 @@ exports.rdns_access = {
             test.ok(this.connection.results.get('access').fail.length);
             test.done();
         }.bind(this);
-        this.connection.remote_ip='1.1.1.1';
-        this.connection.remote_host='host.antispam.com';
+        this.connection.remote.ip='1.1.1.1';
+        this.connection.remote.host='host.antispam.com';
         var black = [ '.*spam.com' ];
         this.plugin.list_re.black.conn = new RegExp('^(' + black.join('|') + ')$', 'i');
         this.plugin.rdns_access(cb, this.connection);

--- a/tests/plugins/auth/auth_base.js
+++ b/tests/plugins/auth/auth_base.js
@@ -59,7 +59,7 @@ exports.hook_capabilities = {
             // console.log(this.connection.capabilities);
             test.done();
         }.bind(this);
-        this.connection.using_tls=true;
+        this.connection.tls.enabled=true;
         this.connection.capabilities=[];
         this.plugin.hook_capabilities(cb, this.connection);
     },

--- a/tests/plugins/auth/auth_vpopmaild.js
+++ b/tests/plugins/auth/auth_vpopmaild.js
@@ -44,7 +44,7 @@ exports.hook_capabilities = {
             // console.log(this.connection.capabilities);
             test.done();
         }.bind(this);
-        this.connection.using_tls=true;
+        this.connection.tls.enabled=true;
         this.connection.capabilities=[];
         this.plugin.hook_capabilities(cb, this.connection);
     },
@@ -57,7 +57,7 @@ exports.hook_capabilities = {
             // console.log(this.connection.capabilities);
             test.done();
         }.bind(this);
-        this.connection.using_tls=true;
+        this.connection.tls.enabled=true;
         this.connection.capabilities=[];
         this.plugin.hook_capabilities(cb, this.connection);
     },

--- a/tests/plugins/bounce.js
+++ b/tests/plugins/bounce.js
@@ -30,7 +30,7 @@ var _set_up = function (done) {
     };
 
     this.connection = Connection.createConnection();
-    this.connection.remote_ip = '8.8.8.8';
+    this.connection.remote.ip = '8.8.8.8';
     this.connection.transaction = {
         header: new Header(),
         results: new ResultStore(this.plugin),

--- a/tests/plugins/connect.fcrdns.js
+++ b/tests/plugins/connect.fcrdns.js
@@ -120,43 +120,43 @@ exports.is_generic_rdns = {
     setUp : _set_up,
     'mail.theartfarm.com': function (test) {
         test.expect(1);
-        this.connection.remote_ip='208.75.177.101';
+        this.connection.remote.ip='208.75.177.101';
         test.equal(false, this.plugin.is_generic_rdns(this.connection, 'mail.theartfarm.com'));
         test.done();
     },
     'dsl-188-34-255-136.asretelecom.net': function (test) {
         test.expect(1);
-        this.connection.remote_ip='188.34.255.136';
+        this.connection.remote.ip='188.34.255.136';
         test.ok(this.plugin.is_generic_rdns(this.connection, 'dsl-188-34-255-136.asretelecom.net'));
         test.done();
     },
     'c-76-121-96-159.hsd1.wa.comcast.net': function (test) {
         test.expect(1);
-        this.connection.remote_ip='76.121.96.159';
+        this.connection.remote.ip='76.121.96.159';
         test.ok(this.plugin.is_generic_rdns(this.connection, 'c-76-121-96-159.hsd1.wa.comcast.net'));
         test.done();
     },
     'c-76-121-96-159.business.wa.comcast.net': function (test) {
         test.expect(1);
-        this.connection.remote_ip='76.121.96.159';
+        this.connection.remote.ip='76.121.96.159';
         test.equal(false, this.plugin.is_generic_rdns(this.connection, 'c-76-121-96-159.business.wa.comcast.net'));
         test.done();
     },
     'null': function (test) {
         test.expect(1);
-        this.connection.remote_ip='192.168.1.1';
+        this.connection.remote.ip='192.168.1.1';
         test.equal(false, this.plugin.is_generic_rdns(this.connection, null));
         test.done();
     },
     'tld, com': function (test) {
         test.expect(1);
-        this.connection.remote_ip='192.168.1.1';
+        this.connection.remote.ip='192.168.1.1';
         test.equal(false, this.plugin.is_generic_rdns(this.connection, 'com'));
         test.done();
     },
     'empty string': function (test) {
         test.expect(1);
-        this.connection.remote_ip='192.168.1.1';
+        this.connection.remote.ip='192.168.1.1';
         test.equal(false, this.plugin.is_generic_rdns(this.connection, ''));
         test.done();
     },
@@ -182,21 +182,21 @@ exports.ptr_compare = {
     setUp : _set_up,
     'fail': function (test) {
         test.expect(1);
-        this.connection.remote_ip = '10.1.1.1';
+        this.connection.remote.ip = '10.1.1.1';
         var iplist = ['10.0.1.1'];
         test.equal(false, this.plugin.ptr_compare(iplist, this.connection, 'foo.example.com'));
         test.done();
     },
     'pass exact': function (test) {
         test.expect(1);
-        this.connection.remote_ip = '10.1.1.1';
+        this.connection.remote.ip = '10.1.1.1';
         var iplist = ['10.1.1.1'];
         test.equal(true, this.plugin.ptr_compare(iplist, this.connection, 'foo.example.com'));
         test.done();
     },
     'pass net': function (test) {
         test.expect(1);
-        this.connection.remote_ip = '10.1.1.1';
+        this.connection.remote.ip = '10.1.1.1';
         var iplist = ['10.1.1.2'];
         test.equal(true, this.plugin.ptr_compare(iplist, this.connection, 'foo.example.com'));
         test.done();
@@ -211,7 +211,7 @@ exports.check_fcrdns = {
             test.equal(rc, undefined);
             test.done();
         };
-        this.connection.remote_ip = '10.1.1.1';
+        this.connection.remote.ip = '10.1.1.1';
         this.plugin.check_fcrdns(this.connection, ['foo.example.com'], cb);
     },
     'null host': function (test) {
@@ -221,7 +221,7 @@ exports.check_fcrdns = {
             test.equal(rc, undefined);
             test.done();
         };
-        this.connection.remote_ip = '10.1.1.1';
+        this.connection.remote.ip = '10.1.1.1';
         this.plugin.check_fcrdns(this.connection, ['foo.example.com','', null], cb);
     },
 };
@@ -232,7 +232,7 @@ exports.hook_lookup_rdns = {
         test.expect(3);
 
         var conn = this.connection;
-        conn.remote_ip = '8.8.4.4';
+        conn.remote.ip = '8.8.4.4';
 
         var cb = function (rc, msg) {
             test.ok( /google.com/.test(conn.results.get('connect.fcrdns').fcrdns[0]));

--- a/tests/plugins/connect.geoip.js
+++ b/tests/plugins/connect.geoip.js
@@ -95,7 +95,7 @@ exports.lookup_maxmind = {
             test.done();
         }.bind(this);
 
-        this.connection.remote_ip='192.48.85.146';
+        this.connection.remote.ip='192.48.85.146';
         this.plugin.cfg.main.calc_distance=true;
         this.plugin.lookup_maxmind(cb, this.connection);
     },
@@ -149,7 +149,7 @@ exports.lookup_geoip = {
             }
             test.done();
         }.bind(this);
-        this.connection.remote_ip='192.48.85.146';
+        this.connection.remote.ip='192.48.85.146';
         this.plugin.lookup_geoip(cb, this.connection);
     },
     'michigan: lat + long': function (test) {
@@ -163,7 +163,7 @@ exports.lookup_geoip = {
             }
             test.done();
         }.bind(this);
-        this.connection.remote_ip='199.176.179.3';
+        this.connection.remote.ip='199.176.179.3';
         this.plugin.lookup_geoip(cb, this.connection);
     },
 };
@@ -244,8 +244,8 @@ exports.calculate_distance = {
             return test.done();
         }
         this.plugin.cfg.main.calc_distance=true;
-        this.plugin.local_ip='192.48.85.146';
-        this.connection.remote_ip='199.176.179.3';
+        this.plugin.local.ip='192.48.85.146';
+        this.connection.remote.ip='199.176.179.3';
         this.plugin.calculate_distance(
                 this.connection,
                 [38, -97],

--- a/tests/plugins/deprecated/relay_acl.js
+++ b/tests/plugins/deprecated/relay_acl.js
@@ -24,36 +24,36 @@ exports.is_acl_allowed = {
     'bare IP' : function (test) {
         test.expect(3);
         this.plugin.acl_allow=['127.0.0.6'];
-        this.connection.remote_ip='127.0.0.6';
+        this.connection.remote.ip='127.0.0.6';
         test.equal(true, this.plugin.is_acl_allowed(this.connection));
-        this.connection.remote_ip='127.0.0.5';
+        this.connection.remote.ip='127.0.0.5';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
-        this.connection.remote_ip='127.0.1.5';
+        this.connection.remote.ip='127.0.1.5';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
         test.done();
     },
     'netmask' : function (test) {
         test.expect(3);
         this.plugin.acl_allow=['127.0.0.6/24'];
-        this.connection.remote_ip='127.0.0.6';
+        this.connection.remote.ip='127.0.0.6';
         test.equal(true, this.plugin.is_acl_allowed(this.connection));
-        this.connection.remote_ip='127.0.0.5';
+        this.connection.remote.ip='127.0.0.5';
         test.equal(true, this.plugin.is_acl_allowed(this.connection));
-        this.connection.remote_ip='127.0.1.5';
+        this.connection.remote.ip='127.0.1.5';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
         test.done();
     },
     'mixed (ipv4 & ipv6 (Issue #428))' : function (test) {
         test.expect(3);
-        this.connection.remote_ip='2607:f060:b008:feed::2';
+        this.connection.remote.ip='2607:f060:b008:feed::2';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
 
         this.plugin.acl_allow=['2607:f060:b008:feed::2/64'];
-        this.connection.remote_ip='2607:f060:b008:feed::2';
+        this.connection.remote.ip='2607:f060:b008:feed::2';
         test.equal(true, this.plugin.is_acl_allowed(this.connection));
 
         this.plugin.acl_allow=['127.0.0.6/24'];
-        this.connection.remote_ip='2607:f060:b008:feed::2';
+        this.connection.remote.ip='2607:f060:b008:feed::2';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
 
         test.done();

--- a/tests/plugins/dnsbl.js
+++ b/tests/plugins/dnsbl.js
@@ -66,13 +66,13 @@ exports.should_skip = {
     },
     'private remote_ip, no zones': function (test) {
         test.expect(1);
-        this.connection.remote_ip = '192.168.1.1';
+        this.connection.remote.ip = '192.168.1.1';
         test.equal(true, this.plugin.should_skip(this.connection));
         test.done();
     },
     'private remote_ip': function (test) {
         test.expect(1);
-        this.connection.remote_ip = '192.168.1.1';
+        this.connection.remote.ip = '192.168.1.1';
 
         this.plugin.load_config();
         this.plugin.cfg.main.zones = 'dnsbl.test, dnsbl2.test';
@@ -83,7 +83,7 @@ exports.should_skip = {
     },
     'public remote_ip': function (test) {
         test.expect(1);
-        this.connection.remote_ip = '208.1.1.1';
+        this.connection.remote.ip = '208.1.1.1';
 
         this.plugin.load_config();
         this.plugin.cfg.main.zones = 'dnsbl.test, dnsbl2.test';
@@ -94,7 +94,7 @@ exports.should_skip = {
     },
     'public remote_ip, no zones': function (test) {
         test.expect(1);
-        this.connection.remote_ip = '208.1.1.1';
+        this.connection.remote.ip = '208.1.1.1';
         test.equal(true, this.plugin.should_skip(this.connection));
         test.done();
     },

--- a/tests/plugins/early_talker.js
+++ b/tests/plugins/early_talker.js
@@ -74,7 +74,7 @@ exports.early_talker = {
         }.bind(this);
         this.plugin.pause = 1000;
         this.plugin.whitelist = this.plugin.load_ip_list(['127.0.0.1']);
-        this.connection.remote_ip = '127.0.0.1';
+        this.connection.remote.ip = '127.0.0.1';
         this.connection.early_talker = true;
         this.plugin.early_talker(next, this.connection);
     },
@@ -88,7 +88,7 @@ exports.early_talker = {
         }.bind(this);
         this.plugin.pause = 1000;
         this.plugin.whitelist = this.plugin.load_ip_list(['127.0.0.0/16']);
-        this.connection.remote_ip = '127.0.0.88';
+        this.connection.remote.ip = '127.0.0.88';
         this.connection.early_talker = true;
         this.plugin.early_talker(next, this.connection);
     },

--- a/tests/plugins/helo.checks.js
+++ b/tests/plugins/helo.checks.js
@@ -11,7 +11,7 @@ var _set_up = function (done) {
     this.plugin.config.root_path = path.resolve(__dirname, '../../config');
 
     this.connection = fixtures.connection.createConnection();
-    this.connection.remote_ip='208.75.199.19';
+    this.connection.remote.ip='208.75.199.19';
 
     this.plugin.register();
 
@@ -121,7 +121,7 @@ exports.rdns_match = {
             test.ok(outer.connection.results.get('helo.checks').pass.length);
         };
         this.plugin.init(stub, this.connection, 'helo.example.com');
-        this.connection.remote_host='helo.example.com';
+        this.connection.remote.host='helo.example.com';
         this.plugin.cfg.check.rdns_match=true;
         this.plugin.cfg.reject.rdns_match=true;
         this.plugin.rdns_match(cb, this.connection, 'helo.example.com');
@@ -136,7 +136,7 @@ exports.rdns_match = {
             test.ok(outer.connection.results.get('helo.checks').pass.length);
         };
         this.plugin.init(stub, this.connection, 'helo.example.com');
-        this.connection.remote_host='ehlo.example.com';
+        this.connection.remote.host='ehlo.example.com';
         this.plugin.cfg.check.rdns_match=true;
         this.plugin.cfg.reject.rdns_match=false;
         this.plugin.rdns_match(cb, this.connection, 'helo.example.com');
@@ -151,7 +151,7 @@ exports.rdns_match = {
             test.ok(outer.connection.results.get('helo.checks').fail.length);
         };
         this.plugin.init(stub, this.connection, 'helo.example.com');
-        this.connection.remote_host='ehlo.gmail.com';
+        this.connection.remote.host='ehlo.gmail.com';
         this.plugin.cfg.check.rdns_match=true;
         this.plugin.cfg.reject.rdns_match=false;
         this.plugin.rdns_match(cb, this.connection, 'helo.example.com');
@@ -166,7 +166,7 @@ exports.rdns_match = {
             test.ok(outer.connection.results.get('helo.checks').fail.length);
         };
         this.plugin.init(stub, this.connection, 'helo.example.com');
-        this.connection.remote_host='ehlo.gmail.com';
+        this.connection.remote.host='ehlo.gmail.com';
         this.plugin.cfg.check.rdns_match=true;
         this.plugin.cfg.reject.rdns_match=true;
         this.plugin.rdns_match(cb, this.connection, 'helo.example.com');
@@ -228,7 +228,7 @@ exports.dynamic = {
             test.equal(undefined, arguments[0]);
             test.ok(outer.connection.results.get('helo.checks').pass.length);
         };
-        this.connection.remote_ip='208.75.177.99';
+        this.connection.remote.ip='208.75.177.99';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.dynamic=true;
         this.plugin.cfg.reject.dynamic=true;
@@ -244,7 +244,7 @@ exports.dynamic = {
             // console.log(outer.connection.results.get('helo.checks'));
             test.ok(outer.connection.results.get('helo.checks').fail.length);
         };
-        this.connection.remote_ip='76.121.96.159';
+        this.connection.remote.ip='76.121.96.159';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.dynamic=true;
         this.plugin.cfg.reject.dynamic=false;
@@ -260,7 +260,7 @@ exports.dynamic = {
             // console.log(outer.connection.results.get('helo.checks'));
             test.ok(outer.connection.results.get('helo.checks').fail.length);
         };
-        this.connection.remote_ip='76.121.96.159';
+        this.connection.remote.ip='76.121.96.159';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.dynamic=true;
         this.plugin.cfg.reject.dynamic=true;
@@ -280,7 +280,7 @@ exports.big_company = {
             test.ok(outer.connection.results.get('helo.checks').pass.length);
             test.done();
         };
-        this.connection.remote_host='yahoo.com';
+        this.connection.remote.host='yahoo.com';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.big_company=true;
         this.plugin.cfg.reject.big_company=true;
@@ -295,7 +295,7 @@ exports.big_company = {
             test.ok(outer.connection.results.get('helo.checks').fail.length);
             test.done();
         };
-        this.connection.remote_host='anything-else.com';
+        this.connection.remote.host='anything-else.com';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.big_company=true;
         this.plugin.cfg.reject.big_company=false;
@@ -310,7 +310,7 @@ exports.big_company = {
             test.ok(outer.connection.results.get('helo.checks').fail.length);
             test.done();
         };
-        this.connection.remote_host='anything-else.com';
+        this.connection.remote.host='anything-else.com';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.big_company=true;
         this.plugin.cfg.reject.big_company=true;
@@ -330,7 +330,7 @@ exports.literal_mismatch = {
             test.ok(outer.connection.results.get('helo.checks').skip.length);
             test.done();
         };
-        this.connection.remote_ip='10.0.1.1';
+        this.connection.remote.ip='10.0.1.1';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.literal_mismatch=1;
         this.plugin.cfg.reject.literal_mismatch=true;
@@ -346,7 +346,7 @@ exports.literal_mismatch = {
             test.ok(outer.connection.results.get('helo.checks').skip.length);
             test.done();
         };
-        this.connection.remote_ip='10.0.1.2';
+        this.connection.remote.ip='10.0.1.2';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.literal_mismatch=2;
         this.plugin.cfg.reject.literal_mismatch=true;
@@ -362,7 +362,7 @@ exports.literal_mismatch = {
             test.ok(outer.connection.results.get('helo.checks').skip.length);
             test.done();
         };
-        this.connection.remote_ip='10.0.1.2';
+        this.connection.remote.ip='10.0.1.2';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.literal_mismatch=0;
         this.plugin.cfg.reject.literal_mismatch=false;
@@ -378,7 +378,7 @@ exports.literal_mismatch = {
             test.ok(outer.connection.results.get('helo.checks').skip.length);
             test.done();
         };
-        this.connection.remote_ip='10.0.1.2';
+        this.connection.remote.ip='10.0.1.2';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.literal_mismatch=0;
         this.plugin.cfg.reject.literal_mismatch=true;
@@ -448,7 +448,7 @@ exports.forward_dns = {
             test.ok(outer.connection.results.get('helo.checks').pass.length);
             test.done();
         };
-        this.connection.remote_ip='4.2.2.2';
+        this.connection.remote.ip='4.2.2.2';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.forward_dns=true;
         this.plugin.cfg.reject.forward_dns=true;
@@ -465,7 +465,7 @@ exports.forward_dns = {
             test.ok(outer.connection.results.get('helo.checks').fail.length);
             test.done();
         };
-        this.connection.remote_ip='66.128.51.163';
+        this.connection.remote.ip='66.128.51.163';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.forward_dns=true;
         this.plugin.cfg.reject.forward_dns=false;
@@ -482,7 +482,7 @@ exports.forward_dns = {
             test.ok(outer.connection.results.get('helo.checks').fail.length);
             test.done();
         };
-        this.connection.remote_ip='66.128.51.163';
+        this.connection.remote.ip='66.128.51.163';
         this.plugin.init(stub, this.connection, test_helo);
         this.plugin.cfg.check.forward_dns=true;
         this.plugin.cfg.reject.forward_dns=true;

--- a/tests/plugins/log.elasticsearch.js
+++ b/tests/plugins/log.elasticsearch.js
@@ -83,8 +83,8 @@ exports.populate_conn_properties = {
     setUp : _set_up,
     'adds conn.local' : function (test) {
         test.expect(1);
-        this.connection.local_ip= '127.0.0.3';
-        this.connection.local_port= '25';
+        this.connection.local.ip= '127.0.0.3';
+        this.connection.local.port= '25';
         var result = {};
         var expected = { ip: '127.0.0.3', port: '25' };
         this.plugin.load_es_ini();
@@ -95,8 +95,8 @@ exports.populate_conn_properties = {
     },
     'adds conn.remote' : function (test) {
         test.expect(1);
-        this.connection.remote_ip='127.0.0.4';
-        this.connection.remote_port='2525';
+        this.connection.remote.ip='127.0.0.4';
+        this.connection.remote.port='2525';
         var result = {};
         var expected = { ip: '127.0.0.4', port: '2525' };
         this.plugin.load_es_ini();
@@ -107,8 +107,8 @@ exports.populate_conn_properties = {
     },
     'adds conn.helo' : function (test) {
         test.expect(1);
-        this.connection.hello_host='testimerson';
-        this.connection.greeting='EHLO';
+        this.connection.hello.host='testimerson';
+        this.connection.hello.verb='EHLO';
         var result = {};
         var expected = { host: 'testimerson', verb: 'EHLO' };
         this.plugin.load_es_ini();

--- a/tests/plugins/relay.js
+++ b/tests/plugins/relay.js
@@ -56,36 +56,36 @@ exports.is_acl_allowed = {
     'bare IP' : function (test) {
         test.expect(3);
         this.plugin.acl_allow=['127.0.0.6'];
-        this.connection.remote_ip='127.0.0.6';
+        this.connection.remote.ip='127.0.0.6';
         test.equal(true, this.plugin.is_acl_allowed(this.connection));
-        this.connection.remote_ip='127.0.0.5';
+        this.connection.remote.ip='127.0.0.5';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
-        this.connection.remote_ip='127.0.1.5';
+        this.connection.remote.ip='127.0.1.5';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
         test.done();
     },
     'netmask' : function (test) {
         test.expect(3);
         this.plugin.acl_allow=['127.0.0.6/24'];
-        this.connection.remote_ip='127.0.0.6';
+        this.connection.remote.ip='127.0.0.6';
         test.equal(true, this.plugin.is_acl_allowed(this.connection));
-        this.connection.remote_ip='127.0.0.5';
+        this.connection.remote.ip='127.0.0.5';
         test.equal(true, this.plugin.is_acl_allowed(this.connection));
-        this.connection.remote_ip='127.0.1.5';
+        this.connection.remote.ip='127.0.1.5';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
         test.done();
     },
     'mixed (ipv4 & ipv6 (Issue #428))' : function (test) {
         test.expect(3);
-        this.connection.remote_ip='2607:f060:b008:feed::2';
+        this.connection.remote.ip='2607:f060:b008:feed::2';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
 
         this.plugin.acl_allow=['2607:f060:b008:feed::2/64'];
-        this.connection.remote_ip='2607:f060:b008:feed::2';
+        this.connection.remote.ip='2607:f060:b008:feed::2';
         test.equal(true, this.plugin.is_acl_allowed(this.connection));
 
         this.plugin.acl_allow=['127.0.0.6/24'];
-        this.connection.remote_ip='2607:f060:b008:feed::2';
+        this.connection.remote.ip='2607:f060:b008:feed::2';
         test.equal(false, this.plugin.is_acl_allowed(this.connection));
 
         test.done();
@@ -126,7 +126,7 @@ exports.acl = {
             test.done();
         }.bind(this);
         this.plugin.cfg.relay.acl=true;
-        this.connection.remote_ip='1.1.1.1';
+        this.connection.remote.ip='1.1.1.1';
         this.plugin.acl_allow=['1.1.1.1/32'];
         this.plugin.acl(next, this.connection);
     },
@@ -138,7 +138,7 @@ exports.acl = {
             test.done();
         }.bind(this);
         this.plugin.cfg.relay.acl=true;
-        this.connection.remote_ip='1.1.1.1';
+        this.connection.remote.ip='1.1.1.1';
         this.plugin.acl_allow=['1.1.1.1'];
         this.plugin.acl(next, this.connection);
     },
@@ -150,7 +150,7 @@ exports.acl = {
             test.done();
         }.bind(this);
         this.plugin.cfg.relay.acl=true;
-        this.connection.remote_ip='1.1.1.1';
+        this.connection.remote.ip='1.1.1.1';
         this.plugin.acl_allow=['1.1.1.1/24'];
         this.plugin.acl(next, this.connection);
     },

--- a/tests/plugins/spf.js
+++ b/tests/plugins/spf.js
@@ -151,11 +151,11 @@ exports.hook_helo = {
             if (completed >= 3) test.done();
         };
         test.expect(3);
-        this.connection.remote_ip='192.168.1.1';
+        this.connection.remote.ip='192.168.1.1';
         this.plugin.hook_helo(next, this.connection);
-        this.connection.remote_ip='10.0.1.1';
+        this.connection.remote.ip='10.0.1.1';
         this.plugin.hook_helo(next, this.connection);
-        this.connection.remote_ip='127.0.0.1';
+        this.connection.remote.ip='127.0.0.1';
         this.plugin.hook_helo(next, this.connection, 'helo.sender.com');
     },
     'IPv4 literal': function (test) {
@@ -164,7 +164,7 @@ exports.hook_helo = {
             test.done();
         };
         test.expect(1);
-        this.connection.remote_ip='190.168.1.1';
+        this.connection.remote.ip='190.168.1.1';
         this.plugin.hook_helo(next, this.connection, '[190.168.1.1]' );
     },
 
@@ -178,7 +178,7 @@ exports.hook_mail = {
             test.done();
         };
         test.expect(1);
-        this.connection.remote_ip='192.168.1.1';
+        this.connection.remote.ip='192.168.1.1';
         this.plugin.hook_mail(next, this.connection);
     },
     'rfc1918 relaying': function (test) {
@@ -187,7 +187,7 @@ exports.hook_mail = {
             test.done();
         };
         test.expect(1);
-        this.connection.remote_ip='192.168.1.1';
+        this.connection.remote.ip='192.168.1.1';
         this.connection.relaying=true;
         this.plugin.hook_mail(next, this.connection);
     },
@@ -197,7 +197,7 @@ exports.hook_mail = {
             test.done();
         };
         test.expect(1);
-        this.connection.remote_ip='207.85.1.1';
+        this.connection.remote.ip='207.85.1.1';
         this.plugin.hook_mail(next, this.connection);
     },
     'txn, no helo': function (test) {
@@ -206,7 +206,7 @@ exports.hook_mail = {
             test.done();
         };
         test.expect(1);
-        this.connection.remote_ip='207.85.1.1';
+        this.connection.remote.ip='207.85.1.1';
         this.plugin.hook_mail(next, this.connection,
             [new Address('<test@example.com>')]);
     },
@@ -216,8 +216,8 @@ exports.hook_mail = {
             test.done();
         };
         test.expect(1);
-        this.connection.remote_ip='207.85.1.1';
-        this.connection.hello_host = 'mail.example.com';
+        this.connection.set('remote', 'ip', '207.85.1.1');
+        this.connection.set('hello', 'host', 'mail.example.com');
         this.plugin.hook_mail(next, this.connection,
             [new Address('<test@example.com>')]);
     },
@@ -227,9 +227,9 @@ exports.hook_mail = {
             test.done();
         };
         test.expect(1);
-        this.connection.remote_ip='207.85.1.1';
+        this.connection.set('remote', 'ip', '207.85.1.1');
         this.connection.relaying=true;
-        this.connection.hello_host = 'mail.example.com';
+        this.connection.set('hello', 'host', 'mail.example.com');
         this.plugin.hook_mail(next, this.connection,
             [new Address('<test@example.com>')]);
     },


### PR DESCRIPTION
### work in progress

Fixes #1098

### connection.js changes *only* in #1577 

- converts connection.remote_* to connection.remote.*
- converts connection.local_* to connection.local.*
- converts connection.using_tls -> connection.tls.enabled
- converts connect.greeting -> connection.hello.verb
- maintains previous names, providing backwards compatibility

### Changes proposed in this pull request:

* updates all code to use the new normalized locations
* Updates all the connection.set invocations to use the new connection.set()

Checklist:
- [x] docs updated
- [x] tests updated
