### PR TITLE
AUTH PLAIN splitted into two lines

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -460,17 +460,18 @@ Connection.prototype.respond = function(code, msg, func) {
         code = msg.code;
         msg = msg.reply;
     }
-    if (!(Array.isArray(msg))) {
-        // msg not an array, make it so:
-        messages = msg.toString().split(/\n/).filter(function (msg2) {
-            return /\S/.test(msg2);
-        });
+    if (!Array.isArray(msg)) {
+        messages = msg.toString().split(/\n/);
+    } else {
+        messages = msg.slice();
     }
-    else {
-        // copy
-        messages = msg.slice().filter(function (msg2) {
-            return /\S/.test(msg2);
-        });
+    messages = messages.filter(function (msg2) {
+        return /\S/.test(msg2);
+    });
+
+    // Multiline AUTH PLAIN as in RFC-4954 page 8.
+    if (code === 334 && !messages.length) {
+        messages = [' '];
     }
 
     if (code >= 400) {

--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -183,16 +183,26 @@ exports.select_auth_method = function(next, connection, method) {
 
 exports.auth_plain = function(next, connection, params) {
     var plugin = this;
-    if (!params || !params.length) {
-        connection.respond(334, ' ', function () {
-            return next(OK);
-        });
-        return;
+    // one parameter given on line, either:
+    //    AUTH PLAIN <param> or
+    //    AUTH PLAIN\n
+    //...
+    //    <param>
+    if (params[0]) {
+        var credentials = utils.unbase64(params[0]).split(/\0/);
+        credentials.shift();  // Discard authid
+        return plugin.check_user(next, connection, credentials, AUTH_METHOD_PLAIN);
+    } else {
+        if (connection.notes.auth_plain_asked_login) {
+            return next(DENYDISCONNECT, 'bad protocol');
+        } else {
+            connection.respond(334, ' ', function () {
+                connection.notes.auth_plain_asked_login = true;
+                return next(OK);
+            });
+            return;
+        }
     }
-
-    var credentials = utils.unbase64(params[0]).split(/\0/);
-    credentials.shift();  // Discard authid
-    return plugin.check_user(next, connection, credentials, AUTH_METHOD_PLAIN);
 };
 
 exports.auth_login = function(next, connection, params) {

--- a/tests/plugins/auth/auth_base.js
+++ b/tests/plugins/auth/auth_base.js
@@ -171,6 +171,15 @@ exports.auth_plain = {
         var method = utils.base64('discard\0test\0testpass');
         this.plugin.auth_plain(next, this.connection, [method]);
     },
+    'params type=with two line login': function (test) {
+        var next = function () {
+            test.expect(2);
+            test.equal(this.connection.notes.auth_plain_asked_login, true);
+            test.equal(arguments[0], OK);
+            test.done();
+        }.bind(this);
+        this.plugin.auth_plain(next, this.connection, '');
+    },
 };
 
 exports.check_user = {


### PR DESCRIPTION
Fixes #1366 .

Changes proposed in this pull request:
- AUTH PLAIN divided in two lines: Server should respond with 334 code.

Checklist:
- [x] tests updated

Now also additional email clients can connect to Haraka, such as Gnome geary.