### PR TITLE
swap lines to fix missing inherited methods

### DIFF
--- a/plugins/dnswl.js
+++ b/plugins/dnswl.js
@@ -1,10 +1,10 @@
 'use strict';
 // dnswl plugin
 
-exports.register = function() {
+exports.register = function () {
     var plugin = this;
-    plugin.load_dnswl_ini();
     plugin.inherits('dns_list_base');
+    plugin.load_dnswl_ini();
 
     // IMPORTANT: don't run this on hook_rcpt otherwise we're an open relay...
     ['ehlo','helo','mail'].forEach(function (hook) {


### PR DESCRIPTION
Fix a transposed pair of lines in `plugins/dnswl.js`

```javascript
    plugin.load_dnswl_ini();
    plugin.inherits('dns_list_base');
```

`plugin.load_dnswl_ini()` attempts to use inherited methods, which aren't yet present.  A line swap fixes it.