### PR TITLE
Cache the node_modules folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,8 @@ after_success:
     - ./node_modules/.bin/codecov
 
 sudo: false
+
+cache:
+    directories:
+        - node_modules
+


### PR DESCRIPTION
This just makes Travis faster. Newer modules update the cache so it's pretty safe.