### PR TITLE
Fixed misleading entries in config/tls.ini

### DIFF
--- a/config/tls.ini
+++ b/config/tls.ini
@@ -1,7 +1,7 @@
 ; See 'haraka -h tls'
 
-; key: tls_key.pem
-; cert: tls_cert.pem
+; key=tls_key.pem
+; cert=tls_cert.pem
 ;
 ; dhparam: dhparams.pem
 ; generate this file with: openssl dhparam -out config/dhparams 2048


### PR DESCRIPTION
Fixes # [N/A]

Changes proposed in this pull request:
- Fixed misleading entries in provided config/tls.ini file

Checklist:
- [N/A] docs updated
- [N/A] tests updated

The previous entries for the key and cert entries in config/tls.ini have
the form:

key: tls_key.pem
cert: tls_cert.pem

This was incorrect. This commit fixes the provided sample config/tls.ini
file with the correct syntax:

key=tls_key.pem
cert=tls_cert.pem