### PR TITLE
updated BSD rc.d REQUIRE targets

### DIFF
--- a/contrib/bsd-rc.d/haraka
+++ b/contrib/bsd-rc.d/haraka
@@ -3,7 +3,8 @@
 #        tested on FreeBSD. Should work on NetBSD and Dragonfly
 
 # PROVIDE: haraka
-# REQUIRE: networking syslog 
+# REQUIRE: NETWORKING ldconfig
+# KEYWORD: shutdown
 
 . /etc/rc.subr
 

--- a/contrib/bsd-rc.d/p0f
+++ b/contrib/bsd-rc.d/p0f
@@ -1,9 +1,7 @@
 #!/bin/sh
 
 # PROVIDE: p0f
-# REQUIRE: ezjail
-# BEFORE:  DAEMON
-# KEYWORD: shutdown
+# REQUIRE: NETWORKING
 
 # Add the following lines to /etc/rc.conf to enable `p0f':
 #


### PR DESCRIPTION
A couple things have made this necessary: node depending on a shared libuv, and FreeBSD 11 having more async rc.d behavior. Without this change, the Haraka startup script can get called before ldconfig, resulting in this error:

`Shared object "libuv.so.1" not found, required by "node"`