### PR TITLE
permit specifying haraka plugins w/o haraka-plugin- prefix

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -77,14 +77,16 @@ Plugin.prototype._get_plugin_path = function () {
         paths.push(
             path.resolve(process.env.HARAKA, 'plugins', name + '.js'),
             path.resolve(process.env.HARAKA, 'plugins', name, 'package.json'),
-            path.resolve(process.env.HARAKA, 'node_modules', name, 'package.json')
+            path.resolve(process.env.HARAKA, 'node_modules', name, 'package.json'),
+            path.resolve(process.env.HARAKA, 'node_modules', 'haraka-plugin-' + name, 'package.json')
         );
     }
 
     paths.push(
         path.resolve(__dirname, 'plugins', name + '.js'),
         path.resolve(__dirname, 'plugins', name, 'package.json'),
-        path.resolve(__dirname, 'node_modules', name, 'package.json')
+        path.resolve(__dirname, 'node_modules', name, 'package.json'),
+        path.resolve(__dirname, 'node_modules', 'haraka-plugin-' + name, 'package.json')
     );
 
     paths.forEach(function (pp) {


### PR DESCRIPTION
Changes proposed in this pull request:

- permit specifying haraka plugins w/o `haraka-plugin-` prefix
- in config/plugins
- in resultstore