### PR TITLE
fixes for file paths on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,20 +3,28 @@ environment:
 
 # Install scripts. (runs after repo cloning)
 install:
-  # Get the latest stable version of Node.js or io.js
-  - ps: Install-Product node $env:nodejs_version
-  # install modules
+  # Get the latest stable version of Node.js
+# - ps: Install-Product node $env:nodejs_version
   - npm install
-  - npm install -g grunt-cli
+  - choco install redis-64
+  - redis-server --service-install
+  - redis-server --service-start
 
-# Post-install test scripts.
-test_script:
+before_build:
+build: off
+#build:
+#  publish_nuget: true
+#  publish_nuget_symbols: true
+#  verbosity: minimal
+after_build:
+
+before_test:
   # Output useful info for debugging.
   - node --version
   - npm --version
-  #- grunt lint  # no need to run lint tests here too
+
+test_script:
   - node run_tests
 
-# Don't actually build.
-build: off
+after_test:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,14 +12,9 @@ install:
 
 before_build:
 build: off
-#build:
-#  publish_nuget: true
-#  publish_nuget_symbols: true
-#  verbosity: minimal
 after_build:
 
 before_test:
-  # Output useful info for debugging.
   - node --version
   - npm --version
 

--- a/configfile.js
+++ b/configfile.js
@@ -22,7 +22,7 @@ var cfreader = exports;
 
 cfreader.config_path = process.env.HARAKA ?
                        path.join(process.env.HARAKA, 'config')
-                     : path.join(__dirname, './config');
+                     : path.join(__dirname, 'config');
 cfreader.watch_files = true;
 cfreader._config_cache = {};
 cfreader._read_args = {};

--- a/configfile.js
+++ b/configfile.js
@@ -188,13 +188,15 @@ cfreader.read_config = function(name, type, cb, options) {
 
     // We can watch the directory on these platforms which
     // allows us to notice when files are newly created.
-    var os = process.platform;
-    if (os === 'linux' || os === 'win32') {
-        cfreader.watch_dir();
-    }
-    else {
-        // All other operating systems
-        cfreader.watch_file(name, type, cb, options);
+    switch (process.platform) {
+        case 'win32':
+        case 'win64':
+        case 'linux':
+            cfreader.watch_dir();
+            break;
+        default:
+            // All other operating systems
+            cfreader.watch_file(name, type, cb, options);
     }
 
     return result;

--- a/outbound.js
+++ b/outbound.js
@@ -6,7 +6,6 @@ var path        = require('path');
 var dns         = require('dns');
 var events      = require('events');
 var net         = require('net');
-var os          = require('os');
 var util        = require('util');
 
 var Address     = require('address-rfc2821').Address;
@@ -41,7 +40,7 @@ var queue_dir = path.resolve(config.get('queue_dir') || (process.env.HARAKA + '/
 
 var uniq = Math.round(Math.random() * MAX_UNIQ);
 var cfg;
-var platformDOT = ((['win32','win64'].indexOf( os.platform() ) !== -1) ? '' : '__tmp__') + '.';
+var platformDOT = ((['win32','win64'].indexOf( process.platform ) !== -1) ? '' : '__tmp__') + '.';
 exports.load_config = function () {
     cfg  = config.get('outbound.ini', {
         booleans: [

--- a/plugins.js
+++ b/plugins.js
@@ -97,13 +97,12 @@ Plugin.prototype._get_plugin_path = function () {
 
     // development mode
     paths = paths.concat(plugin_search_paths(__dirname, name));
-
     paths.forEach(function (pp) {
         if (plugin.plugin_path) return;
         try {
             fs.statSync(pp);
             plugin.plugin_path = pp;
-            if (/\/package\.json$/.test(pp)) {
+            if (path.basename(pp) === 'package.json') {
                 plugin.hasPackageJson = true;
             }
         }

--- a/plugins.js
+++ b/plugins.js
@@ -101,7 +101,7 @@ Plugin.prototype._get_plugin_path = function () {
         if (plugin.plugin_path) return;
         try {
             fs.statSync(pp);
-            plugin.plugin_path = pp;
+            plugin.plugin_path = pp.replace(/\\/, '\\\\');
             if (path.basename(pp) === 'package.json') {
                 plugin.hasPackageJson = true;
             }

--- a/plugins.js
+++ b/plugins.js
@@ -101,7 +101,7 @@ Plugin.prototype._get_plugin_path = function () {
         if (plugin.plugin_path) return;
         try {
             fs.statSync(pp);
-            plugin.plugin_path = pp.replace(/\\/, '\\\\');
+            plugin.plugin_path = pp;
             if (path.basename(pp) === 'package.json') {
                 plugin.hasPackageJson = true;
             }
@@ -204,7 +204,12 @@ Plugin.prototype._get_code = function (pp) {
     var plugin = this;
 
     if (plugin.hasPackageJson) {
-        return 'var _p = require("' + path.dirname(pp) + '"); for (var k in _p) { exports[k] = _p[k] }';
+        var packageDir = path.dirname(pp);
+        if (/^win(32|64)/.test(process.platform)) {
+            // escape the c:\path\back\slashes else they disappear
+            packageDir = packageDir.replace(/\\/g, '\\\\');
+        }
+        return 'var _p = require("' + packageDir + '"); for (var k in _p) { exports[k] = _p[k] }';
     }
 
     try {

--- a/tests/installation/node_modules/test-plugin/package.json
+++ b/tests/installation/node_modules/test-plugin/package.json
@@ -1,5 +1,5 @@
 {
     "name": "test-plugin",
     "version": "1.0.0",
-    "main": "./test-plugin.js"
+    "main": "test-plugin"
 }

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -57,42 +57,43 @@ exports.get_timeout = {
     setUp : function (done) {
         process.env.WITHOUT_CONFIG_CACHE=true;
         this.to = getVal();
-        fs.writeFile(toPath, this.to, done);
+        var self = this;
+        fs.writeFile(toPath, this.to, function () {
+            self.plugin = new plugin.Plugin(piName);
+            done();
+        });
     },
     tearDown : function (done) {
         fs.unlink(toPath, done);
     },
     '0s' : function (test) {
-        var pi = new plugin.Plugin(piName);
         test.expect(1);
-        test.equal( pi.timeout, this.to );
+        test.equal( this.plugin.timeout, this.to );
         test.done();
     },
     '3s' : function (test) {
-        var pi = new plugin.Plugin(piName);
         test.expect(1);
-        test.equal( pi.timeout, this.to );
+        test.equal( this.plugin.timeout, this.to );
         test.done();
     },
     '60s' : function (test) {
-        var pi = new plugin.Plugin(piName);
         test.expect(1);
-        test.equal( pi.timeout, this.to );
+        test.equal( this.plugin.timeout, this.to );
         test.done();
     },
     '30s default (overrides NaN apple)' : function (test) {
-        var pi = new plugin.Plugin(piName);
         test.expect(1);
-        test.equal( pi.timeout, 30 );
+        test.equal( this.plugin.timeout, 30 );
         test.done();
     },
 };
 
 exports.plugin_paths = {
-
+    setUp : function (done) {
+        process.env.HARAKA = '';
+        done();
+    },
     'CORE plugin: (tls)' : function (test) {
-        delete process.env.HARAKA;
-
         var p = new plugin.Plugin('tls');
 
         test.expect(1);
@@ -199,9 +200,12 @@ exports.plugin_paths = {
 };
 
 exports.plugin_config = {
+    setUp : function (done) {
+        process.env.HARAKA = '';
+        done();
+    },
 
     'CORE plugin: (tls)' : function (test) {
-        delete process.env.HARAKA;
 
         var p = new plugin.Plugin('tls');
 
@@ -234,6 +238,5 @@ exports.plugin_config = {
         test.equal(p.config.overrides_path, path.resolve(__dirname, 'installation', 'config'));
         test.done();
     },
-
 }
 

--- a/tests/plugins/access.js
+++ b/tests/plugins/access.js
@@ -10,7 +10,7 @@ var ResultStore  = fixtures.result_store;
 var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('access');
-    this.plugin.config.root_path = path.resolve(__dirname, '../../config');
+    this.plugin.config.module_config(path.resolve(__dirname, 'config'));
     this.plugin.register();
 
     this.connection = fixtures.connection.createConnection();


### PR DESCRIPTION
This PR (and already published updates to haraka-test-fixtures) fixes all but two [test failures of Haraka running on Windows](https://ci.appveyor.com/project/msimerson/haraka-pa8a5). The two failing tests are failing (see error below) when npm attempts to require a package.json's `main` property. It seems to be treating the `\` characters in the path as escape sequences, and thus fails to properly load the target file. I've run out of time to determine why that's happening.

* remove grunt from appveyor
* get redis up and running on appveyor
* get access config overrides working on windows
* clear env.HARAKA by setting to empty string
* plugins.get_timeout: DRY refactor
* use path.basename for package.json filename detection (vs regex)


````
plugins
✔ plugin - new Plugin() object
✔ get_timeout - 0s
✔ get_timeout - 3s
✔ get_timeout - 60s
✔ get_timeout - 30s default (overrides NaN apple)
✔ plugin_paths - CORE plugin: (tls)
✔ plugin_paths - INSTALLED override: (tls)
pp: C:\projects\haraka-pa8a5\tests\installation\node_modules\test-plugin\package.json
mcr: C:projectsharaka-pa8a5	estsinstallation
ode_modules	est-plugin
Error: Cannot find module 'C:projectsharaka-pa8a5	estsinstallation
ode_modules	est-plugin'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at C:\projects\haraka-pa8a5\plugins.js:181:23
    at C:\projects\haraka-pa8a5\tests\installation\node_modules\test-plugin\package.json:1:10
    at ContextifyScript.Script.runInNewContext (vm.js:18:15)
    at Object.exports.runInNewContext (vm.js:49:17)
    at Plugin._compile (C:\projects\haraka-pa8a5\plugins.js:251:12)
    at Object.exports.plugin_paths.INSTALLED node_modules package plugin: (test-plugin) (C:\projects\haraka-pa8a5\tests\plugins.js:123:15)
    at C:\projects\haraka-pa8a5\node_modules\nodeunit\lib\core.js:232:20
    at C:\projects\haraka-pa8a5\node_modules\nodeunit\deps\async.js:168:13
    at C:\projects\haraka-pa8a5\node_modules\nodeunit\deps\async.js:131:25
    at C:\projects\haraka-pa8a5\node_modules\nodeunit\deps\async.js:165:17
    at C:\projects\haraka-pa8a5\node_modules\nodeunit\deps\async.js:463:34
    at Object.exports.plugin_paths.setUp (C:\projects\haraka-pa8a5\tests\plugins.js:94:9)
✖ plugin_paths - INSTALLED node_modules package plugin: (test-plugin)
````