### PR TITLE
Queue filename refactor

### DIFF
--- a/outbound.js
+++ b/outbound.js
@@ -424,31 +424,29 @@ exports.stats = function () {
 };
 
 
-var MAX_UNIQ     = 10000;
 var _qfile = exports.qfile = {
     // File Name Format: $arrival_$nextattempt_$attempts_$pid_$uniquenum_$host
     name : function(overrides){
         var o = overrides || {};
         var time = new Date().getTime();
         return [
-            o.arrival || time,
-            o.next_attempt || time,
-            o.attempts || 0,
-            o.pid || process.pid,
-            o.uid || _qfile.next_unique(),
-            o.host || my_hostname
+            o.arrival       || time,
+            o.next_attempt  || time,
+            o.attempts      || 0,
+            o.pid           || process.pid,
+            o.uid           || _qfile.rnd_unique(),
+            o.host          || my_hostname
         ].join('_');
-
-        return time + '_' + time + '_0_' + process.pid + "_" + _qfile.next_unique() + '_' + my_hostname;
     },
 
-    rnd_unique : function(){
-        return Math.round(Math.random() * MAX_UNIQ);
-    },
-    next_unique : function(){
-        var next = unique_count+1;
-        unique_count = (next < MAX_UNIQ)?next:_qfile.rnd_unique();
-        return unique_count;
+    rnd_unique: function(len) {
+        len = len || 10; // default length
+        var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        var result = [];
+        for (var i = len; i > 0; --i){
+            result.push(chars[Math.floor(Math.random() * chars.length)]);
+        }
+        return result.join('');
     },
 
     parts : function(filename){
@@ -490,13 +488,12 @@ var _qfile = exports.qfile = {
             next_attempt : parseInt(p[1]),
             attempts     : parseInt(p[2]),
             pid          : parseInt(p[3]),
-            uid          : parseInt(p[4]),
+            uid          : p[4],
             host         : p[5],
             age          : time - parseInt(p[0])
         };
     }
 };
-var unique_count = _qfile.rnd_unique();
 
 
 exports.send_email = function () {

--- a/outbound.js
+++ b/outbound.js
@@ -2274,11 +2274,12 @@ HMailItem.prototype.deferred_respond = function (retval, msg, params) {
         delay = parseInt(msg, 10) * 1000;
     }
 
-    var until = Date.now() + delay;
-
     this.loginfo("Temp failing " + this.filename + " for " + (delay/1000) + " seconds: " + params.err);
-
-    var new_filename = this.filename.replace(/^(\d+)_(\d+)_/, until + '_' + this.num_failures + '_');
+    var parts = _.qfile.parts(this.filename);
+    parts.next_attempt = Date.now() + delay;
+    parts.attempts = this.num_failures;
+    var new_filename = _.qfile.name(parts);
+    // var new_filename = this`.filename.replace(/^(\d+)_(\d+)_/, until + '_' + this.num_failures + '_');
 
     var hmail = this;
     fs.rename(this.path, path.join(queue_dir, new_filename), function (err) {

--- a/outbound.js
+++ b/outbound.js
@@ -430,7 +430,6 @@ var _qfile = exports.qfile = {
     name : function(overrides){
         var o = overrides || {};
         var time = new Date().getTime();
-        var a = o.attempts || 0;
         return [
             o.arrival || time,
             o.next_attempt || time,
@@ -454,7 +453,7 @@ var _qfile = exports.qfile = {
 
     parts : function(filename){
         if (!filename){
-           throw new Error("No filename provided");
+            throw new Error("No filename provided");
         }
 
         var PARTS_EXPECTED_OLD = 4;

--- a/plugins/dnswl.js
+++ b/plugins/dnswl.js
@@ -3,8 +3,8 @@
 
 exports.register = function() {
     var plugin = this;
-    plugin.load_dnswl_ini();
     plugin.inherits('dns_list_base');
+    plugin.load_dnswl_ini();
 
     // IMPORTANT: don't run this on hook_rcpt otherwise we're an open relay...
     ['ehlo','helo','mail'].forEach(function (hook) {

--- a/run_tests
+++ b/run_tests
@@ -5,7 +5,7 @@
 try {
     var reporter = require('nodeunit').reporters.default;
 }
-catch(e) {
+catch (e) {
     console.log("Error: " + e.message);
     console.log("");
     console.log("Cannot find nodeunit module.");

--- a/tests/outbound.js
+++ b/tests/outbound.js
@@ -1,7 +1,8 @@
-'use strict';
 
+'use strict';
 var fs   = require('fs');
 var path = require('path');
+var os   = require('os');
 
 var lines = [
     'From: John Johnson <john@example.com>',
@@ -41,6 +42,85 @@ exports.outbound = {
         test.done();
     }
 };
+
+exports.qfile = {
+    setUp : function (done) {
+        this.qfile = require('../outbound').qfile;
+        done();
+    },
+    'name() basic functions': function(test){
+        test.expect(3);
+        var name = this.qfile.name();
+        var split = name.split('_');
+        test.equal(split.length, 6);
+        test.equal(split[2], 0);
+        test.equal(split[3], process.pid);
+        test.done();
+    },
+    'name() with overrides': function(test){
+        test.expect(7);
+        var overrides = {
+            arrival : 12345,
+            next_attempt : 12345,
+            attempts : 15,
+            pid : process.pid,
+            uid : 'XXYYZZ',
+            host : os.hostname(),
+        };
+        var name = this.qfile.name(overrides);
+        var split = name.split('_');
+        test.equal(split.length, 6);
+        test.equal(split[0], overrides.arrival);
+        test.equal(split[1], overrides.next_attempt);
+        test.equal(split[2], overrides.attempts);
+        test.equal(split[3], overrides.pid);
+        test.equal(split[4], overrides.uid);
+        test.equal(split[5], overrides.host);
+        test.done();
+    },
+    'rnd_unique() is unique-ish': function(test){
+        var repeats = 1000;
+        test.expect(repeats);
+        var u = this.qfile.rnd_unique();
+        for (var i = 0; i < repeats; i++){
+            test.notEqual(u, this.qfile.rnd_unique());
+        }
+        test.done();
+    },
+    'parts() updates previous queue filenames': function(test){
+        test.expect(5);
+        // $nextattempt_$attempts_$pid_$uniq.$host
+        var name = "1111_0_2222_3333.foo.example.com"
+        var parts = this.qfile.parts(name);
+        test.equal(parts.next_attempt, 1111);
+        test.equal(parts.attempts, 0);
+        test.equal(parts.pid, 2222);
+        test.equal(parts.uid, 3333);
+        test.equal(parts.host, 'foo.example.com');
+        test.done();
+    },
+    'parts() handles standard queue filenames': function(test){
+        test.expect(6);
+        var overrides = {
+            arrival : 12345,
+            next_attempt : 12345,
+            attempts : 15,
+            pid : process.pid,
+            uid : 'XXYYZZ',
+            host : os.hostname(),
+        };
+        var name = this.qfile.name(overrides);
+        var parts = this.qfile.parts(name);
+        test.equal(parts.arrival, overrides.arrival);
+        test.equal(parts.next_attempt, overrides.next_attempt);
+        test.equal(parts.attempts, overrides.attempts);
+        test.equal(parts.pid, overrides.pid);
+        test.equal(parts.uid, overrides.uid);
+        test.equal(parts.host, overrides.host);
+        test.done();
+    }
+};
+
 
 exports.get_tls_options = {
     setUp : function (done) {

--- a/tests/outbound.js
+++ b/tests/outbound.js
@@ -52,7 +52,7 @@ exports.qfile = {
         test.expect(3);
         var name = this.qfile.name();
         var split = name.split('_');
-        test.equal(split.length, 6);
+        test.equal(split.length, 7);
         test.equal(split[2], 0);
         test.equal(split[3], process.pid);
         test.done();
@@ -69,13 +69,13 @@ exports.qfile = {
         };
         var name = this.qfile.name(overrides);
         var split = name.split('_');
-        test.equal(split.length, 6);
+        test.equal(split.length, 7);
         test.equal(split[0], overrides.arrival);
         test.equal(split[1], overrides.next_attempt);
         test.equal(split[2], overrides.attempts);
         test.equal(split[3], overrides.pid);
         test.equal(split[4], overrides.uid);
-        test.equal(split[5], overrides.host);
+        test.equal(split[6], overrides.host);
         test.done();
     },
     'rnd_unique() is unique-ish': function(test){
@@ -88,14 +88,13 @@ exports.qfile = {
         test.done();
     },
     'parts() updates previous queue filenames': function(test){
-        test.expect(5);
+        test.expect(4);
         // $nextattempt_$attempts_$pid_$uniq.$host
         var name = "1111_0_2222_3333.foo.example.com"
         var parts = this.qfile.parts(name);
         test.equal(parts.next_attempt, 1111);
         test.equal(parts.attempts, 0);
         test.equal(parts.pid, 2222);
-        test.equal(parts.uid, 3333);
         test.equal(parts.host, 'foo.example.com');
         test.done();
     },


### PR DESCRIPTION
- Standardize on the underscore for delimiting all queue filename bits
- Return a simple object for the parts
- Add the original arrival timestamp to the filename
- Calculate message "age" value when getting file parts
- Allow for [re]names with defaults & overrides
- Convert older filename formats in the queue during an update