### PR TITLE
Redis consistency

### DIFF
--- a/config/rate_limit.ini
+++ b/config/rate_limit.ini
@@ -1,7 +1,11 @@
 ; Example configuration file for the rate_limit plugin
 
-; redis_server = 1.2.3.4
 ; tarpit_delay = 30
+
+[redis]
+; host = 1.2.3.4
+; port = 6379
+; db = 0
 
 [concurrency]
 ; NOTE: this limit is per server child and does not use Redis

--- a/config/tls.ini
+++ b/config/tls.ini
@@ -16,7 +16,7 @@ ciphers=ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-G
 
 
 [redis]
-; options in this block require redis to be available.
+; options in this block require redis to be enabled in config/plugins.
 
 ; remember when a remote fails STARTTLS. The next time they connect,
 ;     don't offer STARTTLS option (so message gets delivered).

--- a/docs/plugins/rate_limit.md
+++ b/docs/plugins/rate_limit.md
@@ -3,62 +3,55 @@ rate\_limit
 
 Enforce limits on connection concurrency, connection rate, and recipient rate.
 
-By default DENYSOFT will be returned when the limits are exceeded, but for 
-concurrency, connection rate and recipient rate by host you can optionally 
-tarpit the connection by adding a delay before every response sent back to the 
-client instead of sending a DENYSOFT.  To do this requires the 'tarpit' plugin 
+By default DENYSOFT will be returned when the limits are exceeded, but for
+concurrency, connection rate and recipient rate by host you can optionally
+tarpit the connection by adding a delay before every response sent back to the
+client instead of sending a DENYSOFT.  To do this requires the 'tarpit' plugin
 to run immediately after this plugin.
 
-To use this plugin you will need a Redis server and will need the redis, 
+To use this plugin you will need a Redis server and will need the redis,
 hiredis and ipaddr.js packages installed via:
 
     cd /path/to/haraka/home
     npm install redis hiredis ipaddr.js
-    
+
 Configuration
 -------------
 
-This plugin uses the configuration file rate\_limit.ini which is checked for 
-updates before each hook, so changes to this file will never require a restart 
+This plugin uses the configuration file rate\_limit.ini which is checked for
+updates before each hook, so changes to this file will never require a restart
 and will take effect seconds after the changes are saved.
 
 The configuration options for each heading are detailed below:
 
 ### [main]
 
-- redis\_server = \<ip | host\>[:port] *(optional)*
-
-    If port is missing then it defaults to 6379.  
-    If this setting is missing entirely then it defaults to 127.0.0.1:6379.
-    
-    Note that Redis does not currently support IPv6.
-
 - tarpit\_delay = seconds *(optional)*
 
-    Set this to the length in seconds that you want to delay every SMTP 
-    response to a remote client that has exceeded the rate limits.  For this 
-    to work the 'tarpit' plugin must be loaded **after** this plugin in 
-    config/plugins. 
+    Set this to the length in seconds that you want to delay every SMTP
+    response to a remote client that has exceeded the rate limits.  For this
+    to work the 'tarpit' plugin must be loaded **after** this plugin in
+    config/plugins.
 
     If 'tarpit' is not loaded or is loaded before this plugin, then no
     rate throttling will occur.
 
 * * *
 
-All of the following sections are optional.  Any missing section disables 
+All of the following sections are optional.  Any missing section disables
 that particular test.
 
 They all use a common configuration format:
 
 - \<lookup\> = \<limit\>[/time[unit]]  *(optional)*
 
-   'lookup' is based upon the limit being enforced and is either an IP 
-   address, rDNS name, sender address or recipient address either in full 
-   or part.  
-   The lookup order is as follows and the first match in this order is 
-   returned and is used as the record key in Redis (except for 'default' 
+   'lookup' is based upon the limit being enforced and is either an IP
+   address, rDNS name, sender address or recipient address either in full
+   or part.
+   The lookup order is as follows and the first match in this order is
+   returned and is used as the record key in Redis (except for 'default'
    which always uses the full lookup for that test as the record key):
-   
+
    **IPv4/IPv6 address or rDNS hostname:**
 
    <pre>
@@ -82,7 +75,7 @@ They all use a common configuration format:
    </pre>
 
    **Sender or Recipient address:**
- 
+
    <pre>
    user@host.sub.part.domain.com
    host.sub.part.domain.com
@@ -93,15 +86,15 @@ They all use a common configuration format:
    default
    </pre>
 
-   In all tests 'default' is used to specify a default limit if nothing else has 
+   In all tests 'default' is used to specify a default limit if nothing else has
    matched.
-   
-   'limit' specifies the limit for this lookup.  Specify 0 (zero) to disable 
+
+   'limit' specifies the limit for this lookup.  Specify 0 (zero) to disable
    limits on a matching lookup.
-   
-   'time' is optional and if missing defaults to 60 seconds.  You can optionally 
+
+   'time' is optional and if missing defaults to 60 seconds.  You can optionally
    specify the following time units (case-insensitive):
-   
+
    - s (seconds)
    - m (minutes)
    - h (hours)
@@ -109,44 +102,53 @@ They all use a common configuration format:
 
 ### [concurrency]
 
-**IMPORTANT NOTE:** connection concurrency is recorded in-memory (in 
-connection.server.notes) and not in Redis, so the limits are per-server and 
+**IMPORTANT NOTE:** connection concurrency is recorded in-memory (in
+connection.server.notes) and not in Redis, so the limits are per-server and
 per-child if you use the cluster module.
 
-IP and rDNS names are looked up by this test.  This section does *not* accept an 
+IP and rDNS names are looked up by this test.  This section does *not* accept an
 interval.  It's a hard limit on the number of connections and not based on time.
 
 ### [rate\_conn]
 
-This section limits the number of connections per interval from a given host 
+This section limits the number of connections per interval from a given host
 or set of hosts.
 
 IP and rDNS names are looked up by this test.
 
 ### [rate\_rcpt\_host]
 
-This section limits the number of recipients per interval from a given host or 
-set of hosts. 
+This section limits the number of recipients per interval from a given host or
+set of hosts.
 
 IP and rDNS names are looked up by this test.
 
 ### [rate\_rcpt\_sender]
 
-This section limits the number of recipients per interval from a sender or 
+This section limits the number of recipients per interval from a sender or
 sender domain.
 
 The sender is looked up by this test.
 
 ### [rate\_rcpt]
 
-This section limits the rate which a recipient or recipient domain can 
+This section limits the rate which a recipient or recipient domain can
 receive messages over an interval.
 
 Each recipient is looked up by this test.
 
 ### [rate\_rcpt\_null]
 
-This section limits the rate at which a recipient can receive messages from 
+This section limits the rate at which a recipient can receive messages from
 a null sender (e.g. DSN, MDN etc.) over an interval.
 
 Each recipient is looked up by this test.
+
+
+### [redis]
+
+- host (default: 127.0.0.1)
+- port (default: 6379)
+- db   (default: 0)
+
+If this section or any values are missing, the defaults from redis.ini are used.

--- a/docs/plugins/redis.md
+++ b/docs/plugins/redis.md
@@ -25,7 +25,7 @@ Publish & Subscribe are DB agnostic and thus have no db setting. If host and por
     ; see https://www.npmjs.com/package/redis#overloading
 
 
-## Usage
+## Usage (shared redis)
 
 Use redis in your plugin like so:
 
@@ -51,3 +51,30 @@ In your plugin:
     exports.hook_disconnect = function (next, connection) {
         this.redis_unsubscribe(connection);
     }
+
+## Custom Usage
+
+This variation lets your plugin establish it's own Redis connection,
+optionally with a redis db ID.
+
+    exports.register = function () {
+        var plugin = this;
+        plugin.inherits('redis');
+
+        plugin.cfg = plugin.config.get('my-plugin.ini');
+
+        // populate plugin.cfg.redis with defaults from redis.ini
+        plugin.merge_redis_ini();
+
+        plugin.register_hook('init_master', 'init_redis_plugin');
+        plugin.register_hook('init_child',  'init_redis_plugin');
+    }
+
+When a db ID is specified in the [redis] section of a redis inheriting plugin, log messages like these will be emitted when Haraka starts:
+
+    [INFO] [-] [redis] connected to redis://172.16.15.16:6379 v3.2.6
+    [INFO] [-] [karma] connected to redis://172.16.15.16:6379/2 v3.2.6
+    [INFO] [-] [known-senders] connected to redis://172.16.15.16:6379/3 v3.2.6
+
+Notice the database ID numbers appended to each plugins redis connection
+message.

--- a/docs/plugins/redis.md
+++ b/docs/plugins/redis.md
@@ -54,7 +54,7 @@ In your plugin:
 
 ## Custom Usage
 
-This variation lets your plugin establish it's own Redis connection,
+This variation lets your plugin establish its own Redis connection,
 optionally with a redis db ID.
 
     exports.register = function () {

--- a/docs/plugins/redis.md
+++ b/docs/plugins/redis.md
@@ -66,6 +66,7 @@ optionally with a redis db ID.
         // populate plugin.cfg.redis with defaults from redis.ini
         plugin.merge_redis_ini();
 
+        // cluster aware redis connection(s)
         plugin.register_hook('init_master', 'init_redis_plugin');
         plugin.register_hook('init_child',  'init_redis_plugin');
     }

--- a/plugins/greylist.js
+++ b/plugins/greylist.js
@@ -469,7 +469,7 @@ exports.retrieve_grey = function (rcpt_key, sender_key, cb) {
     multi.hgetall(rcpt_key);
     multi.hgetall(sender_key);
 
-    return multi.exec(function (err, result) {
+    multi.exec(function (err, result) {
         if (err) {
             plugin.lognotice("DB error: " + util.inspect(err));
             err.what = 'db_error';

--- a/plugins/greylist.js
+++ b/plugins/greylist.js
@@ -1,6 +1,6 @@
-// Greylisting Haraka plugin
+// Greylisting plugin for Haraka
 
-// version 0.1.3
+// version 0.1.4
 
 var util = require('util');
 var redis = require('redis');
@@ -16,12 +16,12 @@ var Address = require('address-rfc2821').Address;
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 exports.register = function (next) {
     var plugin = this;
+    plugin.inherits('redis');
 
     plugin.load_config();
-    plugin.load_config_lists();
 
-    this.register_hook('init_master', 'redis_onInit');
-    this.register_hook('init_child', 'redis_onInit');
+    this.register_hook('init_master', 'init_redis_plugin');
+    this.register_hook('init_child',  'init_redis_plugin');
 
     this.register_hook('rcpt_ok', 'hook_rcpt_ok');
 };
@@ -39,6 +39,7 @@ exports.load_config = function () {
         plugin.load_config();
     });
 
+    plugin.merge_redis_ini();
     plugin.load_config_lists();
 };
 
@@ -98,49 +99,8 @@ exports.load_config_lists = function () {
 };
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-exports.redis_onInit = function (next, server) {
-    var plugin = this;
-
-    if (plugin.redis)
-        return next();
-
-    /*
-    var r_opts = {
-        connect_timeout: 1000
-    };
-    */
-
-    var next_called;
-
-    plugin.redis = redis.createClient(plugin.cfg.redis.port, plugin.cfg.redis.host);
-
-    plugin.redis.on('error', function (err) {
-        plugin.logerror(err);
-        plugin.logerror("[gl] Redis error: " + err + '. Reconnecting...');
-    })
-    .on('ready', function () {
-        plugin.loginfo('[gl] Redis connected to ' + plugin.redis.host + ':' + (plugin.redis.port || 0) +
-            '/' + (plugin.cfg.redis.db || 0) + ' v' + plugin.redis.server_info.redis_version);
-
-        if (plugin.cfg.redis.db) {
-            plugin.redis.select(plugin.cfg.redis.db, function () {
-                if (!next_called) {
-                    next_called = true;
-                    return next();
-                }
-            });
-        }
-        else if (!next_called) {
-            next_called = true;
-            return next();
-        }
-    });
-};
-
 exports.shutdown = function () {
-    if (this.redis) {
-        this.redis.quit();
-    }
+    if (this.db) this.db.quit();
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -504,7 +464,7 @@ exports.craft_hostid = function (connection) {
 // not implemented
 exports.retrieve_grey = function (rcpt_key, sender_key, cb) {
     var plugin = this;
-    var multi = plugin.redis.multi();
+    var multi = plugin.db.multi();
 
     multi.hgetall(rcpt_key);
     multi.hgetall(sender_key);
@@ -523,7 +483,7 @@ exports.retrieve_grey = function (rcpt_key, sender_key, cb) {
 exports.update_grey = function (key, create, cb) {
     // { created: TS, updated: TS, lifetime: TTL, tried: Integer }
     var plugin = this;
-    var multi = plugin.redis.multi();
+    var multi = plugin.db.multi();
 
     var ts_now = Math.round(Date.now() / 1000);
 
@@ -575,13 +535,13 @@ exports.promote_to_white = function (connection, grey_rec, cb) {
 
     var white_key = plugin.craft_white_key(connection);
 
-    return plugin.redis.hmset(white_key, white_rec, function (err, result) {
+    return plugin.db.hmset(white_key, white_rec, function (err, result) {
         if (err) {
             plugin.lognotice("DB error: " + util.inspect(err));
             err.what = 'db_error';
             throw err;
         }
-        plugin.redis.expire(white_key, white_ttl, function (err2, result2) {
+        plugin.db.expire(white_key, white_ttl, function (err2, result2) {
             plugin.lognotice("DB error: " + util.inspect(err2));
             return cb(err2, result2);
         });
@@ -592,7 +552,7 @@ exports.promote_to_white = function (connection, grey_rec, cb) {
 exports.update_white_record = function (key, record, cb) {
     var plugin = this;
 
-    var multi = plugin.redis.multi();
+    var multi = plugin.db.multi();
     var ts_now = Math.round(Date.now() / 1000);
 
     // { first_connect: TS, whitelisted: TS, updated: TS, lifetime: TTL, tried: Integer, tried_when_greylisted: Integer }
@@ -617,7 +577,7 @@ exports.update_white_record = function (key, record, cb) {
 exports.db_lookup = function (key, cb) {
     var plugin = this;
 
-    plugin.redis.hgetall(key, function (err, result) {
+    plugin.db.hgetall(key, function (err, result) {
         if (err) {
             plugin.lognotice("DB error: " + util.inspect(err), key);
         }

--- a/plugins/rcpt_to.routes.js
+++ b/plugins/rcpt_to.routes.js
@@ -13,7 +13,7 @@ exports.register = function() {
     plugin.route_list={};
 
     plugin.load_rcpt_to_routes_ini();
-    plugin.load_redis_ini();
+    plugin.merge_redis_ini();
 
     plugin.register_hook('init_master',  'init_redis_plugin');
     plugin.register_hook('init_child',   'init_redis_plugin');

--- a/plugins/redis.js
+++ b/plugins/redis.js
@@ -45,6 +45,8 @@ exports.merge_redis_ini = function () {
         plugin.cfg.redis = {};
     }
 
+    if (!plugin.redisCfg) plugin.load_redis_ini();
+
     ['host', 'port', 'db'].forEach(function (k) {
         if (plugin.cfg.redis[k]) return;  // property already set
         plugin.cfg.redis[k] = plugin.redisCfg.server[k];

--- a/tests/plugins/rcpt_to.routes.js
+++ b/tests/plugins/rcpt_to.routes.js
@@ -51,7 +51,7 @@ var _set_up_redis = function (done) {
     };
 
     var t = this;
-    this.plugin.init_redis_connection(function (err) {
+    this.plugin.init_redis_shared(function (err) {
         if (err) {
             console.error(err.message);
             return done();


### PR DESCRIPTION
# Background

The redis plugin has three personalities:
1. add `redis` to config/plugins and at startup, the redis plugin connects to the redis server and leaves a shared db handle at `server.notes.redis`. This shared redis handle is used by the results store, the tls plugin, and any plugins that `inherit('redis')` without specifying a DB ID in their config.
2. As a base class for other plugins to inherit. This is how it has been used by rcpt_to.routes and the karma plugin. The redis plugin exports `merge_redis_ini()` and `init_redis_plugin()` which are used solely by plugins to populate their redis connection settings and establish the redis connection when Haraka starts up.
3. As a pub/sub agent helper. The result_store publishes all results as plugins emit them. Other plugins can subscribe to those redis channels. Both `karma` and `watch` plugins use redis subscriptions.

# Changes in this pull request:

- redis: 
    - only establish the shared server.notes.redis when plugin.name=redis
        - avoids extra establishment attempts when other plugins do: plugin.inherits("redis");
    - add merge_redis_ini() for plugins to call. Provides defaults for host, port, and db, when they're not specifically defined in the inheriting plugins [redis] config.
    - add test coverage for merge_redis_ini
    - add test coverage for redis_init_plugin with a DB ID specified
    - add inheritance usage example to docs
    - renamed `init_redis_connection()` -> `init_redis_shared()`  (better contrast with `init_redis_plugin`)
- rcpt_to.routes: use merge_redis_ini()
- tls: make redis comment more specific
- greylist: inherit(redis), prune redundant redis setup code
- rate_limit: inherit(redis), prune redundant redis setup code
    - rename self -> plugin (consistency)
    - use plugin.cfg w/cb for rate_limit.ini  (vs lots of var config = plugin.config.get(...))
    - update redis config format so a DB ID can be specified
        - with a backwards compatible config shim

Checklist:
- [x] docs updated
- [x] tests updated