### PR TITLE
comment out working test sample auth user

### DIFF
--- a/config/auth_flat_file.ini
+++ b/config/auth_flat_file.ini
@@ -2,4 +2,4 @@
 methods=CRAM-MD5
 
 [users]
-matt=test
+; matt=test


### PR DESCRIPTION
# Fixes

With the new config loading feature, whereby local config files are merged onto the included config files, having valid sample credentials in that config file has the potential to turn Haraka instances into open relays when the admin enables the `auth_flat_file` plugin.

Changes proposed in this pull request:
- comment out the example entry