### PR TITLE
Fix data.headers plugin crash

### DIFF
--- a/plugins/data.headers.js
+++ b/plugins/data.headers.js
@@ -285,6 +285,10 @@ exports.from_match = function (next, connection) {
     }
 
     var hdr_addr = (plugin.addrparser.parse(hdr_from))[0];
+    if (!hdr_addr) {
+        connection.transaction.results.add(plugin, {fail: 'from_match(unparsable)'});
+        return next();
+    }
 
     if (env_addr.address().toLowerCase() === hdr_addr.address.toLowerCase()) {
         connection.transaction.results.add(plugin, {pass: 'from_match'});


### PR DESCRIPTION
Fixes:

`````
[CRIT] [ED90CD6F-BDA8-4E8D-B0D4-370F45CDE561.1] [core] Plugin data.headers failed: TypeError: Cannot read property 'address' of undefined
    at Plugin.exports.from_match (/home/smf/git/Haraka/plugins/data.headers.js:289:54)
    at Object.plugins.run_next_hook (/home/smf/git/Haraka/plugins.js:486:28)
    at callback (/home/smf/git/Haraka/plugins.js:442:32)
    at Plugin.exports.direct_to_mx (/home/smf/git/Haraka/plugins/data.headers.js:259:16)
    at Object.plugins.run_next_hook (/home/smf/git/Haraka/plugins.js:486:28)
    at callback (/home/smf/git/Haraka/plugins.js:442:32)
    at Plugin.exports.user_agent (/home/smf/git/Haraka/plugins/data.headers.js:231:12)
    at Object.plugins.run_next_hook (/home/smf/git/Haraka/plugins.js:486:28)
    at callback (/home/smf/git/Haraka/plugins.js:442:32)
    at Plugin.exports.invalid_return_path (/home/smf/git/Haraka/plugins/data.headers.js:146:12)
`````

Same bug as #1640 
