### PR TITLE
handle valid recipients properly in rcpt_to.ldap

### DIFF
--- a/plugins/rcpt_to.ldap.js
+++ b/plugins/rcpt_to.ldap.js
@@ -97,7 +97,10 @@ exports.ldap_rcpt = function(next, connection, params) {
         res.on('end', function(result) {
             connection.logdebug(plugin, 'LDAP search results: ' + items.length + ' -- ' + util.inspect(items));
 
-            if (items.length) return next();
+            if (items.length) {
+              txn.results.add(plugin, {pass: 'rcpt_to'});
+              return next(OK);
+            }
 
             next(DENY, "Sorry - no mailbox here by that name.");
         });


### PR DESCRIPTION
add rcpt_to to passed results and send next(ok) if a fitting mail attribute was found to properly indicate a successfull recipient lookup