### PR TITLE
auth/vpopmail: do not toString() when null

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 
 after_success:
     - npm install istanbul codecov
-    - npm run coverage
+    - npm run cover
     - ./node_modules/.bin/codecov
 
 sudo: false

--- a/connection.js
+++ b/connection.js
@@ -870,14 +870,15 @@ Connection.prototype.ehlo_respond = function(retval, msg) {
         default:
             // RFC5321 section 4.1.1.1
             // Hostname/domain should appear after 250
-            var response = [config.get('me') + " Hello " +
-                            ((this.remote.host && this.remote.host !== 'DNSERROR' &&
-                            this.remote.host !== 'NXDOMAIN') ? this.remote.host + ' ' : '') +
-                            "[" + this.remote.ip + "]" +
-                            ", Haraka is at your service.",
-                            "PIPELINING",
-                            "8BITMIME",
-                            ];
+            var response = [
+                config.get('me') + " Hello " +
+                ((this.remote.host && this.remote.host !== 'DNSERROR' &&
+                this.remote.host !== 'NXDOMAIN') ? this.remote.host + ' ' : '') +
+                "[" + this.remote.ip + "]" +
+                ", Haraka is at your service.",
+                "PIPELINING",
+                "8BITMIME",
+            ];
 
             var databytes = parseInt(config.get('databytes')) || 0;
             response.push("SIZE " + databytes);

--- a/host_pool.js
+++ b/host_pool.js
@@ -36,9 +36,10 @@ function HostPool(hostports_str, retry_secs){
                 if (! splithost[1]){
                     splithost[1] = 25;
                 }
-                return { host: splithost[0],
-                         port: splithost[1]
-                        };
+                return {
+                    host: splithost[0],
+                    port: splithost[1]
+                };
             });
     self.hostports_str = hostports_str;
     self.hosts = utils.shuffle(hosts);

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
   "scripts": {
     "test": "node run_tests",
     "lint": "grunt lint",
-    "coverage": "NODE_ENV=cov ./node_modules/.bin/istanbul cov run_tests"
+    "cover": "NODE_ENV=cov ./node_modules/.bin/istanbul cov run_tests"
   }
 }

--- a/plugins/auth/auth_vpopmaild.js
+++ b/plugins/auth/auth_vpopmaild.js
@@ -155,6 +155,6 @@ exports.get_plain_passwd = function (user, connection, cb) {
         }
     });
     socket.on('end', function () {
-        cb(plain_pass.toString());
+        cb(plain_pass ? plain_pass.toString() : plain_pass);
     });
 };

--- a/plugins/auth/auth_vpopmaild.js
+++ b/plugins/auth/auth_vpopmaild.js
@@ -142,7 +142,7 @@ exports.get_plain_passwd = function (user, connection, cb) {
         }
         if (chunk_count > 2) {
             if (/^\-ERR/.test(chunk)) {
-                plugin.logerror("get_plain failed: " + chunk);
+                plugin.lognotice("get_plain failed: " + chunk);
                 socket.end();         // disconnect
                 return;
             }

--- a/plugins/avg.js
+++ b/plugins/avg.js
@@ -93,8 +93,7 @@ exports.hook_data_post = function (next, connection) {
             connection.logprotocol(plugin, '< ' + line);
             if (!matches) {
                 connection.results.add(plugin,
-                    { err: 'Unrecognized response: ' + line,
-                });
+                    { err: 'Unrecognized response: ' + line });
                 socket.end();
                 if (!plugin.cfg.defer.error) return do_next();
                 return do_next(DENYSOFT, 'Virus scanner error (AVG)');

--- a/plugins/connect.fcrdns.js
+++ b/plugins/connect.fcrdns.js
@@ -295,8 +295,8 @@ exports.log_summary = function (connection) {
     var note = connection.results.get('connect.fcrdns');
     if (!note) return;
 
-    connection.loginfo(this,
-        ['ip=' + connection.remote.ip,
+    connection.loginfo(this, [
+        'ip=' + connection.remote.ip,
         'rdns="' + ((note.ptr_names.length > 2) ? note.ptr_names.slice(0,2).join(',') + '...' : note.ptr_names.join(',')) + '"',
         'rdns_len=' + note.ptr_names.length,
         'fcrdns="' + ((note.fcrdns.length > 2) ? note.fcrdns.slice(0,2).join(',') + '...' : note.fcrdns.join(',')) + '"',
@@ -304,7 +304,7 @@ exports.log_summary = function (connection) {
         'other_ips_len=' + note.other_ips.length,
         'invalid_tlds=' + note.invalid_tlds.length,
         'generic_rdns=' + ((note.ptr_name_has_ips) ? 'true' : 'false'),
-        ].join(' '));
+    ].join(' '));
 };
 
 exports.refresh_config = function (connection) {

--- a/plugins/data.headers.js
+++ b/plugins/data.headers.js
@@ -57,9 +57,11 @@ exports.duplicate_singular = function(next, connection) {
     // RFC 5322 Section 3.6, Headers that MUST be unique if present
     var singular = plugin.cfg.main.singular !== undefined ?
                    plugin.cfg.main.singular.split(',') :
-                   ['Date', 'From', 'Sender', 'Reply-To', 'To', 'Cc',
-                    'Bcc', 'Message-Id', 'In-Reply-To', 'References',
-                    'Subject'];
+    [
+        'Date', 'From', 'Sender', 'Reply-To', 'To', 'Cc',
+        'Bcc', 'Message-Id', 'In-Reply-To', 'References',
+        'Subject'
+    ];
 
     var failures = [];
     for (var i=0; i < singular.length; i++ ) {

--- a/plugins/data.rfc5322_header_checks.js
+++ b/plugins/data.rfc5322_header_checks.js
@@ -1,8 +1,10 @@
 // Enforce RFC 5322 Section 3.6
 var required_headers = ['Date', 'From'];
-var singular_headers =  ['Date', 'From', 'Sender', 'Reply-To', 'To', 'Cc',
-                         'Bcc', 'Message-Id', 'In-Reply-To', 'References',
-                         'Subject'];
+var singular_headers =  [
+    'Date', 'From', 'Sender', 'Reply-To', 'To', 'Cc',
+    'Bcc', 'Message-Id', 'In-Reply-To', 'References',
+    'Subject'
+];
 
 exports.register = function () {
     this.logwarn("NOTICE: plugin deprecated, use 'data.headers' instead!");

--- a/plugins/karma.js
+++ b/plugins/karma.js
@@ -16,10 +16,10 @@ exports.register = function () {
             ['unrecognized_command','helo','data','data_post','queue']
         );
     plugin.deny_exclude_hooks = utils.to_object('rcpt_to, queue');
-    plugin.deny_exclude_plugins = utils.to_object(
-            ['access', 'helo.checks', 'data.headers', 'spamassassin',
-            'mail_from.is_resolvable', 'clamd', 'tls']
-    );
+    plugin.deny_exclude_plugins = utils.to_object([
+        'access', 'helo.checks', 'data.headers', 'spamassassin',
+        'mail_from.is_resolvable', 'clamd', 'tls'
+    ]);
 
     plugin.load_karma_ini();
     plugin.load_redis_ini();
@@ -119,14 +119,14 @@ exports.preparse_result_awards = function () {
         if (!plugin.result_awards[pi_name][property]) {
             plugin.result_awards[pi_name][property] = [];
         }
-        plugin.result_awards[pi_name][property].push(
-                {   id         : anum,
-                    operator   : parts[2],
-                    value      : parts[3],
-                    award      : parts[4],
-                    reason     : parts[5],
-                    resolution : parts[6],
-                });
+        plugin.result_awards[pi_name][property].push({
+            id         : anum,
+            operator   : parts[2],
+            value      : parts[3],
+            award      : parts[4],
+            reason     : parts[5],
+            resolution : parts[6],
+        });
     });
 };
 

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -27,8 +27,10 @@ exports.load_spamassassin_ini = function () {
         plugin.cfg.main[key] = defaults[key];
     }
 
-    ['reject_threshold', 'relay_reject_threshold',
-    'munge_subject_threshold', 'max_size'].forEach(function (item) {
+    [
+        'reject_threshold', 'relay_reject_threshold',
+        'munge_subject_threshold', 'max_size'
+    ].forEach(function (item) {
         if (!plugin.cfg.main[item]) return;
         plugin.cfg.main[item] = Number(plugin.cfg.main[item]);
     });

--- a/plugins/tarpit.js
+++ b/plugins/tarpit.js
@@ -1,9 +1,10 @@
 // tarpit
 
-var hooks_to_delay = ['connect', 'helo', 'ehlo', 'mail', 'rcpt', 'rcpt_ok',
-     'data', 'data_post', 'queue', 'unrecognized_command', 'vrfy', 'noop',
-     'rset', 'quit'
-     ];
+var hooks_to_delay = [
+    'connect', 'helo', 'ehlo', 'mail', 'rcpt', 'rcpt_ok',
+    'data', 'data_post', 'queue', 'unrecognized_command', 'vrfy', 'noop',
+    'rset', 'quit'
+];
 
 exports.register = function () {
     // Register tarpit function last

--- a/tests/configfile.js
+++ b/tests/configfile.js
@@ -109,8 +109,10 @@ exports.load_ini_config = {
     'test.ini, sect1, opts, w/defaults' : function (test) {
         test.expect(6);
         var r = this.cfreader.load_ini_config('tests/config/test.ini', {
-            booleans: ['+sect1.bool_true','-sect1.bool_false',
-                       '+sect1.bool_true_default', 'sect1.-bool_false_default']
+            booleans: [
+                '+sect1.bool_true','-sect1.bool_false',
+                '+sect1.bool_true_default', 'sect1.-bool_false_default'
+            ]
         });
         test.strictEqual(r.sect1.bool_true, true);
         test.strictEqual(r.sect1.bool_false, false);

--- a/tests/plugins/tls.js
+++ b/tests/plugins/tls.js
@@ -55,9 +55,11 @@ function tls_ini_overload (plugin) {
         ]
     });
 
-    var config_options = ['ciphers','requestCert','rejectUnauthorized',
-       'key','cert','honorCipherOrder','ecdhCurve','dhparam',
-       'secureProtocol'];
+    var config_options = [
+        'ciphers','requestCert','rejectUnauthorized',
+        'key','cert','honorCipherOrder','ecdhCurve','dhparam',
+        'secureProtocol'
+    ];
 
     for (var i = 0; i < config_options.length; i++) {
         var opt = config_options[i];

--- a/tests/result_store.js
+++ b/tests/result_store.js
@@ -78,11 +78,12 @@ exports.default_result = {
         this.connection.results.push('test_plugin', { other: 'test2' });
         delete this.connection.results.store.test_plugin.human;
         delete this.connection.results.store.test_plugin.human_html;
-        test.deepEqual(
-                { pass: [], other: ['test2'], fail: [], msg: [],
-                  err: [], skip: [] },
-                this.connection.results.get('test_plugin')
-                );
+        test.deepEqual({
+            pass: [], other: ['test2'], fail: [], msg: [],
+            err: [], skip: []
+        },
+        this.connection.results.get('test_plugin')
+        );
         test.done();
     },
 };

--- a/utils.js
+++ b/utils.js
@@ -88,8 +88,10 @@ exports.ISODate = function (d) {
 };
 
 var _daynames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-var _monnames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+var _monnames = [
+    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+];
 
 function _pad (num, n, p) {
     var s = '' + num;


### PR DESCRIPTION
* do not toString() when null
    * avoids a CRIT error when plain_pass is null/undefined.
* reduce log severity of failed pass
* lint fixes (whitespace)