### PR TITLE
fix ES test setup when plugin cannot load

### DIFF
--- a/tests/plugins/log.elasticsearch.js
+++ b/tests/plugins/log.elasticsearch.js
@@ -11,7 +11,7 @@ var _set_up = function (done) {
     }
     catch (e) {
         console.error('unable to load log.elasticsearch plugin');
-        return;
+        return done('failed to load log.elasticsearch');
     }
 
     this.connection = fixtures.connection.createConnection();


### PR DESCRIPTION
Not calling that callback was causing AppVeyor CI testing to hang.

Changes proposed in this pull request:
- call the setup callback after plugin load failure

Checklist:
- [x] tests updated