### PR TITLE
rcpt_to.routes URI format w/ LMTP support

### DIFF
--- a/docs/plugins/rcpt_to.routes.md
+++ b/docs/plugins/rcpt_to.routes.md
@@ -60,6 +60,11 @@ The [routes] section can include routes for domains and email addresses:
     matt@example.com=some.where.com
     spam@example.com=honeybucket.where.com:26
 
+You may also use URI format to specify SMTP vs LMTP:
+    [routes]
+    aaron@example.com=lmtp://mail.example.com:2525
+    matt@example.com=smtp://127.0.0.1:4242
+
 # Performance
 
 ## File based

--- a/docs/plugins/rcpt_to.routes.md
+++ b/docs/plugins/rcpt_to.routes.md
@@ -1,4 +1,4 @@
-# `rcpt_to.routes`
+# rcpt_to.routes
 
 Recipient Routes does two things: recipient validation and MX routing.
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "js-yaml"               : "~3.6.1",
     "nopt"                  : "~3.0.4",
     "npid"                  : "~0.4.0",
+    "url-parse"             : "~1.1.3",
     "semver"                : "~5.0.3",
     "sprintf-js"            : "~1.0.3",
     "haraka-tld"            : "*",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "js-yaml"               : "~3.6.1",
     "nopt"                  : "~3.0.4",
     "npid"                  : "~0.4.0",
-    "url-parse"             : "~1.1.3",
     "semver"                : "~5.0.3",
     "sprintf-js"            : "~1.0.3",
     "haraka-tld"            : "*",

--- a/plugins/rcpt_to.routes.js
+++ b/plugins/rcpt_to.routes.js
@@ -3,7 +3,7 @@
 // validates incoming recipients against flat file & Redis
 // routes mail based on per-email or per-domain specified routes
 
-var urlparser = require('url-parse');
+var urlparser = require('url');
 
 exports.register = function() {
     var plugin = this;
@@ -120,7 +120,7 @@ exports.get_mx = function(next, hmail, domain) {
         var mx = {};
         // check email adress for route
         if (plugin.route_list[address]) {
-            var uri = new urlparser(plugin.route_list[address]);
+            var uri = new urlparser.parse(plugin.route_list[address]);
             if ( uri.protocol == 'lmtp:' ) {
                 mx.exchange = uri.hostname;
                 mx.port = uri.port;

--- a/plugins/rcpt_to.routes.js
+++ b/plugins/rcpt_to.routes.js
@@ -108,9 +108,9 @@ exports.get_mx = function(next, hmail, domain) {
     var plugin = this;
 
     // get email address
-    var address = domain;
+    var address = domain.toLowerCase();
     if (hmail && hmail.todo && hmail.todo.rcpt_to && hmail.todo.rcpt_to[0]) {
-        address = hmail.todo.rcpt_to[0].address();
+        address = hmail.todo.rcpt_to[0].address().toLowerCase();
     }
     else {
         plugin.logerror('no rcpt from hmail, falling back to domain' );


### PR DESCRIPTION
- Allow rcpt_to.routes to use URI-formatted destinations so ```lmtp://``` vs ```smtp://``` can be specified

- [x] docs updated
- [ ] tests updated

Existing tests pass, but I'm not sure they are thorough enough.  I'm a bit lost in the rcpt_to.routes.js test file, so I haven't written specific tests for my changes yet.