### PR TITLE
fix a spurious error emitted by p0f

### DIFF
--- a/plugins/connect.p0f.js
+++ b/plugins/connect.p0f.js
@@ -233,7 +233,7 @@ exports.hook_data_post = function (next, connection) {
 
     connection.transaction.remove_header(header_name);
     var result = connection.results.get('connect.p0f');
-    if (!result || !result.os) {
+    if (!result || !result.os_name) {
         connection.results.add(plugin, {err: 'no p0f note'});
         return next();
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- check for `os_name`, not `os` property
