### PR TITLE
Added option to bypass SpamAssassin headers' merge

### DIFF
--- a/config/spamassassin.ini
+++ b/config/spamassassin.ini
@@ -37,5 +37,5 @@ modern_status_syntax=1
 ; in seconds (default: 300)
 ;results_timeout=
 
-; Do not merge SpamAssassin's headers into the message
-;bypass_extra_headers=true
+; Merge SpamAssassin's headers into the message
+;add_headers=true

--- a/config/spamassassin.ini
+++ b/config/spamassassin.ini
@@ -36,3 +36,6 @@ modern_status_syntax=1
 ; How long should we wait for a result from SpamAssassin
 ; in seconds (default: 300)
 ;results_timeout=
+
+; Do not merge SpamAssassin's headers into the message
+;bypass_extra_headers=true

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -24,11 +24,10 @@ exports.load_spamassassin_ini = function () {
         max_size:     500000,
         old_headers_action: "rename",
         subject_prefix: "*** SPAM ***",
-        add_headers: true,
     };
 
     for (var key in defaults) {
-        if (plugin.cfg.main[key] !== undefined) continue;
+        if (plugin.cfg.main[key]) continue;
         plugin.cfg.main[key] = defaults[key];
     }
 
@@ -188,10 +187,9 @@ exports.do_header_updates = function (connection, spamd_response) {
     }
 
     var modern = plugin.cfg.main.modern_status_syntax;
-    var add_headers = plugin.cfg.main.add_headers;
+    if ( !plugin.cfg.main.add_headers ) return;
 
     for (var key in spamd_response.headers) {
-        if ( !add_headers ) break;
         if (!key || key === '' || key === undefined) continue;
         var val = spamd_response.headers[key];
         if (val === undefined) { val = ''; }

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -20,6 +20,7 @@ exports.load_spamassassin_ini = function () {
         max_size:     500000,
         old_headers_action: "rename",
         subject_prefix: "*** SPAM ***",
+        bypass_extra_headers: false,
     };
 
     for (var key in defaults) {
@@ -116,8 +117,10 @@ exports.hook_data_post = function (next, connection) {
             flag: spamd_response.flag,
         });
 
-        plugin.fixup_old_headers(connection.transaction);
-        plugin.do_header_updates(connection, spamd_response);
+        if ( !plugin.cfg.main.bypass_extra_headers ) {
+            plugin.fixup_old_headers(connection.transaction);
+            plugin.do_header_updates(connection, spamd_response);
+        }
         plugin.log_results(connection, spamd_response);
 
         var exceeds_err = plugin.score_too_high(connection, spamd_response);


### PR DESCRIPTION
Changes proposed in this pull request:
- possibility not to merge SpamAssassin headers' into the message

Checklist:
- [x] docs updated
- [ ] tests updated
