### PR TITLE
do not set timer if timeout=0

### DIFF
--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -124,13 +124,15 @@ exports.tls_unrecognized_command = function (next, connection, params) {
     var timed_out = false;
     // adjust plugin.timeout like so: echo '45' > config/tls.timeout
     var timeout = plugin.timeout - 1;
-
-    var timer = setTimeout(function () {
-        timed_out = true;
-        connection.logerror(plugin, 'timeout');
-        plugin.set_notls(connection.remote.ip);
-        return next(DENYSOFTDISCONNECT);
-    }, timeout * 1000);
+    var timer;
+    if (timeout && timeout > 0) {
+        timer = setTimeout(function () {
+            timed_out = true;
+            connection.logerror(plugin, 'timeout');
+            plugin.set_notls(connection.remote.ip);
+            return next(DENYSOFTDISCONNECT);
+        }, timeout * 1000);
+    }
 
     connection.notes.tls_timer = timer;
 


### PR DESCRIPTION
Fixes #1534

Changes proposed in this pull request:
- when plugin.timeout =0, don't set a tls timer

This essentially does what one expects (after reading the docs) and setting plugin.timeout=0. However, it might be better to instead use a default (30s) timer. Thoughts?