### PR TITLE
#1667 bring port 465 SMTPS TLS config support on par with standard STARTTLS

### DIFF
--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -27,6 +27,8 @@ exports.register = function () {
         return;
     }
 
+    plugin.tls_opts_valid = true;
+
     plugin.register_hook('capabilities', 'advertise_starttls');
     plugin.register_hook('unrecognized_command', 'upgrade_connection');
 };

--- a/server.js
+++ b/server.js
@@ -318,12 +318,12 @@ Server.get_smtp_server = function (host, port, inactivity_timeout) {
         return server;
     }
 
-    if (!plugins.registered_plugins['tls']) {
+    if (!plugins.registered_plugins.tls) {
         logger.logerror("TLS plugin not activated. Cannot listen on port 465 (SMTPS) without config");
         return;
     }
 
-    var tls_plugin = plugins.registered_plugins['tls'];
+    var tls_plugin = plugins.registered_plugins.tls;
 
     if (!tls_plugin.tls_opts_valid) {
         logger.logerror("No valid TLS setup in the tls config. Cannot listen on port 465.");


### PR DESCRIPTION
Fixes #1667

Changes proposed in this pull request:
- for port 465 to work, plugin tls has to be enabled.
- tls.ini config is properly included in SMTPS server setup
- session security is included in Received header

Note:
- PR is based on #1682.

Checklist:
- [x] no doc update needed (port 465 was considered no special case, now it is no special case anymore)
- [ ] tests updated
