### PR TITLE
fixing one bug hilighted another

### DIFF
--- a/bin/haraka
+++ b/bin/haraka
@@ -139,6 +139,7 @@ function mkDir (dstPath) {
     }
     catch (e) {
         // File exists
+        console.error(e);
         if (e.errno == 17) {
             warning(e.message);
         }
@@ -191,11 +192,12 @@ function copyFile (srcFile, dstFile) {
     }
     catch (e) {
         // File NOT exists
-        if (e.errno == 2) {
+        if (e.errno == -2) {
             fs.writeFileSync(dstFile, fs.readFileSync(srcFile));
             create(dstFile)
         }
         else {
+            console.log('copy ' + srcFile + ' to ' + dstFile);
             throw e;
         }
     }

--- a/plugins/limit.js
+++ b/plugins/limit.js
@@ -1,5 +1,0 @@
-'use strict';
-
-exports.register = function () {
-    this.logerror('deprecated! See https://github.com/haraka/haraka-plugin-limit');
-};

--- a/plugins/redis.js
+++ b/plugins/redis.js
@@ -1,6 +1,0 @@
-
-exports.register = function () {
-    this.logerror("Replaced by https://github.com/haraka/haraka-plugin-redis");
-    this.logerror("update your code to load haraka-plugin-redis instead");
-};
-

--- a/server.js
+++ b/server.js
@@ -476,8 +476,6 @@ Server.init_master_respond = function (retval, msg) {
         return;
     }
 
-    if (!c.outbound) return;
-
     // Running under cluster, fork children here, so that
     // cluster events can be registered in init_master hooks.
     outbound.scan_queue_pids(function (err, pids) {


### PR DESCRIPTION
Changes proposed in this pull request:
- now that we're using a comparison operator `e.errno == 2`, it reveals that the correct errno is -2 
- remove a bit of debugging code that missed getting purged
- more verbose error logging when copyFile/Dir fails
- remove redis & limit stubs (they take precedence over the npm packaged plugins)

Checklist:
- [ ] docs updated
- [ ] tests updated