### PR TITLE
This may or may not fix issues with short attachments.

### DIFF
--- a/attachment_stream.js
+++ b/attachment_stream.js
@@ -29,13 +29,18 @@ AttachmentStream.prototype.emit_data = function (data) {
     }
 };
 
-AttachmentStream.prototype.emit_end = function () {
-    if (this.paused) {
+AttachmentStream.prototype.emit_end = function (force) {
+    if (this.paused && !force) {
         // console.log("YYY: end emit (cache)");
         this.end_emitted = true;
     }
     else {
         // console.log("YYY: end emit");
+        if (this.buffer.length > 0) {
+            while (this.buffer.length > 0) {
+                this.emit_data(this.buffer.shift());
+            }
+        }
         this.emit('end');
     }
 };

--- a/mailbody.js
+++ b/mailbody.js
@@ -237,6 +237,18 @@ Body.prototype._empty_filter = function (ct, enc) {
     return new_buf.toString("binary");
 }
 
+Body.prototype.force_end = function () {
+    if (this.state === 'attachment') {
+        if (this.buf_fill > 0) {
+            // see below for why we create a new buffer here.
+            var to_emit = new Buffer(this.buf_fill);
+            this.buf.copy(to_emit, 0, 0, this.buf_fill);
+            this.attachment_stream.emit_data(to_emit);
+        }
+        this.attachment_stream.emit_end(true);
+    }
+}
+
 Body.prototype.parse_end = function (line) {
     if (!line) {
         line = '';

--- a/transaction.js
+++ b/transaction.js
@@ -144,6 +144,8 @@ Transaction.prototype.end_data = function (cb) {
                        .replace(/\r?\n/gm, '\r\n');
             var line = new Buffer(data, 'binary');
 
+            this.body.force_end();
+
             if (!this.discard_data) this.message_stream.add_line(line);
         }
     }


### PR DESCRIPTION
This is basically some belt and braces around short attachments sent in one TCP packet.

It has been running on emailitin.com for a month or so, with no adverse effects, I just don't have feedback on whether it fixed the issue or not - I was unable to replicate it (it requires major full control of the sending SMTP client library at the TCP level), and the customer who had the problem left the service. But I think we should merge it anyway.
