### PR TITLE
Added missing 'default' keyword in rspamd plugin. Score wasn't added …

### DIFF
--- a/plugins/log.elasticsearch.js
+++ b/plugins/log.elasticsearch.js
@@ -336,8 +336,8 @@ exports.populate_message = function (pir, connection) {
     }
 
     if (pir.rcpt_to && pir.rcpt_to.recipient) {
-	for (var key in pir.rcpt_to.recipient) {
-                pir.rcpt_to.recipient[key].address=pir.rcpt_to.recipient[key].address.toLowerCase();
+        for (var key in pir.rcpt_to.recipient) {
+            pir.rcpt_to.recipient[key].address=pir.rcpt_to.recipient[key].address.toLowerCase();
         }
         pir.message.envelope.recipient = pir.rcpt_to.recipient;
         delete pir.rcpt_to;

--- a/plugins/log.elasticsearch.js
+++ b/plugins/log.elasticsearch.js
@@ -331,11 +331,14 @@ exports.populate_message = function (pir, connection) {
     };
 
     if (pir.mail_from && pir.mail_from.address) {
-        pir.message.envelope.sender = pir.mail_from.address;
+        pir.message.envelope.sender = pir.mail_from.address.toLowerCase();
         delete pir.mail_from.address;
     }
 
     if (pir.rcpt_to && pir.rcpt_to.recipient) {
+	for (var key in pir.rcpt_to.recipient) {
+                pir.rcpt_to.recipient[key].address=pir.rcpt_to.recipient[key].address.toLowerCase();
+        }
         pir.message.envelope.recipient = pir.rcpt_to.recipient;
         delete pir.rcpt_to;
     }

--- a/plugins/rspamd.js
+++ b/plugins/rspamd.js
@@ -274,12 +274,12 @@ exports.add_headers = function (connection, data) {
         var spamBar = '';
         var spamBarScore = 1;
         var spamBarChar = cfg.spambar.neutral || '/';
-        if (data.score >= 1) {
-            spamBarScore = Math.floor(data.score);
+        if (data.default.score >= 1) {
+            spamBarScore = Math.floor(data.default.score);
             spamBarChar = cfg.spambar.positive || '+';
         }
-        else if (data.score <= -1) {
-            spamBarScore = Math.floor(data.score * -1);
+        else if (data.default.score <= -1) {
+            spamBarScore = Math.floor(data.default.score * -1);
             spamBarChar = cfg.spambar.negative || '-';
         }
         for (var i = 0; i < spamBarScore; i++) {
@@ -304,6 +304,6 @@ exports.add_headers = function (connection, data) {
 
     if (cfg.header && cfg.header.score) {
         connection.transaction.remove_header(cfg.header.score);
-        connection.transaction.add_header(cfg.header.score, '' + data.score);
+        connection.transaction.add_header(cfg.header.score, '' + data.default.score);
     }
 };

--- a/tests/plugins/rspamd.js
+++ b/tests/plugins/rspamd.js
@@ -54,8 +54,8 @@ exports.add_headers = {
     'adds a header to a message with positive score': function (test) {
         test.expect(3);
         var test_data = {
-            score: 1.1,
             default: {
+		score: 1.1,
                 FOO: {
                     name: 'FOO',
                     score: 0.100000,
@@ -78,7 +78,9 @@ exports.add_headers = {
     'adds a header to a message with negative score': function (test) {
         test.expect(2);
         var test_data = {
-            score: -1,
+		default: {
+            		score: -1,
+		}
         };
         this.plugin.add_headers(this.connection, test_data);
         // console.log(this.connection.transaction.header);

--- a/tests/plugins/rspamd.js
+++ b/tests/plugins/rspamd.js
@@ -55,7 +55,7 @@ exports.add_headers = {
         test.expect(3);
         var test_data = {
             default: {
-		score: 1.1,
+                score: 1.1,
                 FOO: {
                     name: 'FOO',
                     score: 0.100000,
@@ -78,9 +78,9 @@ exports.add_headers = {
     'adds a header to a message with negative score': function (test) {
         test.expect(2);
         var test_data = {
-		default: {
-            		score: -1,
-		}
+            default: {
+                score: -1,
+            }
         };
         this.plugin.add_headers(this.connection, test_data);
         // console.log(this.connection.transaction.header);


### PR DESCRIPTION
r.data which contains the rspamd answer also contains the 'default' index which was omitted by the author in a few places. Because of this, scores weren't added properly to headers.