### PR TITLE
Rspamd plugin: restore spam report header

### DIFF
--- a/tests/plugins/rspamd.js
+++ b/tests/plugins/rspamd.js
@@ -52,13 +52,27 @@ exports.add_headers = {
         test.done();
     },
     'adds a header to a message with positive score': function (test) {
-        test.expect(2);
+        test.expect(3);
         var test_data = {
-            score: 1,
+            score: 1.1,
+            default: {
+                FOO: {
+                    name: 'FOO',
+                    score: 0.100000,
+                    description: 'foo',
+                    options: ['foo', 'bar'],
+                },
+                BAR: {
+                    name: 'BAR',
+                    score: 1.0,
+                    description: 'bar',
+                }
+            }
         };
         this.plugin.add_headers(this.connection, test_data);
-        test.equal(this.connection.transaction.header.headers['X-Rspamd-Score'], '1');
+        test.equal(this.connection.transaction.header.headers['X-Rspamd-Score'], '1.1');
         test.equal(this.connection.transaction.header.headers['X-Rspamd-Bar'], '+');
+        test.equal(this.connection.transaction.header.headers['X-Rspamd-Report'], 'FOO(0.1) BAR(1)');
         test.done();
     },
     'adds a header to a message with negative score': function (test) {


### PR DESCRIPTION
Fixes #1563

Maybe I should just PR this. I planned to try make this header look better but I've not gotten round to that (nor other things in mind for Haraka & rspamd plugin) yet. @msimerson doesn't like having stuff nested under `default` and well, it is strange, but the idea is to really have the raw response from rspamd which makes this necessary evil. :)

Changes proposed in this pull request:
- Restore spam report header
- Round down scores for spambar
- Restore untampered rspamd JSON
- Logs should be unaffected

Checklist:
- [N/A] docs updated
- [YEBO] tests updated