### PR TITLE
helo.checks: bring plugin into alignment with docs

### DIFF
--- a/config/helo.checks.ini
+++ b/config/helo.checks.ini
@@ -3,34 +3,34 @@
 ;dns_timeout=30
 
 [check]
-match_re=true
-bare_ip=true
-dynamic=true
-big_company=true
+; match_re=true
+; bare_ip=true
+; dynamic=true
+; big_company=true
 ; literal_mismatch:  1 = exact IP match, 2 = IP/24 match, 3 = /24 or RFC1918
-literal_mismatch=2
-valid_hostname=true
-forward_dns=true
-rdns_match=true
-; mismatch:  hostname differs between EHLO invocations
-mismatch=true
+; literal_mismatch=2
+; valid_hostname=true
+; forward_dns=true
+; rdns_match=true
+; host_mismatch:  hostname differs between EHLO invocations
+; host_mismatch=true
 ; proto_mismatch: host sent EHLO but then tries to sent HELO or vice-versa
-proto_mismatch=true
+; proto_mismatch=true
 
 [reject]
-mismatch=true
-proto_mismatch=false
-rdns_match=false
-dynamic=false
-bare_ip=false
-literal_mismatch=false
-valid_hostname=false
-forward_dns=false
-big_company=true
+; host_mismatch=true
+; proto_mismatch=false
+; rdns_match=false
+; dynamic=false
+; bare_ip=false
+; literal_mismatch=false
+; valid_hostname=false
+; forward_dns=false
+; big_company=true
 
 [skip]
-private_ip=true
-relaying=true
+; private_ip=true
+; relaying=true
 ; whitelist=true  ; TODO
 
 [bigco]

--- a/docs/plugins/helo.checks.md
+++ b/docs/plugins/helo.checks.md
@@ -83,7 +83,7 @@ helo.checks results can be accessed by subsequent plugins:
       Sees if the HELO hostname (or at least the domain) match the rDNS
       hostname(s).
 
-    * mismatch=true
+    * host\_mismatch=true
 
       If HELO is called multiple times, checks if the hostname differs between
       EHLO invocations.
@@ -100,12 +100,12 @@ helo.checks results can be accessed by subsequent plugins:
     Defaults shown:
 
     [reject]
-    mismatch=false
+    host_mismatch=false
+    literal_mismatch=false
     proto_mismatch=false
     rdns_match=false
     dynamic=false
     bare_ip=false
-    literal_mismatch=false
     valid_hostname=false
     forward_dns=false
     big_company=false

--- a/tests/plugins/helo.checks.js
+++ b/tests/plugins/helo.checks.js
@@ -37,12 +37,11 @@ exports.host_mismatch = {
         var outer = this;
         var cb = function () {
             test.equal(undefined, arguments[0]);
-            // console.log(outer.connection.results.get('helo.checks'));
             test.ok(outer.connection.results.get('helo.checks').fail.length);
         };
         this.plugin.init(stub, this.connection, 'helo.example.com');
-        this.plugin.cfg.check.mismatch=true;
-        this.plugin.cfg.reject.mismatch=false;
+        this.plugin.cfg.check.host_mismatch=true;
+        this.plugin.cfg.reject.host_mismatch=false;
         this.plugin.host_mismatch(cb, this.connection, 'anything');
         test.done();
     },
@@ -55,8 +54,8 @@ exports.host_mismatch = {
             test.ok(outer.connection.results.get('helo.checks').fail.length);
         };
         this.plugin.init(stub, this.connection, 'helo.example.com');
-        this.plugin.cfg.check.mismatch=true;
-        this.plugin.cfg.reject.mismatch=true;
+        this.plugin.cfg.check.host_mismatch=true;
+        this.plugin.cfg.reject.host_mismatch=true;
         this.plugin.host_mismatch(cb, this.connection, 'anything');
         test.done();
     },


### PR DESCRIPTION
Changes proposed in this pull request:

* rename config setting mismatch to host_mismatch
    * there are 3 mismatch functions
    * with a backwards compat config shim
* comment out boolean config settings
    * their defaults are already defined in the plugin
* build the config.booleans from the global `checks` array
    * removes bunch of redundant tokens

Fixes #1832 
Fixes msimerson/Mail-Toaster-6#202

Checklist:
- [x] docs updated
- [x] tests updated