### PR TITLE
add logger methods on outbound

### DIFF
--- a/tests/outbound.js
+++ b/tests/outbound.js
@@ -39,7 +39,18 @@ exports.outbound = {
         });
         test.done();
     },
-    'log_methods added': function (test) {
+    'log_methods added to outbound': function (test) {
+        var logger = require('../logger');
+        test.expect(Object.keys(logger.levels).length);
+
+        var outbound = require('../outbound');
+
+        Object.keys(logger.levels).forEach(function (level) {
+            test.ok(outbound['log' + level.toLowerCase()], "Log method for level: " + level);
+        });
+        test.done();
+    },
+    'log_methods added to HMailItem': function (test) {
         var logger = require('../logger');
         test.expect(Object.keys(logger.levels).length);
 


### PR DESCRIPTION
Fixes #1821

Using `this.log*` in outbound is generally a good thing, as it automatically prefixes the log emissions with the `[outbound]` prefix. A problem came along in #1807 when 23 lines of code were astutely replaced with one:

```js
logger.add_log_methods(HMailItem.prototype, "outbound");
```

The problem was, the previous 23 lines of code added the logger functions to **both** HMailItem.prototype and exports, and the new line of code added them to only HMailItem.prototype. This I expect caused caused much crashing during local testing as `this.log*` methods blew up.

Rather than also adding the log methods to exports, this was instead done:

```diff
-    this.loginfo("Processing domain: " + todo.domain);
+    logger.loginfo("[outbound] Processing domain: " + todo.domain);
```

Was this a conscious choice, or a "I should have gone to bed an hour ago" choice? 

This PR assumes the latter, adds the logging methods back to exports, and removes the no-longer-necessary `[outbound]` prefixes from the log invocations.