### PR TITLE
Allow multiple key and cert parameters for RSA+ECDSA setups

### DIFF
--- a/docs/plugins/tls.md
+++ b/docs/plugins/tls.md
@@ -66,8 +66,8 @@ If multiple pairs of key and cert chain files should be used, outside of the har
 ### cert
 
 Specifies an alternative location for the certificate chain file. If multiple
-certificate chains are to be used, use `cert[]=` assignmet for each of them.
-Non-absolute pahts are relative to the `config/` directory. See the description of
+certificate chains are to be used, use `cert[]=` assignment for each of them.
+Non-absolute paths are relative to the `config/` directory. See the description of
 the `key` parameter for specific use.
 
 ### no_tls_hosts

--- a/docs/plugins/tls.md
+++ b/docs/plugins/tls.md
@@ -7,10 +7,10 @@ For this plugin to work you must have SSL certificates installed correctly.
 ## Install Location
 
 Key and certificate chain default locations are as follows. The paths
-can be overridden in the config/tls.ini file.
+can be overridden in the config/tls.ini file using `key` and `cert` options.
 
-    config/tls_key.pem
-    config/tls_cert.pem
+    key=tls_key.pem
+    cert=tls_cert.pem
 
 ## Purchased Certificate
 
@@ -45,11 +45,15 @@ The following settings can be specified in config/tls.ini.
 
 ### key
 
-Specifies an alternative location for the key file.
+Specifies an alternative location for the key file. If multiple keys are to be
+specified, use key[]= assignment for each of them. Non-absolute paths are relative
+to the config/ directory.
 
 ### cert
 
-Specifies an alternative location for the certificate chain file.
+Specifies an alternative location for the certificate chain file. If multiple
+certificate chains are to be used, use cert[]= assignmet for each of them.
+Non-absolute pahts are relative to the config/ directory.
 
 ### `no_tls_hosts`
 

--- a/docs/plugins/tls.md
+++ b/docs/plugins/tls.md
@@ -7,7 +7,7 @@ For this plugin to work you must have SSL certificates installed correctly.
 ## Install Location
 
 Key and certificate chain default locations are as follows. The paths
-can be overridden in the config/tls.ini file using `key` and `cert` options.
+can be overridden in the `config/tls.ini` file using `key` and `cert` options.
 
     key=tls_key.pem
     cert=tls_cert.pem
@@ -41,13 +41,13 @@ be the same as the contents of your `config/me` file.
 
 ## Configuration
 
-The following settings can be specified in config/tls.ini.
+The following settings can be specified in `config/tls.ini`.
 
 ### key
 
 Specifies an alternative location for the key file. If multiple keys are to be
-specified, use key[]= assignment for each of them. Non-absolute paths are relative
-to the config/ directory.
+specified, use `key[]=` assignment for each of them. Non-absolute paths are relative
+to the `config/` directory.
 
 For example, to configure single key and cert chain files, located in the `config/`
 directory, use the following in `tls.ini`:
@@ -66,13 +66,13 @@ If multiple pairs of key and cert chain files should be used, outside of the har
 ### cert
 
 Specifies an alternative location for the certificate chain file. If multiple
-certificate chains are to be used, use cert[]= assignmet for each of them.
-Non-absolute pahts are relative to the config/ directory. See the description of
+certificate chains are to be used, use `cert[]=` assignmet for each of them.
+Non-absolute pahts are relative to the `config/` directory. See the description of
 the `key` parameter for specific use.
 
-### `no_tls_hosts`
+### no_tls_hosts
 
-If needed, add this section to the tls.ini file and list any IP ranges that have
+If needed, add this section to the `config/tls.ini` file and list any IP ranges that have
 broken TLS. Ex:
 
     [no_tls_hosts]
@@ -85,9 +85,9 @@ about the following options.
 
 ### ciphers
 
-A list of allowable ciphers to use.
+A list of allowable ciphers to use. Example:
 
-    `ciphers=...`
+    ciphers=EECDH+AESGCM:EDH+aRSA+AESGCM:EECDH+AES256:EDH+aRSA+AES256:EECDH+AES128:EDH+aRSA+AES128:RSA+AES:RSA+3DES
 
 See also: [Strong SSL Ciphers](http://cipherli.st) and the [SSLlabs Test Page](https://www.ssllabs.com/ssltest/index.html)
 
@@ -95,12 +95,12 @@ See also: [Strong SSL Ciphers](http://cipherli.st) and the [SSLlabs Test Page](h
 
 If specified, the list of configured ciphers is treated as the cipher priority from
 highest to lowest. The first matching cipher will be used, instead of letting the
-client choose the cipher.
+client choose the cipher. The default is `false`.
 
 ### ecdhCurve
 
 Specifies the elliptic curve used for ECDH or ECDHE ciphers.
-Only one curve can be specified. The default is prime256v1 (NIST P-256).
+Only one curve can be specified. The default is `prime256v1` (NIST P-256).
 
 ### dhparam
 
@@ -112,20 +112,20 @@ No DH ciphers can be used without this parameter given.
 
 Whether Haraka should request a certificate from a connecting client.
 
-    `requestCert=[true|false]`  (default: true)
+    requestCert=[true|false]  (default: true)
 
 ### rejectUnauthorized
 
 Reject connections from clients without a CA validated TLS certificate.
 
-    `rejectUnauthorized=[true|false]`  (default: false)
+    rejectUnauthorized=[true|false]  (default: false)
 
 ### secureProtocol
 
 Specifies the OpenSSL API function used for handling the TLS session. Choose
 one of the methods described at the
 [OpenSSL API page](https://www.openssl.org/docs/manmaster/ssl/ssl.html).
-The default is SSLv23_method.
+The default is `SSLv23_method`.
 
 ## Inbound Specific Configuration
 

--- a/docs/plugins/tls.md
+++ b/docs/plugins/tls.md
@@ -49,11 +49,26 @@ Specifies an alternative location for the key file. If multiple keys are to be
 specified, use key[]= assignment for each of them. Non-absolute paths are relative
 to the config/ directory.
 
+For example, to configure single key and cert chain files, located in the `config/`
+directory, use the following in `tls.ini`:
+
+    key=example.com.key.pem
+    cert=example.com.crt-chain.pem
+
+If multiple pairs of key and cert chain files should be used, outside of the haraka
+`config/` directory, configure instead:
+
+    key[]=/etc/ssl/private/example.com.rsa.key.pem
+    cert[]=/etc/ssl/private/example.com.rsa.crt-chain.pem
+    key[]=/etc/ssl/private/example.com.ecdsa.key.pem
+    cert[]=/etc/ssl/private/example.com.ecdsa.crt-chain.pem
+
 ### cert
 
 Specifies an alternative location for the certificate chain file. If multiple
 certificate chains are to be used, use cert[]= assignmet for each of them.
-Non-absolute pahts are relative to the config/ directory.
+Non-absolute pahts are relative to the config/ directory. See the description of
+the `key` parameter for specific use.
 
 ### `no_tls_hosts`
 

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -50,14 +50,14 @@ exports.register = function () {
             plugin.logcrit("tls key " + keyFileName + " could not be loaded. See 'haraka -h tls'");
         }
         return key;
-        });
+    });
     plugin.tls_opts.cert = plugin.tls_opts.cert.map(function(certFileName) {
         var cert = plugin.load_pem(certFileName);
         if (!cert) {
             plugin.logcrit("tls cert " + certFileName + " could not be loaded. See 'haraka -h tls'");
         }
         return cert;
-        });
+    });
 
     // now do the error handling for unloadable key/cert files
     if (plugin.tls_opts.key.some(function(key) { return !key;}) ||

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -20,10 +20,6 @@ exports.register = function () {
 
     plugin.logdebug(plugin.tls_opts);
 
-    // transform key and cert filenames into key and cert in binary form
-    plugin.tls_opts.key = plugin.load_pem(plugin.tls_opts.key);
-    plugin.tls_opts.cert = plugin.load_pem(plugin.tls_opts.cert);
-
     if (plugin.tls_opts.dhparam) {
         plugin.tls_opts.dhparam = plugin.load_pem(plugin.tls_opts.dhparam);
         if (!plugin.tls_opts.dhparam) {
@@ -32,12 +28,40 @@ exports.register = function () {
         }
     }
 
-    if (!plugin.tls_opts.key) {
-        plugin.logcrit("tls key not loaded. See 'haraka -h tls'");
-        return;
+    // make non-array key/cert option into Arrays with one entry
+    if (!(Array.isArray(plugin.tls_opts.key))) {
+        plugin.tls_opts.key = [plugin.tls_opts.key];
     }
-    if (!plugin.tls_opts.cert) {
-        plugin.logcrit("tls certificate not loaded. See 'haraka -h tls'");
+    if (!(Array.isArray(plugin.tls_opts.cert))) {
+        plugin.tls_opts.cert = [plugin.tls_opts.cert];
+    }
+
+    if (plugin.tls_opts.key.length != plugin.tls_opts.cert.length) {
+        plugin.logcrit("number of keys (" +
+                       plugin.tls_opts.key.length + ") doesn't match number of certs (" +
+                       plugin.tls_opts.cert.length + "). See 'haraka -h tls'");
+        throw new Error('syntax error');
+    }
+
+    // turn key/cert file names into actual key/cert binary data
+    plugin.tls_opts.key = plugin.tls_opts.key.map(function(keyFileName) {
+        var key = plugin.load_pem(keyFileName);
+        if (!key) {
+            plugin.logcrit("tls key " + keyFileName + " could not be loaded. See 'haraka -h tls'");
+        }
+        return key;
+        });
+    plugin.tls_opts.cert = plugin.tls_opts.cert.map(function(certFileName) {
+        var cert = plugin.load_pem(certFileName);
+        if (!cert) {
+            plugin.logcrit("tls cert " + certFileName + " could not be loaded. See 'haraka -h tls'");
+        }
+        return cert;
+        });
+
+    // now do the error handling for unloadable key/cert files
+    if (plugin.tls_opts.key.some(function(key) { return !key;}) ||
+        plugin.tls_opts.cert.some(function(cert) { return !cert;})) {
         return;
     }
 


### PR DESCRIPTION
Allows multiple file locations to specify for key and cert parameters in tls.

This allows multiple different key types to use which is required for RSA+ECDSA setups.

The patch fixes also a small documentation bug about the location of relative files, ```config/``` is automatically prepended.

Checklist:
- [x] docs updated
- [x] no test updates required.

