### PR TITLE
fixed TLS client after server TLSSocket rework

### DIFF
--- a/tls_socket.js
+++ b/tls_socket.js
@@ -155,6 +155,34 @@ function pipe(cleartext, socket) {
     socket.on('close', onclose);
 }
 
+function client_pipe(pair, socket) {
+    pair.encrypted.pipe(socket);
+    socket.pipe(pair.encrypted);
+
+    pair.fd = socket.fd;
+    var cleartext = pair.cleartext;
+    cleartext.socket = socket;
+    cleartext.encrypted = pair.encrypted;
+    cleartext.authorized = false;
+
+    function onerror(e) {
+        if (cleartext._controlReleased) {
+            cleartext.emit('error', e);
+        }
+    }
+
+    function onclose() {
+        socket.removeListener('error', onerror);
+        socket.removeListener('close', onclose);
+    }
+
+    socket.on('error', onerror);
+    socket.on('close', onclose);
+
+    return cleartext;
+}
+
+
 function createServer(cb) {
     var serv = net.createServer(function (cryptoSocket) {
 
@@ -290,7 +318,7 @@ function connect (port, host, cb) {
 
         socket.pair = pair;
 
-        var cleartext = pipe(pair, cryptoSocket);
+        var cleartext = client_pipe(pair, cryptoSocket);
 
         pair.on('error', function(exception) {
             socket.emit('error', exception);


### PR DESCRIPTION
The TLS client connect code broke miserably through the introduction of TLSSocket into the server code. We still need the old `pipe()` code before the client gets updated for TLSSocket, too.

Checklist:
- [x] no docs update required
- [ ] We should have some STARTTLS tests, actually.
