### PR TITLE
Do not create a top level secureContext

### DIFF
--- a/tls_socket.js
+++ b/tls_socket.js
@@ -10,8 +10,6 @@ var stream    = require('stream');
 var log       = require('./logger');
 var EventEmitter = require('events');
 
-var secureContext;
-
 var ocsp;
 try {
     ocsp      = require('ocsp');
@@ -209,8 +207,6 @@ if (ocsp) {
 exports.ocsp = ocsp;
 
 function _getSecureContext (options) {
-    if (secureContext) return secureContext;
-
     if (options === undefined) options = {};
 
     if (options.requestCert === undefined) {
@@ -221,12 +217,12 @@ function _getSecureContext (options) {
     }
     if (!options.sessionIdContext) {
        	options.sessionIdContext = 'haraka';
-    };
+    }
     if (!options.sessionTimeout) {
        	// options.sessionTimeout = 1;
-    };
+    }
 
-    secureContext = tls.createSecureContext(options);
+    var secureContext = tls.createSecureContext(options);
     return secureContext;
 }
 
@@ -250,7 +246,7 @@ function createServer (cb) {
                 if (options.enableOCSPStapling) {
                     if (ocsp) {
                         options.server = pseudoServ;
-                        pseudoServ._sharedCreds = secureContext;
+                        pseudoServ._sharedCreds = options.secureContext;
                     } else {
                         log.logerror("OCSP Stapling cannot be enabled because the ocsp module is not loaded");
                     }

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -222,8 +222,7 @@ function _getSecureContext (options) {
        	// options.sessionTimeout = 1;
     }
 
-    var secureContext = tls.createSecureContext(options);
-    return secureContext;
+    return tls.createSecureContext(options);
 }
 
 function createServer (cb) {


### PR DESCRIPTION
This causes problems because the secureContext ends up being used by
Haraka in server and client mode. Currently, the server mode loads
TLS keys as part of the context in (plugins/tls_socket). The client
mode does not load keys (in smtp_client.js). This discrepancy causes
tls connections to fail when there is an incoming mail immediately
followed by an outgoing mail.
