### PR TITLE
update geoip for compat with newer ES

### DIFF
--- a/docs/plugins/log.elasticsearch.md
+++ b/docs/plugins/log.elasticsearch.md
@@ -132,7 +132,7 @@ curl -XPUT localhost:9200/_template/haraka_results -d '
                         "geoip" : {
                             "properties" : {
                                 "org"      : { "type" : "string", "index" : "not_analyzed" },
-                                "ll"       : { "type" : "geo_point" },
+                                "geo"      : { "type" : "geo_point" },
                                 "distance" : { "type" : "float" }
                             }
                         },

--- a/plugins/connect.geoip.js
+++ b/plugins/connect.geoip.js
@@ -146,6 +146,12 @@ exports.lookup_maxmind = function (next, connection) {
     }
     if (loc.latitude) {
         connection.results.add(plugin, {ll: [loc.latitude, loc.longitude]});
+        connection.results.add(plugin, {
+            geo: {
+                lat: loc.latitude,
+                lon: loc.longitude
+            }
+        });
     }
 
     if (show.length === 0) return next();

--- a/plugins/log.elasticsearch.js
+++ b/plugins/log.elasticsearch.js
@@ -454,6 +454,9 @@ exports.prune_noisy = function (res, pi) {
             var arr = plugin.objToArray(res.fcrdns.ptr_name_to_ip);
             res.fcrdns.ptr_name_to_ip = arr;
             break;
+        case 'geoip':
+            delete res.geoip.ll;
+            break;
         case 'max_unrecognized_commands':
             res.unrecognized_commands =
                 res.max_unrecognized_commands.count;


### PR DESCRIPTION
Changes proposed in this pull request:
- adds a geo property to the result store for geoip plugin
- send the more explicit geo property to ES

Checklist:
- [x] docs updated

see caution note here: [https://www.elastic.co/guide/en/elasticsearch/guide/current/lat-lon-formats.html](https://www.elastic.co/guide/en/elasticsearch/guide/current/lat-lon-formats.html)