### PR TITLE
SPF: Fix modifier regexp

### DIFF
--- a/spf.js
+++ b/spf.js
@@ -217,7 +217,7 @@ SPF.prototype.check_host = function (ip, domain, mail_from, cb) {
         var mod_array = [];
         var mech_regexp1 = /^([-+~?])?(all|a|mx|ptr)$/;
         var mech_regexp2 = /^([-+~?])?(a|mx|ptr|ip4|ip6|include|exists)((?::[^\/ ]+(?:\/\d+(?:\/\/\d+)?)?)|\/\d+(?:\/\/\d+)?)$/;
-        var mod_regexp = /^([^ =]+)=([a-z0-9._-]+)$/;
+        var mod_regexp = /^([^ =]+)=([a-z0-9:\/._-]+)$/;
         var split = spf_record.split(' ');
         for (i=1; i<split.length; i++) {
             // Skip blanks


### PR DESCRIPTION
Fixes:

``````
# spf --debug --domain champollion.ro --ip 85.9.45.137
ip=85.9.45.137 domain=champollion.ro mail_from=postmaster@champollion.ro
found SPF record for domain champollion.ro: v=spf1 include:myhost.ro -all
found mechanism: include:myhost.ro,+,include,:myhost.ro
found mechanism: -all,-,all
SPF record for 'champollion.ro' validated OK
running mechanism: include args=+,:myhost.ro domain=champollion.ro
ip=85.9.45.137 domain=myhost.ro mail_from=postmaster@champollion.ro
discarding TXT record: google-site-verification=ikrCSa_5Gl7n9D0s0Ix8VskWko7TXFMqavE2RCmVYFI
found SPF record for domain myhost.ro: v=spf1 ip4:85.9.45.129/25 ip4:46.102.236.32/28 ip4:85.9.53.122 ip4:185.72.242.16/28 include:spf.sendmachine.info ?include:netblocks.zooku.ro -all ra=postmaster rp=10 rr=e:f exp=info.myhost.ro
found mechanism: ip4:85.9.45.129/25,+,ip4,:85.9.45.129/25
found mechanism: ip4:46.102.236.32/28,+,ip4,:46.102.236.32/28
found mechanism: ip4:85.9.53.122,+,ip4,:85.9.53.122
found mechanism: ip4:185.72.242.16/28,+,ip4,:185.72.242.16/28
found mechanism: include:spf.sendmachine.info,+,include,:spf.sendmachine.info
found mechanism: ?include:netblocks.zooku.ro,?,include,:netblocks.zooku.ro
found mechanism: -all,-,all
found modifier: ra=postmaster,ra,postmaster
skipping unknown modifier: ra
found modifier: rp=10,rp,10
skipping unknown modifier: rp
syntax error: rr=e:f
mech_include: domain=myhost.ro returned=SPF_PERMERROR
ip=85.9.45.137 helo="" domain="champollion.ro" result=PermError
``````

After fix:

``````
# spf --debug --domain champollion.ro --ip 85.9.45.137
ip=85.9.45.137 domain=champollion.ro mail_from=postmaster@champollion.ro
found SPF record for domain champollion.ro: v=spf1 include:myhost.ro -all
found mechanism: include:myhost.ro,+,include,:myhost.ro
found mechanism: -all,-,all
SPF record for 'champollion.ro' validated OK
running mechanism: include args=+,:myhost.ro domain=champollion.ro
ip=85.9.45.137 domain=myhost.ro mail_from=postmaster@champollion.ro
discarding TXT record: google-site-verification=ikrCSa_5Gl7n9D0s0Ix8VskWko7TXFMqavE2RCmVYFI
found SPF record for domain myhost.ro: v=spf1 ip4:85.9.45.129/25 ip4:46.102.236.32/28 ip4:85.9.53.122 ip4:185.72.242.16/28 include:spf.sendmachine.info ?include:netblocks.zooku.ro -all ra=postmaster rp=10 rr=e:f exp=info.myhost.ro
found mechanism: ip4:85.9.45.129/25,+,ip4,:85.9.45.129/25
found mechanism: ip4:46.102.236.32/28,+,ip4,:46.102.236.32/28
found mechanism: ip4:85.9.53.122,+,ip4,:85.9.53.122
found mechanism: ip4:185.72.242.16/28,+,ip4,:185.72.242.16/28
found mechanism: include:spf.sendmachine.info,+,include,:spf.sendmachine.info
found mechanism: ?include:netblocks.zooku.ro,?,include,:netblocks.zooku.ro
found mechanism: -all,-,all
found modifier: ra=postmaster,ra,postmaster
skipping unknown modifier: ra
found modifier: rp=10,rp,10
skipping unknown modifier: rp
found modifier: rr=e:f,rr,e:f
skipping unknown modifier: rr
found modifier: exp=info.myhost.ro,exp,info.myhost.ro
SPF record for 'myhost.ro' validated OK
running mechanism: ip4 args=+,:85.9.45.129/25 domain=myhost.ro
mech_ip: 85.9.45.137 => 85.9.45.129/25: MATCH!
mech_include: domain=myhost.ro returned=SPF_PASS
ip=85.9.45.137 helo="" domain="champollion.ro" result=Pass
``````

