### PR TITLE
Fixed documentation error for the 'check.authenticated' setting in the Rspamd plugin

### DIFF
--- a/docs/plugins/rspamd.md
+++ b/docs/plugins/rspamd.md
@@ -55,7 +55,7 @@ rspamd.ini
 
     Default: false
 
-    If true, messages from authenticated users will not be scanned by Rspamd.
+    If true, messages from authenticated users will be scanned by Rspamd.
 
 - check.private\_ip
 


### PR DESCRIPTION
The documentation says that the `check.authenticated` setting should be set to `false` if you want to check the authenticated messages. However, this is the exact opposite of what the plugin does. The setting should be set to `true` if authenticated messages need to be checked.

Changes proposed in this pull request:
- Fixed documentation error for the 'check.authenticated' setting in the Rspamd plugin

Checklist:
- [X] docs updated
- [ ] tests updated