### PR TITLE
Catch errors on header decode in rfc2231

### DIFF
--- a/mailheader.js
+++ b/mailheader.js
@@ -135,7 +135,12 @@ function _decode_rfc2231 (params) {
 
         params.cur_key = key_actual;
         params.keys[key_actual] = '';
-        value = decodeURIComponent(value);
+        try {
+            value = decodeURIComponent(value);
+        }
+        catch (e) {
+            logger.logerror("Decode header failed: " + key + ": " + value);
+        }
         params.kv[key_actual + '*' + key_id] = params.cur_enc ? try_convert(value, params.cur_enc) : value;
         return '';
     }


### PR DESCRIPTION
Fixes #1596 .

Changes proposed in this pull request:
- Catch errors from decodeURIcomponent()

Checklist:
- [ ] docs updated
- [ ] tests updated

