### PR TITLE
Fix connection.remote_host and NXDOMAIN result

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -728,8 +728,12 @@ Connection.prototype.lookup_rdns_respond = function (retval, msg) {
 Connection.prototype.rdns_response = function (err, domains) {
     if (err) {
         switch (err.code) {
-            case dns.NXDOMAIN: this.remote.host = 'NXDOMAIN'; break;
-            default:           this.remote.host = 'DNSERROR'; break;
+            case dns.NOTFOUND:
+                this.set('remote', 'host', 'NXDOMAIN');
+                break;
+            default:
+                this.set('remote', 'host', 'DNSERROR');
+                break;
         }
     }
     else {

--- a/connection.js
+++ b/connection.js
@@ -728,6 +728,7 @@ Connection.prototype.lookup_rdns_respond = function (retval, msg) {
 Connection.prototype.rdns_response = function (err, domains) {
     if (err) {
         switch (err.code) {
+            case dns.NXDOMAIN:
             case dns.NOTFOUND:
                 this.set('remote', 'host', 'NXDOMAIN');
                 break;


### PR DESCRIPTION
The legacy property connection.remote_host was broken by https://github.com/haraka/Haraka/commit/8e412b10f2a3e646165801d6e519028f7e212563 and was undefined if the DNS lookup returned an error.

Additionally, `dns.NXDOMAIN` was incorrect - as per the Node docs, this should be `dns.NOTFOUND`, so it would appear this has been broken since day one.