### PR TITLE
delay_deny: add included mode

### DIFF
--- a/docs/plugins/delay_deny.md
+++ b/docs/plugins/delay_deny.md
@@ -8,6 +8,14 @@ This allows relays and authenticated users to bypass pre-DATA rejections.
 
 Configuration options are in config/delay\_deny.ini.
 
+This plugin operates in one of two modes: included and excluded.
+
+### included plugins
+
+A comma or semicolon separated list of denials that are to be included.
+In this mode, _only_ plugins in the list are bypassed. All other plugins
+can immediately reject connections.
+
 ### excluded plugins
 
 A comma or semicolon separated list of denials that are to be excluded.


### PR DESCRIPTION
Currently, this plugin delay denies everything unless listed in the
config file. This can be a little risky when experimenting this plugin
when a lot of other plugins are already in use.

In such cases, it's easier to use an included mode (a whitelist mode)
where one can add plugins to bypass one by one.