### PR TITLE
Corrects an issue with the logger in configfile.js causing it to crash

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -6,7 +6,7 @@ var path = require('path');
 var yaml = require('js-yaml');
 var logger = require('./logger')
 
-logger.logdebug = function() {
+logger.logdebug = function () {
     if (!logger.log) {
         console.log.apply(console, arguments);
     }
@@ -15,8 +15,8 @@ logger.logdebug = function() {
     }
 }
 
-logger.loginfo = function() {
-    if(!logger.log) {
+logger.loginfo = function () {
+    if (!logger.log) {
         console.log.apply(console, arguments);
     }
     else {
@@ -24,8 +24,8 @@ logger.loginfo = function() {
     }
 }
 
-logger.logerror = function() {
-    if(!logger.log) {
+logger.logerror = function () {
+    if (!logger.log) {
         console.error.apply(console, arguments);
     }
     else {

--- a/configfile.js
+++ b/configfile.js
@@ -4,8 +4,34 @@
 var fs   = require('fs');
 var path = require('path');
 var yaml = require('js-yaml');
+var logger = require('./logger')
 
-var logger = getStubLogger();
+logger.logdebug = function() {
+    if (!logger.log) {
+        console.log.apply(console, arguments);
+    }
+    else {
+        logger.log.apply(logger, [logger.levels.DEBUG, arguments[0].toString()]);
+    }
+}
+
+logger.loginfo = function() {
+    if(!logger.log) {
+        console.log.apply(console, arguments);
+    }
+    else {
+        logger.log.apply(logger, [logger.levels.INFO, arguments[0].toString()]);
+    }
+}
+
+logger.logerror = function() {
+    if(!logger.log) {
+        console.error.apply(console, arguments);
+    }
+    else {
+        logger.log.apply(logger, [logger.levels.ERROR, arguments[0].toString()]);
+    }
+}
 
 // for "ini" type files
 var regex = exports.regex = {
@@ -72,21 +98,6 @@ function get_path_to_config_dir () {
 }
 get_path_to_config_dir();
 // logger.logdebug('cfreader.config_path: ' + cfreader.config_path);
-
-function getStubLogger () {
-    // stubs used before logger is loaded
-    return {
-        logdebug: function () {
-            console.log.apply(console, arguments);
-        },
-        loginfo: function () {
-            console.log.apply(console, arguments);
-        },
-        logerror: function () {
-            console.error.apply(console, arguments);
-        },
-    }
-}
 
 cfreader.on_watch_event = function (name, type, options, cb) {
     return function (fse, filename) {
@@ -623,4 +634,4 @@ cfreader.load_binary_config = function (name, type) {
         }
     }
 };
-logger = require('./logger');
+//logger = require('./logger');


### PR DESCRIPTION
On Ubuntu 16.04 (at least, was not tested with anything else), Haraka
would error out immediately after start, complaining about how
`logger.logerror` didn't exist. As it turns out, the inclusion of
`logger = require("./logger")` at the end of the file caused the
simplistic logger to be overwritten with Haraka's custom logger, which
doesn't have any log* (logdebug, loginfo, and logerror) functions. This
makes sure that logger has been properly included - if it hasn't, it
falls back to outputting directly to console - and calls `logger.log`
with the appropriate log level (`DEBUG`, `INFO`, and `ERROR`,
respectively).

Changes proposed in this pull request:
- Basic change to the way logging is required in `configfile.js`

Checklist:
- [ ] docs updated (N/A - No feature added)
- [ ] tests updated (N/A - No feature added)
