### PR TITLE
Handle unparseable responses from rspamd

### DIFF
--- a/plugins/rspamd.js
+++ b/plugins/rspamd.js
@@ -145,6 +145,7 @@ exports.hook_data_post = function (next, connection) {
             res.on('data', function (chunk) { rawData += chunk; });
             res.on('end', function () {
                 var r = plugin.parse_response(rawData, connection);
+                if (!r) return callNext();
                 if (!r.data) return callNext();
                 if (!r.data.default) return callNext();
                 if (!r.log) return callNext();


### PR DESCRIPTION
Fixes issue reported by 'last1' on rspamd IRC channel.

Changes proposed in this pull request:
- Don't crash if response from rspamd couldn't be parsed

Checklist:
- [ ] docs updated
- [ ] tests updated
