### PR TITLE
spf fix for relaying & context=myself

### DIFF
--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -16,6 +16,8 @@ exports.register = function () {
 
 exports.load_config = function () {
     var plugin = this;
+    plugin.nu = net_utils;   // so tests can set public_ip
+
     plugin.cfg = plugin.config.get('spf.ini', {
         booleans: [
             '-defer.helo_temperror',
@@ -172,8 +174,7 @@ exports.hook_mail = function (next, connection, params) {
             domain: host,
             emit: true,
         });
-        return plugin.return_results(next, connection, spf, 'mfrom', result,
-            '<'+mfrom+'>');
+        plugin.return_results(next, connection, spf, 'mfrom', result, '<'+mfrom+'>');
     };
 
     // typical inbound (!relay)
@@ -198,7 +199,7 @@ exports.hook_mail = function (next, connection, params) {
             if (result) {
                 spf_result = spf.result(result).toLowerCase();
             }
-            if (err || spf_result && spf_result !== 'pass') {
+            if (err || (spf_result && spf_result !== 'pass')) {
                 if (e) {
                     // Error looking up public IP
                     return ch_cb(e);
@@ -206,9 +207,11 @@ exports.hook_mail = function (next, connection, params) {
                 if (!my_public_ip) {
                     return ch_cb(new Error("failed to discover public IP"));
                 }
-                return spf.check_host(my_public_ip, host, mfrom, function (er, r) {
-                    return ch_cb(er, r, my_public_ip);
+                spf = new SPF();
+                spf.check_host(my_public_ip, host, mfrom, function (er, r) {
+                    ch_cb(er, r, my_public_ip);
                 });
+                return;
             }
             ch_cb(err, result, connection.remote.ip);
         });

--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -17,6 +17,7 @@ exports.register = function () {
 exports.load_config = function () {
     var plugin = this;
     plugin.nu = net_utils;   // so tests can set public_ip
+    plugin.SPF = SPF;
 
     plugin.cfg = plugin.config.get('spf.ini', {
         booleans: [

--- a/tests/plugins/spf.js
+++ b/tests/plugins/spf.js
@@ -1,11 +1,7 @@
 'use strict';
 
-var path         = require('path');
-
 var Address      = require('address-rfc2821').Address;
 var fixtures     = require('haraka-test-fixtures');
-
-var Connection   = fixtures.connection;
 
 var SPF          = require('../../spf').SPF;
 var spf          = new SPF();
@@ -13,10 +9,12 @@ var spf          = new SPF();
 var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('spf');
-    this.plugin.config.root_path = path.resolve(__dirname, '../../config');
-    this.plugin.cfg = { main: { }, defer: {}, deny: {} };
+    this.plugin.load_config();
+    this.plugin.timeout = 8000;
 
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
+    this.connection.transaction = fixtures.transaction.createTransaction();
+    this.connection.transaction.results = new fixtures.result_store(this.connection);
 
     done();
 };
@@ -167,6 +165,8 @@ exports.hook_helo = {
 
 };
 
+var test_addr = new Address('<test@example.com>');
+
 exports.hook_mail = {
     setUp : _set_up,
     'rfc1918': function (test) {
@@ -175,8 +175,9 @@ exports.hook_mail = {
             test.done();
         };
         test.expect(1);
+        this.connection.remote.is_private=true;
         this.connection.remote.ip='192.168.1.1';
-        this.plugin.hook_mail(next, this.connection);
+        this.plugin.hook_mail(next, this.connection, [test_addr]);
     },
     'rfc1918 relaying': function (test) {
         var next = function () {
@@ -184,9 +185,10 @@ exports.hook_mail = {
             test.done();
         };
         test.expect(1);
+        this.connection.remote.is_private=true;
         this.connection.remote.ip='192.168.1.1';
         this.connection.relaying=true;
-        this.plugin.hook_mail(next, this.connection);
+        this.plugin.hook_mail(next, this.connection, [test_addr]);
     },
     'no txn': function (test) {
         var next = function () {
@@ -195,6 +197,7 @@ exports.hook_mail = {
         };
         test.expect(1);
         this.connection.remote.ip='207.85.1.1';
+        delete this.connection.transaction;
         this.plugin.hook_mail(next, this.connection);
     },
     'txn, no helo': function (test) {
@@ -203,9 +206,9 @@ exports.hook_mail = {
             test.done();
         };
         test.expect(1);
+        this.plugin.cfg.deny.mfrom_fail = false;
         this.connection.remote.ip='207.85.1.1';
-        this.plugin.hook_mail(next, this.connection,
-            [new Address('<test@example.com>')]);
+        this.plugin.hook_mail(next, this.connection, [test_addr]);
     },
     'txn': function (test) {
         var next = function (rc) {
@@ -215,8 +218,7 @@ exports.hook_mail = {
         test.expect(1);
         this.connection.set('remote', 'ip', '207.85.1.1');
         this.connection.set('hello', 'host', 'mail.example.com');
-        this.plugin.hook_mail(next, this.connection,
-            [new Address('<test@example.com>')]);
+        this.plugin.hook_mail(next, this.connection, [test_addr]);
     },
     'txn, relaying': function (test) {
         var next = function (rc) {
@@ -227,8 +229,23 @@ exports.hook_mail = {
         this.connection.set('remote', 'ip', '207.85.1.1');
         this.connection.relaying=true;
         this.connection.set('hello', 'host', 'mail.example.com');
-        this.plugin.hook_mail(next, this.connection,
-            [new Address('<test@example.com>')]);
+        this.plugin.hook_mail(next, this.connection, [test_addr]);
+    },
+    'txn, relaying, is_private': function (test) {
+        var next = function (rc) {
+            console.log(arguments);
+            test.equal(undefined, rc);
+            test.done();
+        };
+        test.expect(1);
+        this.plugin.cfg.relay.context='myself';
+        this.plugin.cfg.deny_relay.mfrom_fail = true;
+        this.connection.set('remote', 'ip', '127.0.1.1');
+        this.connection.set('remote', 'is_private', true);
+        this.connection.relaying = true;
+        this.connection.set('hello', 'host', 'www.tnpi.net');
+        this.plugin.nu.public_ip = '66.128.51.165';
+        this.plugin.hook_mail(next, this.connection, [new Address('<nonexist@tnpi.net>')]);
     },
 };
 

--- a/tests/plugins/spf.js
+++ b/tests/plugins/spf.js
@@ -12,6 +12,9 @@ var _set_up = function (done) {
     this.plugin.load_config();
     this.plugin.timeout = 8000;
 
+    // uncomment this line to see detailed SPF evaluation
+    this.plugin.SPF.prototype.log_debug = function () {};
+
     this.connection = fixtures.connection.createConnection();
     this.connection.transaction = fixtures.transaction.createTransaction();
     this.connection.transaction.results = new fixtures.result_store(this.connection);
@@ -233,7 +236,6 @@ exports.hook_mail = {
     },
     'txn, relaying, is_private': function (test) {
         var next = function (rc) {
-            console.log(arguments);
             test.equal(undefined, rc);
             test.done();
         };


### PR DESCRIPTION
which has been broken since #1528

the money shot is line 210: spf = new SPF();

Changes proposed in this pull request:
- fixes many of the tests, which have been broken since `if (!host) return next();`
- adds a mock transaction, restoring functionality to even more tests
- adds transaction.results, enabling them newly running tests to complete
- loads a default config, which sets up the cfg object completely, so that more tests can succeed
- merged a bunch of redundant new Address() calls into a variable
- adds a new test, for context=myself, relaying=true, and connection.remote.is_private=true
- set the mock plugin's timeout property, as without it, tests timeout before evaluation can complete
- re-initialize the SPF library before second evaluation, fixing the `context=myself` feature.

Checklist:
- [x] tests updated