### PR TITLE
add a BIND compatible folded key syntax

### DIFF
--- a/config/dkim/dkim_key_gen.sh
+++ b/config/dkim/dkim_key_gen.sh
@@ -6,21 +6,21 @@ usage() {
     exit
 }
 
-if [ -z $1 ];
+if [ -z "$1" ];
 then
     usage
 fi
 
 DOMAIN=$1
 SMTPD=$2
-if [ -z $SMTPD ];
+if [ -z "$SMTPD" ];
 then
     SMTPD="www"
 fi
 
 # create a directory for each DKIM signing domain
-mkdir -p $DOMAIN
-cd $DOMAIN
+mkdir -p "$DOMAIN"
+cd "$DOMAIN" || exit
 
 # The selector can be any value that is a valid DNS label
 # create in the common format: mmmYYYY (apr2014)
@@ -35,13 +35,26 @@ openssl genrsa -out private 2048
 chmod 400 private
 openssl rsa -in private -out public -pubout
 
+DNS_NAME="$(tr -d "\n" < selector)._domainkey"
+DNS_ADDRESS="v=DKIM1;p=$(grep -v -e '^-' public | tr -d "\n")"
+
+# fold width is arbitrary, any value between 80 and 255 is reasonable.
+BIND_SPLIT_ADDRESS="$(echo "$DNS_ADDRESS" | fold -w 110 | sed -e 's/^/	"/g; s/$/"/g')"
+
 # make it really easy to publish the public key in DNS
 # by creating a file named 'dns', with instructions
 cat > dns <<EO_DKIM_DNS
 
 Add this TXT record to the $DOMAIN DNS zone.
 
-`cat selector | tr -d "\n"`._domainkey TXT "v=DKIM1;p=`grep -v -e '^-' public | tr -d "\n"`"
+$DNS_NAME    IN   TXT   $DNS_ADDRESS
+
+
+BIND zone file formatted:
+
+$DNS_NAME    IN   TXT (
+$BIND_SPLIT_ADDRESS
+        )
 
 Tell the world that the ONLY mail servers that send mail from this domain are DKIM signed and/or bear our MX and A records.
 
@@ -54,10 +67,6 @@ With DMARC:
 
 _dmarc  TXT "v=DMARC1; p=reject; adkim=s; aspf=r; rua=mailto:dmarc-feedback@$DOMAIN; ruf=mailto:dmarc-feedback@$DOMAIN; pct=100"
 
-With DomainKeys (deprecated)
-
-_domainkey TXT "o=-; t=y; r=postmaster@$DOMAIN"
-
 For more information about DKIM and SPF policy, the documentation within each plugin contains a longer discussion and links to more detailed information:
 
    haraka -h dkim_sign
@@ -67,4 +76,3 @@ For more information about DKIM and SPF policy, the documentation within each pl
 EO_DKIM_DNS
 
 cd ..
-#chown -R $SMTPD:$SMTPD $DOMAIN


### PR DESCRIPTION
Fixes #1767 

Changes proposed in this pull request:
- add a BIND compatible folded DKIM key 
- remove deprecated DomainKeys instructions

# Example

````
$ ./dkim_key_gen.sh example.com
Generating RSA private key, 2048 bit long modulus
.+++
........................................................+++
e is 65537 (0x10001)
writing RSA key
$ cat example.com/dns 

Add this TXT record to the example.com DNS zone.

jan2017._domainkey    IN   TXT   v=DKIM1;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6zHpE5XCsmePfOuBHs871yUgNu+gTMytJ+55HipUl7Uem6uD4zcZAgflSrP7lgJKgrZC1WNJn5hlv7t3NiyurEGRrhCy/V2k4Xm87mGO00ZMFHd5Zq/EFshmtFIX9dOPc4am12Mdmyri7tpc2ap961EGBOR8w8HCWZCh7fjX2zV5IM7DP2eNnXM6uOBYwGsYDIGp8ul0i3z9aKoMvzDbv/9yauFDKsQrsAFi5opkf99XDki2DP4qNTog+LG1a7ixpZHTiuS44KkSkz5P4GVSfzgJ+DUJaxyki5pIPaKYWS/faOO3B0uu0uaXlXDHee1fGDij+qeCTZJ1O7Q80925oQIDAQAB


BIND zone file formatted:

jan2017._domainkey    IN   TXT (
	"v=DKIM1;p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6zHpE5XCsmePfOuBHs871yUgNu+gTMytJ+55HipUl7Uem6uD4zcZAgfl"
	"SrP7lgJKgrZC1WNJn5hlv7t3NiyurEGRrhCy/V2k4Xm87mGO00ZMFHd5Zq/EFshmtFIX9dOPc4am12Mdmyri7tpc2ap961EGBOR8w8HCWZCh7f"
	"jX2zV5IM7DP2eNnXM6uOBYwGsYDIGp8ul0i3z9aKoMvzDbv/9yauFDKsQrsAFi5opkf99XDki2DP4qNTog+LG1a7ixpZHTiuS44KkSkz5P4GVS"
	"fzgJ+DUJaxyki5pIPaKYWS/faOO3B0uu0uaXlXDHee1fGDij+qeCTZJ1O7Q80925oQIDAQAB"
        )

Tell the world that the ONLY mail servers that send mail from this domain are DKIM signed and/or bear our MX and A records.

With SPF:

        SPF "v=spf1 mx a -all"
        TXT "v=spf1 mx a -all"

With DMARC:

_dmarc  TXT "v=DMARC1; p=reject; adkim=s; aspf=r; rua=mailto:dmarc-feedback@example.com; ruf=mailto:dmarc-feedback@example.com; pct=100"

For more information about DKIM and SPF policy, the documentation within each plugin contains a longer discussion and links to more detailed information:

   haraka -h dkim_sign
   haraka -h spf
````