### PR TITLE
fix tls option servername (not hostname)

### DIFF
--- a/smtp_client.js
+++ b/smtp_client.js
@@ -201,7 +201,7 @@ SMTPClient.prototype.load_tls_config = function (plugin) {
         }
     }
 
-    if (this.host) { tls_options.hostname = this.host };
+    if (this.host) { tls_options.servername = this.host };
 
     this.tls_options = tls_options;
 }


### PR DESCRIPTION
Seems I made a typo. The given hostname should be stored in `servername` to be recognized as the SNI hostname when acting as a SMTP client. For some reason I added the feature correctly to `outbound.js` but not to `smtp_client.js`. See [here](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback).
