### PR TITLE
Fix adding/removing headers in rspamd plugin; add never_add_headers

### DIFF
--- a/config/rspamd.ini
+++ b/config/rspamd.ini
@@ -1,6 +1,9 @@
 ;host = localhost
 ;port = 11333
-;always_add_headers = false
+;add_headers = sometimes
+
+[dkim]
+;enabled = true
 
 [header]
 bar = X-Rspamd-Bar
@@ -15,6 +18,9 @@ score = X-Rspamd-Score
 ;message = Detected as spam
 ;authenticated=false
 ;spam = true
+
+[rmilter_headers]
+;enabled = true
 
 [spambar]
 ;positive = +

--- a/docs/plugins/rspamd.md
+++ b/docs/plugins/rspamd.md
@@ -20,6 +20,18 @@ rspamd.ini
 
     Port Rspamd is listening on.
 
+- add\_headers
+
+    Default: sometimes
+
+    Possible values are:
+
+        "always" - always add headers
+        "never" - never add headers (unless provided by rspamd - see rmilter\_headers)
+        "sometimes" - add headers when rspamd recommends `add header` action
+
+    Format of these headers is governed by header.* settings
+
 - reject.message
 
     Default: Detected as spam
@@ -58,13 +70,6 @@ rspamd.ini
 
     If set to true, allow rspamd to add DKIM signatures to messages.
 
-- always\_add\_headers
-
-    Default: false
-
-    If true, always add headers (otherwise only do this when Rspamd recommends
-    *add header* action).
-
 - header.bar
 
     Default: undefined
@@ -84,11 +89,11 @@ rspamd.ini
 
     If set, add the numeric spam score in a header with this name.
 
-- headers.enabled
+- rmilter_headers.enabled
 
     Default: true
 
-    If set to true, allow rspamd to add/remove headers from messages.
+    If set to true, allow rspamd to add/remove headers to messages via [task:rmilter_set_reply()](https://rspamd.com/doc/lua/task.html#me7351).
 
 - soft\_reject.enabled
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Oops! We had some [bad documentation](https://github.com/vstakhov/rspamd/pull/836/files) RE: use of `task:set_rmilter_reply` and consequently Haraka plugin was expecting data in a wrong format. :(
- Also add `never_add_headers` option, which could be useful if you want to use custom headers from Rspamd, or just don't want to add headers for whatever reason.

Checklist:
- [x] docs updated
- [ ] ~~tests updated~~