### PR TITLE
smtp forward dest split routing

### DIFF
--- a/config/rcpt_to.qmail_deliverable.ini
+++ b/config/rcpt_to.qmail_deliverable.ini
@@ -10,6 +10,11 @@ host=127.0.0.1
 ; the TCP port qmail_deliverabled is listening on, default 8998
 port=8998
 
+; By default, the first queue plugin enabled is used. With this option, a
+; specific queue plugin can be used for recipients validated by this plugin
+; queue=outbound
+; queue=smtp_forward
+; queue=qmail-queue
 
 ;[example.com]
 ;host=127.0.0.10

--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -63,6 +63,23 @@ Configuration
 
     SMTP AUTH password to use.
 
+  * queue
+
+    Which queue plugin to use. Default: undefined. The default bahavior is to
+    use smtp_forward for inbound connections and outbound for relaying
+    connections. This option is used for complex mail routes.
+
+  * check_sender=false
+
+    Requires that sender domains defined in smtp_forward.ini (see Per-Domain below) have relaying privileges. This is a form of spoof prevention and assumes that any mail clients have relaying or AUTH privileges. This is usually the case.
+
+  * check_recipient=false
+
+    By default, Haraka accepts no emails until a recipient plugin has been configured to accept mails for a domain. The simplest common case is the in_host_list plugin with a list of domains in config/host_host. An alternative is to set `check_recipient=true` and list each domain in a definition block in smtp_forward.ini (see Per-Domain Configuration). An example for two domains:
+
+    [example.com]
+    [example.net]
+
 # Per-Domain Configuration
 
 More specific forward routes for domains can be defined. More specific routes
@@ -87,6 +104,7 @@ connections where every recipient host is identical.
     [example3.com]
     host=1.2.3.6
 
-## split-host forward routing
 
-When an incoming email transaction has multiple recipients with differing forward routes,  recipients to subsequent forward routes are deferred. Example: an incoming email transaction has recipients user@example1.com, user@example2.com, and user@example3.com. The first two messages will be accepted (they share the same forward destination) and the latter one will be deferred. It will arrive in a future delivery attempt by the remote.
+# Split host forward routing
+
+When an incoming email transaction has multiple recipients with different forward routes,  recipients to subsequent forward routes are deferred. Example: an incoming email transaction has recipients user@example1.com, user@example2.com, and user@example3.com. The first two messages will be accepted (they share the same forward destination) and the latter one will be deferred. It will arrive in a future delivery attempt by the remote.

--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -87,13 +87,6 @@ connections where every recipient host is identical.
     [example3.com]
     host=1.2.3.6
 
-Messages with a single recipient to example[1-3].com will get delivered
-directly to the specified host. Messages with recipients only in the domains
-example1.com and example2.com will get delivered directly to 1.2.3.5.
-Everything else gets delivered to 1.2.3.4.
+## split-host forward routing
 
-## Per-Domain Limitations
-
-See [GitHub Issue #573](https://github.com/haraka/Haraka/issues/573) for
-background on the limitations of smtp-forward with recipients in different
-domains.
+When an incoming email transaction has multiple recipients with differing forward routes,  recipients to subsequent forward routes are deferred. Example: an incoming email transaction has recipients user@example1.com, user@example2.com, and user@example3.com. The first two messages will be accepted (they share the same forward destination) and the latter one will be deferred. It will arrive in a future delivery attempt by the remote.

--- a/outbound.js
+++ b/outbound.js
@@ -126,7 +126,6 @@ exports.stat_queue = function (cb) {
 };
 
 exports.scan_queue_pids = function (cb) {
-    var self = this;
 
     // Under cluster, this is called first by the master so
     // we create the queue directory if it doesn't exist.

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -127,7 +127,7 @@ exports.check_recipient = function (next, connection, params) {
             return next(OK);
         }
         txn.results.add(plugin, {pass: 'rcpt_to.split'});
-        return next(DENYSOFT, "Queue error, try again soon");
+        return next(DENYSOFT, "Split transaction, retry soon");
     }
 
     if (connection.relaying && txn.notes.local_sender) {

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -11,8 +11,18 @@ exports.register = function () {
 
     plugin.load_smtp_forward_ini();
 
+    if (plugin.cfg.main.check_sender) {
+        plugin.register_hook('mail', 'check_sender');
+    }
+
+    if (plugin.cfg.main.check_recipient) {
+        plugin.register_hook('rcpt', 'check_recipient');
+    }
+
+    plugin.register_hook('queue', 'queue_forward');
+
     if (plugin.cfg.main.enable_outbound) {
-        plugin.register_hook('queue_outbound', 'hook_queue');
+        plugin.register_hook('queue_outbound', 'queue_forward');
     }
 };
 
@@ -24,6 +34,8 @@ exports.load_smtp_forward_ini = function () {
             '-main.enable_tls',
             '+main.enable_outbound',
             'main.one_message_per_rcpt',
+            '-main.check_sender',
+            '-main.check_recipient',
             '*.enable_tls',
         ],
     },
@@ -45,8 +57,8 @@ exports.get_config = function (connection) {
     var rcpt_count = connection.transaction.rcpt_to.length;
     if (rcpt_count === 1) { return plugin.cfg[dom]; }
 
-    for (var i=1; i < rcpt_count; i++) {
-        var dom2 = connection.transaction.rcpt_to[i].host;
+    for (let i=1; i < rcpt_count; i++) {
+        let dom2 = connection.transaction.rcpt_to[i].host;
         if (!dom2 || !plugin.cfg[dom2]) return plugin.cfg.main;
         if (plugin.cfg[dom2].host !== plugin.cfg[dom].host) {
             // differing destination hosts
@@ -56,59 +68,152 @@ exports.get_config = function (connection) {
     return plugin.cfg[dom];
 };
 
-exports.hook_queue = function (next, connection) {
+exports.check_sender = function (next, connection, params) {
     var plugin = this;
-    var cfg = plugin.get_config(connection);
     var txn = connection.transaction;
+    if (!txn) return;
 
-    connection.loginfo(plugin, 'forwarding to ' +
-            (cfg.forwarding_host_pool ? "configured forwarding_host_pool" : cfg.host + ':' + cfg.port)
-        );
+    var email = params[0].address();
+    if (!email) {
+        txn.results.add(plugin, {skip: 'mail_from.null', emit: true});
+        return next();
+    }
 
-    var smc_cb = function (err, smtp_client) {
-        smtp_client.next = next;
+    var domain = params[0].host.toLowerCase();
+    if (!plugin.cfg[domain]) return next();
 
-        if (cfg.auth_user) {
-            connection.loginfo(plugin, 'Configuring authentication for SMTP server ' + cfg.host + ':' + cfg.port);
-            smtp_client.on('capabilities', function () {
-                connection.loginfo(plugin, 'capabilities received');
-                if ('secured' in smtp_client) {
-                    connection.loginfo(plugin, 'secured is pending');
-                    if (smtp_client.secured === false) {
-                        connection.loginfo(plugin,"Waiting for STARTTLS to complete. AUTH postponed");
-                        return;
-                    }
-                }
+    // domain is defined in smtp_forward.ini
+    txn.notes.local_sender = true;
 
-                var base64 = function (str) {
-                    var buffer = new Buffer(str, 'UTF-8');
-                    return buffer.toString('base64');
-                };
+    if (!connection.relaying) {
+        txn.results.add(plugin, {fail: 'mail_from!spoof'});
+        return next(DENY, "Spoofed MAIL FROM");
+    }
 
-                if (cfg.auth_type === 'plain') {
-                    connection.loginfo(plugin, 'Authenticating with AUTH PLAIN ' + cfg.auth_user);
-                    smtp_client.send_command('AUTH', 'PLAIN ' + base64('\0' + cfg.auth_user + '\0' + cfg.auth_pass));
-                }
-                else if (cfg.auth_type === 'login') {
-                    smtp_client.authenticating = true;
-                    smtp_client.authenticated=false;
+    txn.results.add(plugin, {pass: 'mail_from'});
+    return next();
+};
 
-                    connection.loginfo(plugin, 'Authenticating with AUTH LOGIN ' + cfg.auth_user);
-                    smtp_client.send_command('AUTH', 'LOGIN');
-                    smtp_client.on('auth', function () {
-                        //TODO: nothing?
-                    });
-                    smtp_client.on('auth_username', function () {
-                        smtp_client.send_command(base64(cfg.auth_user));
-                    });
-                    smtp_client.on('auth_password', function () {
-                        smtp_client.send_command(base64(cfg.auth_pass));
-                    });
-                }
-            });
+exports.set_queue = function (connection, queue_wanted, domain) {
+    var plugin = this;
+
+    var dom_cfg = plugin.cfg[domain];
+    if (dom_cfg === undefined) dom_cfg = {};
+
+    if (!queue_wanted) queue_wanted = dom_cfg.queue || plugin.cfg.main.queue;
+    if (!queue_wanted) return true;
+
+    queue_wanted += ':' + (dom_cfg.host || plugin.cfg.main.host || '');
+
+    if (!connection.transaction.notes.queue) {
+        connection.transaction.notes.queue = queue_wanted;
+        return true;
+    }
+
+    // multiple recipients with same destination
+    if (connection.transaction.notes.queue === queue_wanted) {
+        return true;
+    }
+
+    // multiple recipients with different forward host, soft deny
+    return false;
+}
+
+exports.check_recipient = function (next, connection, params) {
+    var plugin = this;
+    var txn = connection.transaction;
+    if (!txn) return;
+
+    var rcpt = params[0];
+    if (!rcpt.host) {
+        txn.results.add(plugin, {skip: 'rcpt!domain'});
+        return next();
+    }
+
+    var domain = rcpt.host.toLowerCase();
+    if (plugin.cfg[domain] !== undefined) {
+        if (plugin.set_queue(connection, 'smtp_forward', domain)) {
+            txn.results.add(plugin, {pass: 'rcpt_to'});
+            return next(OK);
+        }
+        txn.results.add(plugin, {pass: 'rcpt_to.split'});
+        return next(DENYSOFT, "Queue error, try again soon");
+    }
+
+    if (connection.relaying && txn.notes.local_sender) {
+        plugin.set_queue(connection, 'outbound');
+        txn.results.add(plugin, {pass: 'relaying local_sender'});
+        return next(OK);
+    }
+
+    // the MAIL FROM domain is not local and neither is the RCPT TO
+    // Another RCPT plugin may vouch for this recipient.
+    txn.results.add(plugin, {msg: 'rcpt!local'});
+    return next();
+};
+
+exports.auth = function (cfg, connection, smtp_client) {
+    var plugin = this;
+
+    connection.loginfo(plugin, 'Configuring authentication for SMTP server ' + cfg.host + ':' + cfg.port);
+    smtp_client.on('capabilities', function () {
+        connection.loginfo(plugin, 'capabilities received');
+
+        if ('secured' in smtp_client) {
+            connection.loginfo(plugin, 'secured is pending');
+            if (smtp_client.secured === false) {
+                connection.loginfo(plugin, "Waiting for STARTTLS to complete. AUTH postponed");
+                return;
+            }
         }
 
+        var base64 = function (str) {
+            var buffer = new Buffer(str, 'UTF-8');
+            return buffer.toString('base64');
+        };
+
+        if (cfg.auth_type === 'plain') {
+            connection.loginfo(plugin, 'Authenticating with AUTH PLAIN ' + cfg.auth_user);
+            smtp_client.send_command('AUTH', 'PLAIN ' + base64('\0' + cfg.auth_user + '\0' + cfg.auth_pass));
+        }
+        else if (cfg.auth_type === 'login') {
+            smtp_client.authenticating = true;
+            smtp_client.authenticated=false;
+
+            connection.loginfo(plugin, 'Authenticating with AUTH LOGIN ' + cfg.auth_user);
+            smtp_client.send_command('AUTH', 'LOGIN');
+            smtp_client.on('auth', function () {
+                //TODO: nothing?
+            });
+            smtp_client.on('auth_username', function () {
+                smtp_client.send_command(base64(cfg.auth_user));
+            });
+            smtp_client.on('auth_password', function () {
+                smtp_client.send_command(base64(cfg.auth_pass));
+            });
+        }
+    });
+}
+
+exports.queue_forward = function (next, connection) {
+    var plugin = this;
+    var txn = connection.transaction;
+
+    if (txn.notes.queue && !/^smtp_forward/.test(txn.notes.queue))
+        return next();
+
+    var cfg = plugin.get_config(connection);
+
+    smtp_client_mod.get_client_plugin(plugin, connection, cfg, function (err, smtp_client) {
+        smtp_client.next = next;
+
         var rcpt = 0;
+
+        if (cfg.auth_user) plugin.auth(cfg, connection, smtp_client);
+
+        connection.loginfo(plugin, 'forwarding to ' +
+            (cfg.forwarding_host_pool ? "host_pool" : cfg.host + ':' + cfg.port)
+        );
 
         var dead_sender = function () {
             if (smtp_client.is_dead_sender(plugin, connection)) {
@@ -132,6 +237,7 @@ exports.hook_queue = function (next, connection) {
         };
 
         smtp_client.on('mail', send_rcpt);
+
         if (cfg.one_message_per_rcpt) {
             smtp_client.on('rcpt', function () {
                 smtp_client.send_command('DATA');
@@ -167,8 +273,5 @@ exports.hook_queue = function (next, connection) {
                                 msg);
             smtp_client.release();
         });
-    };
-
-    smtp_client_mod.get_client_plugin(plugin, connection, cfg, smc_cb);
+    });
 };
-

--- a/plugins/rcpt_to.qmail_deliverable.js
+++ b/plugins/rcpt_to.qmail_deliverable.js
@@ -66,7 +66,8 @@ exports.set_queue = function (connection, queue_wanted, domain) {
     if (!queue_wanted) return true;
 
     if (queue_wanted === 'smtp_forward') {
-        queue_wanted += ':' + (dom_cfg.host || plugin.cfg.main.host || '');
+        var dst_host = dom_cfg.host || plugin.cfg.main.host;
+        if (dst_host) queue_wanted += ':' + dst_host;
     }
 
     if (!connection.transaction.notes.queue) {

--- a/plugins/rcpt_to.qmail_deliverable.js
+++ b/plugins/rcpt_to.qmail_deliverable.js
@@ -104,7 +104,7 @@ exports.hook_rcpt = function (next, connection, params) {
             if (plugin.set_queue(connection, null, domain)) {
                 return next(OK);
             }
-            return next(DENYSOFT, "Queue error, try again soon");
+            return next(DENYSOFT, "Split transaction, retry soon");
         }
 
         // a client with relaying privileges is sending from a local domain.

--- a/plugins/rcpt_to.qmail_deliverable.js
+++ b/plugins/rcpt_to.qmail_deliverable.js
@@ -4,12 +4,6 @@
 var http = require('http');
 var querystring = require('querystring');
 
-var options = {
-    method: 'get',
-    host: '127.0.0.1',
-    port: 8998,
-};
-
 exports.register = function () {
     var plugin = this;
     plugin.load_qmd_ini();
@@ -17,10 +11,10 @@ exports.register = function () {
 
 exports.load_qmd_ini = function () {
     var plugin = this;
-    plugin.cfg = plugin.config.get(
-                'rcpt_to.qmail_deliverable.ini',
-                function () { plugin.load_qmd_ini(); }
-                );
+    var cfgName = 'rcpt_to.qmail_deliverable.ini';
+    plugin.cfg = plugin.config.get(cfgName, function () {
+        plugin.load_qmd_ini();
+    });
 };
 
 exports.hook_mail = function (next, connection, params) {
@@ -39,7 +33,7 @@ exports.hook_mail = function (next, connection, params) {
 
     var domain = params[0].host.toLowerCase();
 
-    var cb = function (err, qmd_r) {
+    plugin.get_qmd_response(connection, domain, email, function (err, qmd_r) {
         if (err) {
             txn.results.add(plugin, {err: err});
             return next(DENYSOFT, err);
@@ -59,10 +53,35 @@ exports.hook_mail = function (next, connection, params) {
 
         txn.results.add(plugin, {msg: "mail_from." + qmd_r[1]});
         return next(CONT, "mail_from." + qmd_r[1]);
-    };
-
-    plugin.get_qmd_response(connection, domain, email, cb);
+    });
 };
+
+exports.set_queue = function (connection, queue_wanted, domain) {
+    var plugin = this;
+
+    var dom_cfg = plugin.cfg[domain];
+    if (dom_cfg === undefined) dom_cfg = {};
+
+    if (!queue_wanted) queue_wanted = dom_cfg.queue || plugin.cfg.main.queue;
+    if (!queue_wanted) return true;
+
+    if (queue_wanted === 'smtp_forward') {
+        queue_wanted += ':' + (dom_cfg.host || plugin.cfg.main.host || '');
+    }
+
+    if (!connection.transaction.notes.queue) {
+        connection.transaction.notes.queue = queue_wanted;
+        return true;
+    }
+
+    // multiple recipients with same destination
+    if (connection.transaction.notes.queue === queue_wanted) {
+        return true;
+    }
+
+    // multiple recipients with different forward host, soft deny
+    return false;
+}
 
 exports.hook_rcpt = function (next, connection, params) {
     var plugin = this;
@@ -71,11 +90,9 @@ exports.hook_rcpt = function (next, connection, params) {
     var rcpt = params[0];
     var domain = rcpt.host.toLowerCase();
 
-    txn.results.add(plugin, {
-        msg: "sock: " + options.host + ':' + options.port
-    });
-
-    var cb = function (err, qmd_r) {
+    // Qmail::Deliverable::Client does a rfc2822 "atext" test
+    // but Haraka has already validated for us by this point
+    plugin.get_qmd_response(connection, domain, rcpt.address(), function (err, qmd_r) {
         if (err) {
             txn.results.add(plugin, {err: err});
             return next(DENYSOFT, "error validating email address");
@@ -83,13 +100,17 @@ exports.hook_rcpt = function (next, connection, params) {
 
         if (qmd_r[0] === OK) {
             txn.results.add(plugin, {pass: "rcpt." + qmd_r[1]});
-            return next(OK);
+            if (plugin.set_queue(connection, null, domain)) {
+                return next(OK);
+            }
+            return next(DENYSOFT, "Queue error, try again soon");
         }
 
         // a client with relaying privileges is sending from a local domain.
         // Any RCPT is acceptable.
         if (connection.relaying && txn.notes.local_sender) {
             txn.results.add(plugin, {pass: "relaying local_sender"});
+            plugin.set_queue(connection, 'outbound');
             return next(OK);
         }
 
@@ -102,15 +123,17 @@ exports.hook_rcpt = function (next, connection, params) {
         // returns OK, then the address is not accepted.
         txn.results.add(plugin, {msg: "rcpt." + qmd_r[1]});
         return next(CONT, qmd_r[1]);
-    };
-
-    // Qmail::Deliverable::Client does a rfc2822 "atext" test
-    // but Haraka has already validated for us by this point
-    plugin.get_qmd_response(connection, domain, rcpt.address(), cb);
+    });
 };
 
 exports.get_qmd_response = function (connection, domain, email, cb) {
     var plugin = this;
+
+    var options = {
+        method: 'get',
+        host: '127.0.0.1',
+        port: 8998,
+    };
 
     if (plugin.cfg[domain]) {
         if (plugin.cfg[domain].host) options.host = plugin.cfg[domain].host;
@@ -120,6 +143,10 @@ exports.get_qmd_response = function (connection, domain, email, cb) {
         if (plugin.cfg.main.host) options.host = plugin.cfg.main.host;
         if (plugin.cfg.main.port) options.port = plugin.cfg.main.port;
     }
+
+    connection.transaction.results.add(plugin, {
+        msg: "sock: " + options.host + ':' + options.port
+    });
 
     connection.logdebug(plugin, "checking " + email);
     options.path = '/qd1/deliverable?' + querystring.escape(email);

--- a/tests/plugins/queue/smtp_forward.js
+++ b/tests/plugins/queue/smtp_forward.js
@@ -5,7 +5,7 @@ var path         = require('path');
 var Address      = require('address-rfc2821').Address;
 var fixtures     = require('haraka-test-fixtures');
 
-var Connection   = fixtures.connection;
+const OK = 906;
 
 function _setup (done) {
     this.plugin = new fixtures.plugin('queue/smtp_forward');
@@ -14,8 +14,8 @@ function _setup (done) {
     this.plugin.config = this.plugin.config.module_config(path.resolve('tests'));
     this.plugin.register();
 
-    this.connection = Connection.createConnection();
-    this.connection.transaction = fixtures.transaction.createTransaction();
+    this.connection = new fixtures.connection.createConnection();
+    this.connection.transaction = new fixtures.transaction.createTransaction();
 
     done();
 }
@@ -92,14 +92,26 @@ exports.get_config = {
         test.deepEqual(cfg.host, '1.2.3.4' );
         test.done();
     },
-    'valid 2 recipients with different routes': function (test) {
-        test.expect(1);
-        this.connection.transaction.rcpt_to.push(
-            new Address('<matt@test1.com>'),
-            new Address('<matt@test2.com>')
-            );
-        var cfg = this.plugin.get_config(this.connection);
-        test.equal(cfg.host, 'localhost' );
-        test.done();
-    },
 };
+
+exports.get_mx = {
+    setUp : _setup,
+    'returns no outbound route for undefined domains' : function (test) {
+        test.expect(2);
+        var cb = function (code, mx) {
+            test.equal(code, undefined);
+            test.deepEqual(mx, undefined);
+            test.done();
+        };
+        this.plugin.get_mx(cb, {}, 'undefined.com');
+    },
+    'returns an outbound route for defined domains' : function (test) {
+        test.expect(2);
+        var cb = function (code, mx) {
+            test.equal(code, OK);
+            test.deepEqual(mx, { priority: 0, exchange: '1.2.3.4', port: 2555 });
+            test.done();
+        };
+        this.plugin.get_mx(cb, {}, 'test.com');
+    },
+}

--- a/tests/plugins/queue/smtp_forward.js
+++ b/tests/plugins/queue/smtp_forward.js
@@ -109,7 +109,11 @@ exports.get_mx = {
         test.expect(2);
         var cb = function (code, mx) {
             test.equal(code, OK);
-            test.deepEqual(mx, { priority: 0, exchange: '1.2.3.4', port: 2555 });
+            test.deepEqual(mx, {
+                priority: 0, exchange: '1.2.3.4', port: 2555,
+                auth_user: 'postmaster@test.com',
+                auth_pass: 'superDuperSecret'
+            });
             test.done();
         };
         this.plugin.get_mx(cb, {}, 'test.com');

--- a/tests/plugins/rcpt_to.routes.js
+++ b/tests/plugins/rcpt_to.routes.js
@@ -141,7 +141,7 @@ exports.get_mx_file = {
             test.equal(rc, OK);
             test.equal(mx, '192.168.1.1');
             test.done();
-        }.bind(this);
+        };
 
         this.plugin.route_list = {'matt@example.com': '192.168.1.1'};
         var addr = new Address('<matt@example.com>');
@@ -153,7 +153,7 @@ exports.get_mx_file = {
             test.equal(rc, OK);
             test.equal(mx, '192.168.1.2');
             test.done();
-        }.bind(this);
+        };
 
         this.plugin.route_list = {'example.com': '192.168.1.2'};
         var addr = new Address('<matt@example.com>');
@@ -165,7 +165,7 @@ exports.get_mx_file = {
             test.equal(rc, OK);
             test.equal(mx, '192.168.1.1');
             test.done();
-        }.bind(this);
+        };
 
         this.plugin.route_list = {
             'matt@example.com': '192.168.1.1',


### PR DESCRIPTION
This is progress on #1472 and it improves upon a longstanding mail routing issue that affects users of per-domain mail forwarding.

I have a bunch of `[domain.com]` blocks in smtp_forward.ini and most domains have differing forward hosts. When a transaction has recipients in domains with different forward hosts, then those subsequent recipients are sent to the wrong destination host. The `one_message_per_rcpt` option in smtp_forward just does an `RSET` between transactions to the forward host of the first recipient.

The previous workaround was to forward transactions with multiple destination hosts to the default forward host and let the smart host sort it out. See #573 and #671. That works reasonably well the vast majority of the time. The edge case is split transactions with undeliverable recipients. They end up being queued and some of those recipients are ultimately undeliverable and bounce.

This PR removes the "forward multiple destination transactions to smarthost and let it sort it out" behavior and adds recipient validation to smtp_forward. Example:

````
 -> MAIL FROM:<matt@****.tnpi.net>
<-  250 sender <matt@****.tnpi.net> OK
 -> RCPT TO:<matt@tnpi.net>
<-  250 recipient <matt@tnpi.net> OK
 -> RCPT TO:<ryan@example.net>
<** 450 [7E794F58-35C@haraka] Queue error, try again soon
 -> DATA
<-  354 go ahead, make my day
````

Within a transaction, it defers subsequent recipients if they have a different forward host than the first recipient. This is possible because `smtp_forward.ini` already has the forward host information. Other recipient/queue plugins can cooperate by setting `txn.notes.queue`.

Changes proposed in this pull request:

- smtp_forward: add `check_sender()` & `check_recipient()` 
    - disabled by default
    - when enabled, if a domain has a definition block in `smtp_forward.ini`:
        - validate sender & recipients
            - for myself, the host_list plugin is no longer necessary
        - for relaying clients, set queue to `txn.notes.queue:outbound`
        - for inbound recipients, set `txn.notes.queue=smtp_forward:hostname`
        - if subsequent recipients on a transaction have differing forward routes:
            - DENYSOFT
            - it's the only safe/sane way to split the transaction
    - remove the "forward to default host when conflicting forward hosts" behavior added in #671
- if `txn.notes.queue` is defined but doesn't start with `smtp_forward`, then smtp_forward doesn't queue.
- moved the AUTH block out of `hook_queue` to its own function
- add `get_mx` hook, so that recipients in connections where `relaying=true` that are destined to a local domain (defined in smtp_forward.ini and for which we are the MX for) can be queued to outbound and still be deliverable.
- qmail_deliverable
    - config, add manually specified queue option
    - like smtp_forward, qmd already supports domain routing
        - specify a queue (for myself: smtp_forward), supporting the smtp_forward queue splitting
    - moved qmd options into get_qmd_response (was plugin global)

Checklist:
- [x] docs updated
- [x] tests updated