### PR TITLE
remove utils.uniq()

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -51,21 +51,6 @@ exports.sort_keys = function (obj) {
     return Object.keys(obj).sort();
 };
 
-exports.uniq = function (arr) {
-    var out = [];
-    var o = 0;
-    for (var i=0,l=arr.length; i < l; i++) {
-        if (out.length === 0) {
-            out.push(arr[i]);
-        }
-        else if (out[o] !== arr[i]) {
-            out.push(arr[i]);
-            o++;
-        }
-    }
-    return out;
-};
-
 exports.extend = function (target) {
     // http://stackoverflow.com/questions/14974864/
     var sources = [].slice.call(arguments, 1);


### PR DESCRIPTION
Changes proposed in this pull request:
- remove utils.uniq()
    - it's unused
    - implementation is poor. It only works on ordered arrays

(discovered while adding test coverage)