### PR TITLE
use shorter results path

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "nodeunit"              : "*",
-    "haraka-test-fixtures"  : "*",
+    "haraka-test-fixtures"  : ">=1.0.17",
     "eslint"                : ">=2"
   },
   "bugs": {

--- a/tests/plugins/access.js
+++ b/tests/plugins/access.js
@@ -5,8 +5,6 @@ var path         = require('path');
 var Address      = require('address-rfc2821').Address;
 var fixtures     = require('haraka-test-fixtures');
 
-var ResultStore  = fixtures.result_store;
-
 var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('access');
@@ -15,7 +13,7 @@ var _set_up = function (done) {
 
     this.connection = fixtures.connection.createConnection();
     this.connection.transaction = {
-        results: new ResultStore(this.connection),
+        results: new fixtures.results(this.connection),
     };
 
     done();

--- a/tests/plugins/bounce.js
+++ b/tests/plugins/bounce.js
@@ -4,7 +4,6 @@ var Address      = require('address-rfc2821');
 var fixtures     = require('haraka-test-fixtures');
 
 var Connection   = fixtures.connection;
-var ResultStore  = fixtures.result_store;
 
 var Body         = require('../../mailbody').Body;
 var Header       = require('../../mailheader').Header;
@@ -33,7 +32,7 @@ var _set_up = function (done) {
     this.connection.remote.ip = '8.8.8.8';
     this.connection.transaction = {
         header: new Header(),
-        results: new ResultStore(this.plugin),
+        results: new fixtures.results(this.plugin),
     };
 
     done();

--- a/tests/plugins/clamd.js
+++ b/tests/plugins/clamd.js
@@ -3,7 +3,6 @@
 var fixtures     = require('haraka-test-fixtures');
 
 var Connection   = fixtures.connection;
-var ResultStore  = fixtures.result_store;
 
 var _set_up = function (done) {
 
@@ -14,7 +13,7 @@ var _set_up = function (done) {
 
     this.connection.transaction = {
         notes: {},
-        results: new ResultStore(this.plugin),
+        results: new fixtures.results(this.plugin),
     };
 
     done();

--- a/tests/plugins/data.headers.js
+++ b/tests/plugins/data.headers.js
@@ -3,9 +3,6 @@
 var Address      = require('address-rfc2821');
 var fixtures     = require('haraka-test-fixtures');
 
-var Connection   = fixtures.connection;
-var ResultStore  = fixtures.result_store;
-
 var Header       = require('../../mailheader').Header;
 
 var _set_up = function (done) {
@@ -19,11 +16,11 @@ var _set_up = function (done) {
     }
     catch (ignore) {}
 
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
 
     this.connection.transaction = {
         header: new Header(),
-        results: new ResultStore(this.plugin),
+        results: new fixtures.results(this.plugin),
         rcpt_to: [],
     };
 

--- a/tests/plugins/deprecated/relay_acl.js
+++ b/tests/plugins/deprecated/relay_acl.js
@@ -2,18 +2,14 @@
 
 var fixtures     = require('haraka-test-fixtures');
 
-var Connection   = fixtures.connection;
-var ResultStore  = fixtures.result_store;
-
 var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('relay_acl');
     this.plugin.cfg = {};
 
-    this.connection = Connection.createConnection();
-
+    this.connection = fixtures.connection.createConnection();
     this.connection.transaction = {
-        results: new ResultStore(this.connection),
+        results: new fixtures.results(this.connection),
     };
 
     done();

--- a/tests/plugins/greylist.js
+++ b/tests/plugins/greylist.js
@@ -4,9 +4,6 @@ var path = require('path');
 var fixtures     = require('haraka-test-fixtures');
 var ipaddr       = require('ipaddr.js');
 
-var Connection   = fixtures.connection;
-var ResultStore  = fixtures.result_store;
-
 var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('greylist');
@@ -25,9 +22,9 @@ var _set_up = function (done) {
     };
     this.plugin.list = {"dyndom":["sgvps.net"]};
 
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
     this.connection.transaction = {
-        results: new ResultStore(this.connection),
+        results: new fixtures.results(this.connection),
     };
 
     done();

--- a/tests/plugins/mail_from.is_resolvable.js
+++ b/tests/plugins/mail_from.is_resolvable.js
@@ -2,19 +2,17 @@
 
 var fixtures     = require('haraka-test-fixtures');
 var dns          = require('dns');
-var Connection   = fixtures.connection;
-var ResultStore  = fixtures.result_store;
 
 var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('mail_from.is_resolvable');
     this.plugin.register();
 
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
 
     this.connection.transaction = {
         notes: {},
-        results: new ResultStore(this.plugin),
+        results: new fixtures.results(this.plugin),
     };
 
     done();

--- a/tests/plugins/rcpt_to.host_list_base.js
+++ b/tests/plugins/rcpt_to.host_list_base.js
@@ -3,18 +3,15 @@
 var Address      = require('address-rfc2821').Address;
 var fixtures     = require('haraka-test-fixtures');
 
-var Connection   = fixtures.connection;
-var ResultStore  = fixtures.result_store;
-
 var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('rcpt_to.host_list_base');
     this.plugin.cfg = {};
     this.plugin.host_list = {};
 
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
     this.connection.transaction = {
-        results: new ResultStore(this.connection),
+        results: new fixtures.results(this.connection),
         notes: {},
     };
 

--- a/tests/plugins/rcpt_to.in_host_list.js
+++ b/tests/plugins/rcpt_to.in_host_list.js
@@ -3,9 +3,6 @@
 var Address      = require('address-rfc2821').Address;
 var fixtures     = require('haraka-test-fixtures');
 
-var Connection   = fixtures.connection;
-var ResultStore  = fixtures.result_store;
-
 var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('rcpt_to.in_host_list');
@@ -13,9 +10,9 @@ var _set_up = function (done) {
     this.plugin.cfg = {};
     this.plugin.host_list = {};
 
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
     this.connection.transaction = {
-        results: new ResultStore(this.connection),
+        results: new fixtures.results(this.connection),
         notes: {},
     };
 

--- a/tests/plugins/rcpt_to.ldap.js
+++ b/tests/plugins/rcpt_to.ldap.js
@@ -3,20 +3,16 @@
 var Address      = require('address-rfc2821').Address;
 var fixtures     = require('haraka-test-fixtures');
 
-var Connection   = fixtures.connection;
-var Plugin       = fixtures.plugin;
-var ResultStore  = fixtures.result_store;
-
 var _set_up = function (done) {
 
-    this.plugin = new Plugin('rcpt_to.ldap');
+    this.plugin = new fixtures.plugin('rcpt_to.ldap');
     this.plugin.inherits('rcpt_to.host_list_base');
 
     this.plugin.cfg = {};
     this.plugin.host_list = {};
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
     this.connection.transaction = {
-        results: new ResultStore(this.connection),
+        results: new fixtures.results(this.connection),
         notes: {},
         rcpt_to: [new Address('test@test.com')]
     };

--- a/tests/plugins/rcpt_to.qmail_deliverable.js
+++ b/tests/plugins/rcpt_to.qmail_deliverable.js
@@ -3,12 +3,10 @@
 var Address      = require('address-rfc2821');
 var fixtures     = require('haraka-test-fixtures');
 
-var Connection   = fixtures.connection;
-
 var _set_up = function (done) {
 
     this.plugin = new fixtures.plugin('rcpt_to.qmail_deliverable');
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
 
     done();
 };

--- a/tests/plugins/rcpt_to.routes.js
+++ b/tests/plugins/rcpt_to.routes.js
@@ -1,11 +1,7 @@
 'use strict';
 
 var Address      = require('address-rfc2821').Address;
-
 var fixtures     = require('haraka-test-fixtures');
-
-var Connection   = fixtures.connection;
-var ResultStore  = fixtures.result_store;
 
 var hmail = {
     todo: {
@@ -28,9 +24,9 @@ var _set_up_file = function (done) {
     this.plugin = new fixtures.plugin('rcpt_to.routes');
 
     this.plugin.register();
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
     this.connection.transaction = fixtures.transaction.createTransaction();
-    this.connection.transaction.results = new ResultStore(this.connection);
+    this.connection.transaction.results = new fixtures.results(this.connection);
 
     done();
 };
@@ -40,9 +36,9 @@ var _set_up_redis = function (done) {
     this.server = {};
     this.plugin = new fixtures.plugin('rcpt_to.routes');
 
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
     this.connection.transaction = fixtures.transaction.createTransaction();
-    this.connection.transaction.results = new ResultStore(this.connection);
+    this.connection.transaction.results = new fixtures.results(this.connection);
 
     this.plugin.register();
     this.plugin.server = { notes: { } };

--- a/tests/plugins/relay.js
+++ b/tests/plugins/relay.js
@@ -2,15 +2,11 @@
 
 var fixtures     = require('haraka-test-fixtures');
 
-var Connection   = fixtures.connection;
-var Plugin       = fixtures.plugin;
-var ResultStore  = fixtures.result_store;
-
 var _set_up = function (done) {
 
-    this.plugin = new Plugin('relay');
+    this.plugin = new fixtures.plugin('relay');
     this.plugin.cfg = {};
-    this.connection = Connection.createConnection();
+    this.connection = fixtures.connection.createConnection();
 
     done();
 };
@@ -94,9 +90,9 @@ exports.is_acl_allowed = {
 
 exports.acl = {
     setUp : function (callback) {
-        this.plugin = new Plugin('relay');
+        this.plugin = new fixtures.plugin('relay');
         this.plugin.cfg = { relay: { dest_domains: true } };
-        this.connection = Connection.createConnection();
+        this.connection = fixtures.connection.createConnection();
         callback();
     },
     'relay.acl=false' : function (test) {
@@ -158,12 +154,12 @@ exports.acl = {
 
 exports.dest_domains = {
     setUp : function (callback) {
-        this.plugin = new Plugin('relay');
+        this.plugin = new fixtures.plugin('relay');
         this.plugin.cfg = { relay: { dest_domains: true } };
 
-        this.connection = Connection.createConnection();
+        this.connection = fixtures.connection.createConnection();
         this.connection.transaction = {
-            results: new ResultStore(this.connection),
+            results: new fixtures.results(this.connection),
         };
 
         callback();
@@ -240,13 +236,13 @@ exports.dest_domains = {
 
 exports.force_routing = {
     setUp : function (callback) {
-        this.plugin = new Plugin('relay');
+        this.plugin = new fixtures.plugin('relay');
         this.plugin.cfg = { relay: { force_routing: true } };
         this.plugin.dest = {};
 
-        this.connection = Connection.createConnection();
+        this.connection = fixtures.connection.createConnection();
         this.connection.transaction = {
-            results: new ResultStore(this.connection),
+            results: new fixtures.results(this.connection),
         };
 
         callback();

--- a/tests/plugins/spf.js
+++ b/tests/plugins/spf.js
@@ -17,7 +17,7 @@ var _set_up = function (done) {
 
     this.connection = fixtures.connection.createConnection();
     this.connection.transaction = fixtures.transaction.createTransaction();
-    this.connection.transaction.results = new fixtures.result_store(this.connection);
+    this.connection.transaction.results = new fixtures.results(this.connection);
 
     done();
 };


### PR DESCRIPTION
- a finger friendlier way to handle tests
- that happens to mirror the way we use it in the code base (results, not result_store).