### PR TITLE
dkim is break : ds.exists return undefined use existsSync

### DIFF
--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -234,7 +234,7 @@ exports.get_key_dir = function (connection, cb) {
 
     async.filter(dom_hier, function (file, cb2) {
         try {
-            cb2(null, fs.exists(file));
+            cb2(null, fs.existsSync(file));
         }
         catch (e) {
             return cb2(e);


### PR DESCRIPTION
Fixes #        dkim is break
 
	fs.exists return undefined, use existsSync
        fs.exists is deprecated since: v1.0.0
 
Changes proposed in this pull request:
-            cb2(null, fs.exists(file));
+            cb2(null, fs.existsSync(file));



