### PR TITLE
Enforce line endings in streams

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -544,13 +544,13 @@ function stream_line_reader (stream, transaction, cb) {
             if (!(current_data.length || this_line.length)) {
                 return;
             }
-            transaction.add_data(new Buffer(this_line));
+            transaction.add_data(new Buffer(this_line.replace(/\r?\n$/, "\r\n")));
         }
     };
 
     function process_end () {
         if (current_data.length) {
-            transaction.add_data(new Buffer(current_data));
+            transaction.add_data(new Buffer(current_data.replace(/\r?\n$/, "\r\n")));
         }
         current_data = '';
         transaction.message_stream.add_line_end();


### PR DESCRIPTION
Fixes #1583 (maybe).

Changes proposed in this pull request:
- Enforce line endings in streams on send_trans_email
