### PR TITLE
Allow streams in outbound.send_email contents

### DIFF
--- a/line_socket.js
+++ b/line_socket.js
@@ -4,7 +4,7 @@
 var net  = require('net');
 var tls  = require('./tls_socket');
 var util = require('util');
-var line_regexp = /^([^\n]*\n)/;
+var line_regexp = require('./utils').line_regexp;
 
 function Socket(options) {
     if (!(this instanceof Socket)) return new Socket(options);

--- a/outbound.js
+++ b/outbound.js
@@ -551,8 +551,8 @@ function stream_line_reader (stream, transaction, cb) {
         cb();
     };
 
-    stream.on('data', function (data) { process_data(data);});
-    stream.once('end',  function ()     { process_end();     });
+    stream.on('data', process_data);
+    stream.once('end', process_end);
     stream.once('error', cb);
 }
 

--- a/outbound.js
+++ b/outbound.js
@@ -522,7 +522,7 @@ exports.send_email = function () {
             if (err) {
                 return next(DENYSOFT, "Error from stream line reader: " + err);
             }
-            this.send_trans_email(transaction, next);
+            exports.send_trans_email(transaction, next);
         });
     }
 
@@ -538,6 +538,9 @@ function stream_line_reader (stream, transaction, cb) {
         while (results = line_regexp.exec(current_data)) {
             var this_line = results[1];
             current_data = current_data.slice(this_line.length);
+            if (!(current_data.length || this_line.length)) {
+                return;
+            }
             transaction.add_data(new Buffer(this_line));
         }
     };

--- a/outbound.js
+++ b/outbound.js
@@ -38,6 +38,9 @@ var my_hostname = require('os').hostname().replace(/\\/, '\\057').replace(/:/, '
 // File Name Format: $time_$attempts_$pid_$uniq.$host
 var fn_re = /^(\d+)_(\d+)_(\d+)(_\d+\..*)$/
 
+// Line regexp
+var line_regexp = utils.line_regexp;
+
 // TODO: For testability, this should be accessible
 var queue_dir = path.resolve(config.get('queue_dir') || (process.env.HARAKA + '/queue'));
 
@@ -431,7 +434,6 @@ function _fname () {
     return time + '_0_' + process.pid + "_" + _next_uniq() + '.' + my_hostname;
 }
 
-var line_regexp = /^([^\n]*\n?)/;
 exports.send_email = function () {
 
     if (arguments.length === 2) {
@@ -1795,7 +1797,6 @@ HMailItem.prototype.populate_bounce_message = function (from, to, reason, cb) {
     var original_header_lines = [];
     var headers_done = false;
     var header = new Header();
-    var line_regexp = /^([^\n]*\n)/;
 
     try {
         var data_stream = this.data_stream();

--- a/utils.js
+++ b/utils.js
@@ -310,4 +310,4 @@ exports.wildcard_to_regexp = function (str) {
         .replace('\\?', '.') + '$';
 };
 
-exports.line_regexp = /^([^\n]*\n?)/;
+exports.line_regexp = /^([^\n]*\n)/;

--- a/utils.js
+++ b/utils.js
@@ -310,4 +310,4 @@ exports.wildcard_to_regexp = function (str) {
         .replace('\\?', '.') + '$';
 };
 
-export.line_regexp = /^([^\n]*\n?)/;
+exports.line_regexp = /^([^\n]*\n?)/;

--- a/utils.js
+++ b/utils.js
@@ -309,3 +309,5 @@ exports.wildcard_to_regexp = function (str) {
         .replace('\\*', '.*')
         .replace('\\?', '.') + '$';
 };
+
+export.line_regexp = /^([^\n]*\n?)/;


### PR DESCRIPTION
Fixes #1549  .

Changes proposed in this pull request:
- Allow send_email to use a stream in the `contents` object

Checklist:
- [ ] docs updated
- [ ] tests updated

