### PR TITLE
Misc. performance improvements

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -169,7 +169,7 @@ cfreader.read_config = function(name, type, cb, options) {
     // Check cache first
     if (!process.env.WITHOUT_CONFIG_CACHE) {
         var cache_key = cfreader.get_cache_key(name, options);
-        if (cfreader._config_cache[cache_key]) {
+        if (cfreader._config_cache[cache_key] !== undefined) {
             //logger.logdebug('Returning cached file: ' + name);
             var cached = cfreader._config_cache[cache_key];
             // Make sure that any .ini file booleans are applied

--- a/connection.js
+++ b/connection.js
@@ -39,7 +39,7 @@ var states = exports.states = {
     STATE_DISCONNECTED:    100,
 };
 
-var nextTick = setImmediate || process.nextTick;
+var nextTick = setImmediate || setImmediate;
 
 // copy logger methods into Connection:
 for (var key in logger) {
@@ -679,7 +679,7 @@ Connection.prototype.resume = function () {
         self.state = self.prev_state;
         self.prev_state = null;
     }
-    process.nextTick(function () { self._process_data();});
+    setImmediate(function () { self._process_data();});
 };
 
 /////////////////////////////////////////////////////////////////////////////

--- a/connection.js
+++ b/connection.js
@@ -39,8 +39,6 @@ var states = exports.states = {
     STATE_DISCONNECTED:    100,
 };
 
-var nextTick = setImmediate || setImmediate;
-
 // copy logger methods into Connection:
 for (var key in logger) {
     if (!/^log\w/.test(key)) continue;
@@ -416,7 +414,7 @@ Connection.prototype._process_data = function() {
                 this.logdebug('[early_talker] state=' + this.state + ' esmtp=' + this.esmtp + ' line="' + this_line + '"');
             }
             this.early_talker = true;
-            nextTick(function () { self._process_data() });
+            setImmediate(function () { self._process_data() });
             break;
         }
         else if ((this.state === states.STATE_PAUSE || this.state === states.STATE_PAUSE_SMTP) && this.esmtp) {
@@ -457,7 +455,7 @@ Connection.prototype._process_data = function() {
                             ' esmtp=' + this.esmtp + ' line="' + this_line + '"');
                 }
                 this.early_talker = true;
-                nextTick(function () { self._process_data() });
+                setImmediate(function () { self._process_data() });
             }
             break;
         }

--- a/docs/tutorials/Migrating_from_v1_to_v2.md
+++ b/docs/tutorials/Migrating_from_v1_to_v2.md
@@ -65,7 +65,7 @@ backpressure manually by checking the return of `write()` and adding
     };
     socket.on('drain', function () {
         if (end_pending && in_data) {
-            process.nextTick(function () { send_data() });
+            setImmediate(function () { send_data() });
         }
     });
 

--- a/fsync_writestream.js
+++ b/fsync_writestream.js
@@ -22,7 +22,7 @@ FsyncWriteStream.prototype.close = function(cb) {
             this.once('open', close);
             return;
         }
-        return process.nextTick(this.emit.bind(this, 'close'));
+        return setImmediate(this.emit.bind(this, 'close'));
     }
     this.closed = true;
     close();

--- a/messagestream.js
+++ b/messagestream.js
@@ -140,7 +140,7 @@ MessageStream.prototype._write = function (data) {
         // Do we have any waiting readers?
         if (this.listeners('data').length && !this.write_complete) {
             this.write_complete = true;
-            process.nextTick(function () {
+            setImmediate(function () {
                 if (self.readable && !self.paused)
                     self._read();
             });
@@ -167,7 +167,7 @@ MessageStream.prototype._write = function (data) {
         this.ws.on('open', function (fd) {
             self.fd = fd;
             self.open_pending = false;
-            process.nextTick(function () {
+            setImmediate(function () {
                 self._write();
             });
         });
@@ -184,7 +184,7 @@ MessageStream.prototype._write = function (data) {
         this.write_pending = true;
         this.ws.once('drain', function () {
             self.write_pending = false;
-            process.nextTick(function () {
+            setImmediate(function () {
                 self._write();
             });
         });
@@ -229,7 +229,7 @@ MessageStream.prototype._read = function () {
         // Add end of headers marker
         this.read_ce.fill(this.line_endings);
         // Loop
-        process.nextTick(function () {
+        setImmediate(function () {
             if (self.readable && !self.paused)
                 self._read();
         });

--- a/plugins.js
+++ b/plugins.js
@@ -240,7 +240,7 @@ Plugin.prototype._compile = function () {
         Buffer: Buffer,
         Math: Math,
         server: plugins.server,
-        setImmediate,
+        setImmediate
     };
     if (plugin.hasPackageJson) {
         delete sandbox.__filename;

--- a/plugins.js
+++ b/plugins.js
@@ -240,7 +240,7 @@ Plugin.prototype._compile = function () {
         Buffer: Buffer,
         Math: Math,
         server: plugins.server,
-        setImmediate
+        setImmediate: setImmediate
     };
     if (plugin.hasPackageJson) {
         delete sandbox.__filename;

--- a/plugins.js
+++ b/plugins.js
@@ -240,6 +240,7 @@ Plugin.prototype._compile = function () {
         Buffer: Buffer,
         Math: Math,
         server: plugins.server,
+        setImmediate,
     };
     if (plugin.hasPackageJson) {
         delete sandbox.__filename;

--- a/plugins/dns_list_base.js
+++ b/plugins/dns_list_base.js
@@ -13,7 +13,7 @@ exports.lookup = function (lookup, zone, cb) {
     var self = this;
 
     if (!lookup || !zone) {
-        return process.nextTick(function () {
+        return setImmediate(function () {
             return cb(new Error('missing data'));
         });
     }

--- a/plugins/graph.js
+++ b/plugins/graph.js
@@ -224,7 +224,7 @@ exports.get_data = function (res, earliest, today, group_by) {
             return res.end();
         }
         else {
-            return process.nextTick(function () {
+            return setImmediate(function () {
                 plugin.get_data(res, next_stop, today, group_by);
             });
         }

--- a/plugins/toobusy.js
+++ b/plugins/toobusy.js
@@ -17,7 +17,7 @@ exports.register = function () {
 
     plugin.loadConfig();
 
-    plugin.register_hook('lookup_rdns', 'check_busy');
+    plugin.register_hook('connect_pre', 'check_busy');
 };
 
 exports.loadConfig = function () {
@@ -39,15 +39,14 @@ exports.check_busy = function (next, connection) {
         return next();
     }
 
-    if (was_busy) {
+    if (!was_busy) {
         was_busy = true;
-        return next(DENYSOFTDISCONNECT, 'Too busy; try again later');
+        // Log a CRIT error at the first occurrence
+        var currentLag = toobusy.lag();
+        var maxLag = toobusy.maxLag();
+        this.logcrit(
+            'deferring connections: lag=' + currentLag + ' max=' + maxLag);
     }
 
-    // Log a CRIT error at the first occurrence
-    var currentLag = toobusy.lag();
-    var maxLag = toobusy.maxLag();
-    this.logcrit(
-        'deferring connections: lag=' + currentLag + ' max=' + maxLag);
-    return next();
+    return next(DENYSOFTDISCONNECT, 'Too busy; please try again later');
 };

--- a/server.js
+++ b/server.js
@@ -383,7 +383,7 @@ Server.setup_smtp_listeners = function (plugins2, type, inactivity_timeout) {
             if (e.code === 'EAFNOSUPPORT' &&
                     /^::0/.test(host) &&
                     Server.default_host) {
-                server.listen(port, '0.0.0.0');
+                server.listen(port, '0.0.0.0', 0);
             }
             else {
                 // Pass error to callback
@@ -391,7 +391,7 @@ Server.setup_smtp_listeners = function (plugins2, type, inactivity_timeout) {
             }
         });
 
-        server.listen(port, host);
+        server.listen(port, host, 0);
     };
 
     async.each(listeners, setupListener, runInitHooks);
@@ -438,7 +438,7 @@ Server.setup_http_listeners = function () {
             cb(e);
         });
 
-        Server.http.server.listen(hp[2], hp[1]);
+        Server.http.server.listen(hp[2], hp[1], 0);
     };
 
     var registerRoutes = function (err) {

--- a/tests/fixtures/util_hmailitem.js
+++ b/tests/fixtures/util_hmailitem.js
@@ -28,7 +28,7 @@ exports.newMockHMailItem = function (outbound_context, test, options, callback) 
             }
             if (!hmail.todo) {
                 hmail.once('ready', function () {
-                    process.nextTick(function(){callback(hmail);});
+                    setImmediate(function(){callback(hmail);});
                 });
             }
             else {


### PR DESCRIPTION
- Fixed bug in config cache that was causing non-existent files to be checked on every call.

- As we've dropped support for earlier versions of Node, replace all calls to process.nextTick() with setImmediate() and expose setImmediate() in the plugin sandbox.

- Fix toobusy plugin, it was completely broken and not working correctly.

- Set backlog to zero on all listen() calls as it was found to improve connection handling under heavy loads (>30 connections/sec).
