### PR TITLE
Rspamd plugin: Fix spambar for negative scores

### DIFF
--- a/plugins/rspamd.js
+++ b/plugins/rspamd.js
@@ -265,20 +265,18 @@ exports.add_headers = function (connection, data) {
 
     if (cfg.header && cfg.header.bar) {
         var spamBar = '';
-        if (data.score === 0) {
-            spamBar = cfg.spambar.neutral || '/';
+        var spamBarScore = 1;
+        var spamBarChar = cfg.spambar.neutral || '/';
+        if (data.score >= 1) {
+            spamBarScore = data.score;
+            spamBarChar = cfg.spambar.positive || '+';
         }
-        else {
-            var spamBarChar;
-            if (data.score > 0) {
-                spamBarChar = cfg.spambar.positive || '+';
-            }
-            else {
-                spamBarChar = cfg.spambar.negative || '-';
-            }
-            for (var i = 0; i < data.score; i++) {
-                spamBar += spamBarChar;
-            }
+        else if (data.score <= -1) {
+            spamBarScore = data.score * -1;
+            spamBarChar = cfg.spambar.negative || '-';
+        }
+        for (var i = 0; i < spamBarScore; i++) {
+            spamBar += spamBarChar;
         }
         connection.transaction.remove_header(cfg.header.bar);
         connection.transaction.add_header(cfg.header.bar, spamBar);

--- a/plugins/rspamd.js
+++ b/plugins/rspamd.js
@@ -122,7 +122,7 @@ exports.hook_data_post = function (next, connection) {
     }
 
     var timer;
-    var timeout = plugin.cfg.timeout || plugin.timeout - 1;
+    var timeout = plugin.cfg.main.timeout || plugin.timeout - 1;
 
     var calledNext=false;
     var callNext = function (code, msg) {

--- a/tests/plugins/rspamd.js
+++ b/tests/plugins/rspamd.js
@@ -1,0 +1,75 @@
+'use strict';
+
+// var Address      = require('address-rfc2821');
+var fixtures     = require('haraka-test-fixtures');
+
+var Connection   = fixtures.connection;
+var Transaction  = fixtures.transaction;
+
+var _set_up = function (done) {
+
+    this.plugin = new fixtures.plugin('rspamd');
+    this.plugin.register();
+    this.connection = Connection.createConnection();
+    this.connection.transaction = Transaction.createTransaction();
+
+    done();
+};
+
+exports.register = {
+    setUp : _set_up,
+    'loads the rspamd plugin': function (test) {
+        test.expect(1);
+        test.equal('rspamd', this.plugin.name);
+        test.done();
+    },
+    'register loads rspamd.ini': function (test) {
+        test.expect(2);
+        this.plugin.register();
+        test.ok(this.plugin.cfg);
+        test.equal(true, this.plugin.cfg.reject.spam);
+        test.done();
+    },
+};
+
+exports.load_rspamd_ini = {
+    setUp : _set_up,
+    'loads rspamd.ini': function (test) {
+        test.expect(1);
+        this.plugin.load_rspamd_ini();
+        test.ok(this.plugin.cfg.header.bar);
+        test.done();
+    },
+};
+
+exports.add_headers = {
+    setUp : _set_up,
+    'add_headers exists as function': function (test) {
+        test.expect(1);
+        // console.log(this.plugin.cfg);
+        test.equal('function', typeof this.plugin.add_headers);
+        // test.ok(!this.plugin.score_too_high(this.connection, {score: 5}));
+        test.done();
+    },
+    'adds a header to a message with positive score': function (test) {
+        test.expect(2);
+        var test_data = {
+            score: 1,
+        };
+        this.plugin.add_headers(this.connection, test_data);
+        test.equal(this.connection.transaction.header.headers['X-Rspamd-Score'], '1');
+        test.equal(this.connection.transaction.header.headers['X-Rspamd-Bar'], '+');
+        test.done();
+    },
+    'adds a header to a message with negative score': function (test) {
+        test.expect(2);
+        var test_data = {
+            score: -1,
+        };
+        this.plugin.add_headers(this.connection, test_data);
+        // console.log(this.connection.transaction.header);
+        test.equal(this.connection.transaction.header.headers['X-Rspamd-Score'], '-1');
+        test.equal(this.connection.transaction.header.headers['X-Rspamd-Bar'], '-');
+        test.done();
+    }
+};


### PR DESCRIPTION
Fixes a warning about an unused variable that points at a bug: negative scores weren't processed correctly.

Also avoid adding an empty spambar when score is > -1 and < 1 (make this neutral instead).