### PR TITLE
Make the new tls option honorCipherOrder actually a boolean

### DIFF
--- a/tls_socket.js
+++ b/tls_socket.js
@@ -369,6 +369,7 @@ exports.load_tls_ini = function (cb) {
         booleans: [
             '+main.requestCert',
             '-main.rejectUnauthorized',
+            '-main.honorCipherOrder',
             '-redis.disable_for_failed_hosts',
         ]
     }, cb);


### PR DESCRIPTION
This change properly registers honorCipherOrder as a boolean configuration option, i.e. one can actually set it to 'false' properly. Before that fix, either 'true' or 'false' would be strings, not honoring the boolean type and result.

Note that, from a security perspective, this flag should always be true, i.e. the server should choose the best available cipher and not the client. However, most TLS libraries take false as default and require manual override to true, so I kept with this system.

Checklist:
- [x] no need for updating the docs
- [x] no need for updating the tests (or do you think we require a test for that?)
