### PR TITLE
Switch 'setuser root' for sudo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN /etc/my_init.d/00_regen_ssh_host_keys.sh
 RUN sed 's/main$/main universe/' -i /etc/apt/sources.list
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y -q update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y -q install python-software-properties g++ make git curl
-RUN curl -sL https://deb.nodesource.com/setup_5.x | sudo bash -
+RUN curl -sL https://deb.nodesource.com/setup_5.x | setuser root bash -
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y -q install nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Fixes #1607

Changes proposed in this pull request:
- change 'setuser root' for 'sudo' in Dockerfile
-
-

Checklist:
- [x] docs updated (n/a)
- [x] tests updated (n/a)

Use setuser within phusion/baseimage and avoid the "sudo command
not found" error.