### PR TITLE
replace util.inherits with class .. extends

### DIFF
--- a/attachment_stream.js
+++ b/attachment_stream.js
@@ -1,19 +1,18 @@
-"use strict";
+'use strict';
 
 var Stream = require('stream');
-var util   = require('util');
 
-function AttachmentStream (header) {
-    Stream.call(this);
-    this.header = header;
-    this.encoding = null;
-    this.paused = false;
-    this.end_emitted = false;
-    this.connection = null;
-    this.buffer = [];
+class AttachmentStream extends Stream {
+    constructor (header) {
+        super();
+        this.header = header;
+        this.encoding = null;
+        this.paused = false;
+        this.end_emitted = false;
+        this.connection = null;
+        this.buffer = [];
+    }
 }
-
-util.inherits(AttachmentStream, Stream);
 
 AttachmentStream.prototype.emit_data = function (data) {
     // console.log("YYY: DATA emit");

--- a/chunkemitter.js
+++ b/chunkemitter.js
@@ -1,51 +1,16 @@
 'use strict';
 
-var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 
-function ChunkEmitter (buffer_size) {
-    EventEmitter.call(this);
-    this.buffer_size = parseInt(buffer_size) || (64 * 1024);
-    this.buf = null;
-    this.pos = 0;
-    this.bufs = [];
-    this.bufs_size = 0;
-}
-
-util.inherits(ChunkEmitter, EventEmitter);
-
-if (!Buffer.concat) {
-    var buf;
-    Buffer.concat = function (list, length) {
-        if (!Array.isArray(list)) {
-            throw new Error('Usage: Buffer.concat(list, [length])');
-        }
-
-        if (list.length === 0) {
-            return new Buffer(0);
-        }
-        else if (list.length === 1) {
-            return list[0];
-        }
-
-        if (typeof length !== 'number') {
-            length = 0;
-            for (let i = 0; i < list.length; i++) {
-                buf = list[i];
-                length += buf.length;
-            }
-        }
-
-        var buffer = new Buffer(length);
-        var pos = 0;
-
-        for (let i = 0; i < list.length; i++) {
-            buf = list[i];
-            buf.copy(buffer, pos);
-            pos += buf.length;
-        }
-        return buffer;
-    };
+class ChunkEmitter extends EventEmitter {
+    constructor (buffer_size) {
+        super();
+        this.buffer_size = parseInt(buffer_size) || (64 * 1024);
+        this.buf = null;
+        this.pos = 0;
+        this.bufs = [];
+        this.bufs_size = 0;
+    }
 }
 
 ChunkEmitter.prototype.fill = function (input) {

--- a/contrib/haraka.service
+++ b/contrib/haraka.service
@@ -2,7 +2,7 @@
 # systemd service file for Haraka
 #
 # Put this file in /usr/lib/systemd/system, modify the paths to suit
-# then run: 
+# then run:
 # sudo systemctl enable haraka
 # sudo systemctl start haraka
 #
@@ -10,13 +10,13 @@
 [Unit]
 Description=Haraka MTA
 After=syslog.target network.target remote-fs.target nss-lookup.target
- 
+
 [Service]
 Type=forking
 PIDFile=/var/run/haraka.pid
 ExecStart=/usr/bin/haraka -c /path/to/your/config
 KillMode=process
 PrivateTmp=true
- 
+
 [Install]
 WantedBy=multi-user.target

--- a/dkim.js
+++ b/dkim.js
@@ -403,35 +403,34 @@ exports.DKIMObject = DKIMObject;
 // DKIMVerifyStream //
 //////////////////////
 
-function DKIMVerifyStream (cb, timeout) {
-    Stream.call(this);
-    this.run_cb = false;
-    var self = this;
-    this.cb = function (err, result, results) {
-        if (!self.run_cb) {
-            self.run_cb = true;
-            return cb(err, result, results);
-        }
-    };
-    this._in_body = false;
-    this._no_signatures_found = false;
-    this.buffer = new Buf();
-    this.headers = [];
-    this.header_idx = {};
-    this.dkim_objects = [];
-    this.results = [];
-    this.result = 'none';
-    this.pending = 0;
-    this.writable = true;
-    this.timeout = timeout || 30;
+class DKIMVerifyStream extends Stream {
+    constructor (cb, timeout) {
+        super();
+        this.run_cb = false;
+        this.cb = (err, result, results) => {
+            if (!this.run_cb) {
+                this.run_cb = true;
+                return cb(err, result, results);
+            }
+        };
+        this._in_body = false;
+        this._no_signatures_found = false;
+        this.buffer = new Buf();
+        this.headers = [];
+        this.header_idx = {};
+        this.dkim_objects = [];
+        this.results = [];
+        this.result = 'none';
+        this.pending = 0;
+        this.writable = true;
+        this.timeout = timeout || 30;
+    }
 }
 
-util.inherits(DKIMVerifyStream, Stream);
 
 DKIMVerifyStream.prototype.debug = function (str) {
     util.debug(str);
 };
-
 
 DKIMVerifyStream.prototype.handle_buf = function (buf) {
     var self = this;

--- a/line_socket.js
+++ b/line_socket.js
@@ -2,15 +2,15 @@
 // A subclass of Socket which reads data by line
 
 var net   = require('net');
-var util  = require('util');
 var utils = require('haraka-utils');
 
 var tls  = require('./tls_socket');
 
-function Socket (options) {
-    if (!(this instanceof Socket)) return new Socket(options);
-    net.Socket.call(this, options);
-    setup_line_processor(this);
+class Socket extends net.Socket {
+    constructor (options) {
+        super(options);
+        setup_line_processor(this);
+    }
 }
 
 function setup_line_processor (socket) {
@@ -35,8 +35,6 @@ function setup_line_processor (socket) {
     socket.on('data', function (data) { socket.process_data(data);});
     socket.on('end',  function ()     { socket.process_end();     });
 }
-
-util.inherits(Socket, net.Socket);
 
 exports.Socket = Socket;
 

--- a/mailbody.js
+++ b/mailbody.js
@@ -1,36 +1,38 @@
 'use strict';
 
+var events = require('events');
+var utils  = require('haraka-utils');
+
 // Mail Body Parser
 var logger = require('./logger');
 var Header = require('./mailheader').Header;
-var utils  = require('haraka-utils');
 var config = require('./config');
-var events = require('events');
-var util   = require('util');
 var Iconv  = require('./mailheader').Iconv;
 var attstr = require('./attachment_stream');
 
 var buf_siz = config.get('mailparser.bufsize') || 65536;
 
-function Body (header, options) {
-    this.header = header || new Header();
-    this.header_lines = [];
-    this.is_html = false;
-    this.options = options || {};
-    this.filters = [];
-    this.bodytext = '';
-    this.body_text_encoded = '';
-    this.body_encoding = null;
-    this.boundary = null;
-    this.ct = null;
-    this.decode_function = null;
-    this.children = []; // if multipart
-    this.state = 'start';
-    this.buf = new Buffer(buf_siz);
-    this.buf_fill = 0;
+class Body extends events.EventEmitter {
+    constructor (header, options) {
+        super();
+        this.header = header || new Header();
+        this.header_lines = [];
+        this.is_html = false;
+        this.options = options || {};
+        this.filters = [];
+        this.bodytext = '';
+        this.body_text_encoded = '';
+        this.body_encoding = null;
+        this.boundary = null;
+        this.ct = null;
+        this.decode_function = null;
+        this.children = []; // if multipart
+        this.state = 'start';
+        this.buf = new Buffer(buf_siz);
+        this.buf_fill = 0;
+    }
 }
 
-util.inherits(Body, events.EventEmitter);
 exports.Body = Body;
 
 Body.prototype.add_filter = function (filter) {

--- a/messagestream.js
+++ b/messagestream.js
@@ -1,57 +1,54 @@
 'use strict';
 
-// MessageStream class
-
-var fs = require('fs');
-var util = require('util');
+var fs     = require('fs');
 var Stream = require('stream').Stream;
-var utils = require('haraka-utils');
+var utils  = require('haraka-utils');
 
 var ChunkEmitter = require('./chunkemitter');
 
 var STATE_HEADERS = 1;
 var STATE_BODY = 2;
 
-function MessageStream (config, id, headers) {
-    if (!id) throw new Error('id required');
-    Stream.call(this);
-    this.uuid = id;
-    this.write_ce = null;
-    this.read_ce = null;
-    this.bytes_read = 0;
-    this.state = STATE_HEADERS;
-    this.idx = {};
-    this.end_called = false;
-    this.end_callback = null;
-    this.buffered = 0;
-    this._queue = [];
-    this.max_data_inflight = 0;
-    this.buffer_max = (!isNaN(config.main.spool_after) ?
-                       Number(config.main.spool_after) : -1);
-    this.spooling = false;
-    this.fd = null;
-    this.open_pending = false;
-    this.spool_dir = config.main.spool_dir || '/tmp';
-    this.filename = this.spool_dir + '/' + id + '.eml';
-    this.write_pending = false;
+class MessageStream extends Stream {
+    constructor (config, id, headers) {
+        super();
+        if (!id) throw new Error('id required');
+        this.uuid = id;
+        this.write_ce = null;
+        this.read_ce = null;
+        this.bytes_read = 0;
+        this.state = STATE_HEADERS;
+        this.idx = {};
+        this.end_called = false;
+        this.end_callback = null;
+        this.buffered = 0;
+        this._queue = [];
+        this.max_data_inflight = 0;
+        this.buffer_max = (!isNaN(config.main.spool_after) ?
+                        Number(config.main.spool_after) : -1);
+        this.spooling = false;
+        this.fd = null;
+        this.open_pending = false;
+        this.spool_dir = config.main.spool_dir || '/tmp';
+        this.filename = this.spool_dir + '/' + id + '.eml';
+        this.write_pending = false;
 
-    this.readable = true;
-    this.paused = false;
-    this.headers = headers || [];
-    this.headers_done = false;
-    this.headers_found_eoh = false;
-    this.line_endings = "\r\n";
-    this.dot_stuffing = false;
-    this.ending_dot = false;
-    this.buffer_size = (1024 * 64);
-    this.start = 0;
-    this.write_complete = false;
-    this.ws = null;
-    this.rs = null;
-    this.in_pipe = false;
+        this.readable = true;
+        this.paused = false;
+        this.headers = headers || [];
+        this.headers_done = false;
+        this.headers_found_eoh = false;
+        this.line_endings = "\r\n";
+        this.dot_stuffing = false;
+        this.ending_dot = false;
+        this.buffer_size = (1024 * 64);
+        this.start = 0;
+        this.write_complete = false;
+        this.ws = null;
+        this.rs = null;
+        this.in_pipe = false;
+    }
 }
-
-util.inherits(MessageStream, Stream);
 
 MessageStream.prototype.add_line = function (line) {
     var self = this;
@@ -417,14 +414,14 @@ MessageStream.prototype.get_data = function (options, cb) { // Or: (cb)
 
 module.exports = MessageStream;
 
-
-function GetDataStream (cb) {
-    this.cb = cb;
-    this.buf = '';
-    this.writable = true;
+class GetDataStream extends Stream {
+    constructor (cb) {
+        super();
+        this.cb = cb;
+        this.buf = '';
+        this.writable = true;
+    }
 }
-
-util.inherits(GetDataStream, Stream);
 
 GetDataStream.prototype.write = function (obj, enc) {
     this.buf += obj;

--- a/outbound/fsync_writestream.js
+++ b/outbound/fsync_writestream.js
@@ -1,17 +1,13 @@
-"use strict";
+'use strict';
 
 var fs      = require('fs');
 var util    = require('util');
 
-module.exports = FsyncWriteStream;
-
-function FsyncWriteStream (path, options) {
-    if (!(this instanceof FsyncWriteStream)) return new FsyncWriteStream(path, options);
-
-    fs.WriteStream.call(this, path, options);
+class FsyncWriteStream extends fs.WriteStream {
+    constructor(path, options) {
+        super(path, options);
+    }
 }
-
-util.inherits(FsyncWriteStream, fs.WriteStream);
 
 FsyncWriteStream.prototype.close = function (cb) {
     var self = this;
@@ -46,3 +42,6 @@ FsyncWriteStream.prototype.close = function (cb) {
         });
     }
 };
+
+module.exports = FsyncWriteStream;
+

--- a/plugins.js
+++ b/plugins.js
@@ -165,7 +165,8 @@ Plugin.prototype.inherits = function (parent_name) {
         if (!this[method]) {
             this[method] = parent_plugin[method];
         }
-        // else if (method == 'shutdown') { // Method is in this module, so it exists in the plugin
+        // else if (method == 'shutdown') {
+        //     Method is in this module, so it exists in the plugin
         //     if (!this.hasOwnProperty('shutdown')) {
         //         this[method] = parent_plugin[method];
         //     }

--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -7,27 +7,26 @@ var crypto     = require('crypto');
 var fs         = require('fs');
 var path       = require('path');
 var Stream     = require('stream').Stream;
-var util       = require('util');
 
 var utils      = require('haraka-utils');
 
-function DKIMSignStream (selector, domain, private_key, headers_to_sign, header, end_callback) {
-    Stream.call(this);
-    this.selector = selector;
-    this.domain = domain;
-    this.private_key = private_key;
-    this.headers_to_sign = headers_to_sign;
-    this.header = header;
-    this.end_callback = end_callback;
-    this.writable = true;
-    this.found_eoh = false;
-    this.buffer = { ar: [], len: 0 };
-    this.hash = crypto.createHash('SHA256');
-    this.line_buffer = { ar: [], len: 0 };
-    this.signer = crypto.createSign('RSA-SHA256');
+class DKIMSignStream extends Stream {
+    constructor (selector, domain, private_key, headers_to_sign, header, end_callback) {
+        super();
+        this.selector = selector;
+        this.domain = domain;
+        this.private_key = private_key;
+        this.headers_to_sign = headers_to_sign;
+        this.header = header;
+        this.end_callback = end_callback;
+        this.writable = true;
+        this.found_eoh = false;
+        this.buffer = { ar: [], len: 0 };
+        this.hash = crypto.createHash('SHA256');
+        this.line_buffer = { ar: [], len: 0 };
+        this.signer = crypto.createSign('RSA-SHA256');
+    }
 }
-
-util.inherits(DKIMSignStream, Stream);
 
 DKIMSignStream.prototype.write = function (buf) {
     /*

--- a/tests/fixtures/line_socket.js
+++ b/tests/fixtures/line_socket.js
@@ -1,20 +1,19 @@
 'use strict';
 
 var events   = require('events');
-var util     = require('util');
 var fixtures = require('haraka-test-fixtures');
 var stub     = fixtures.stub.stub;
 
-function Socket (port, host) {
-    events.EventEmitter.call(this);
-    this.port = port;
-    this.host = host;
-    this.setTimeout = stub();
-    this.setKeepAlive = stub();
-    this.destroy = stub();
+class Socket extends events.EventEmitter {
+    constructor (port, host) {
+        super();
+        this.port = port;
+        this.host = host;
+        this.setTimeout = stub();
+        this.setKeepAlive = stub();
+        this.destroy = stub();
+    }
 }
-
-util.inherits(Socket, events.EventEmitter);
 
 exports.Socket = Socket;
 

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -12,26 +12,26 @@ var EventEmitter = require('events');
 
 var ocsp;
 try {
-    ocsp      = require('ocsp');
-} catch (er) {
+    ocsp = require('ocsp');
+}
+catch (er) {
     log.lognotice("Can't load module ocsp. OCSP Stapling not available.");
-    ocsp = null;
 }
 
 // provides a common socket for attaching
 // and detaching from either main socket, or crypto socket
-function pluggableStream (socket) {
-    stream.Stream.call(this);
-    this.readable = this.writable = true;
-    this._timeout = 0;
-    this._keepalive = false;
-    this._writeState = true;
-    this._pending = [];
-    this._pendingCallbacks = [];
-    if (socket) this.attach(socket);
+class pluggableStream extends stream.Stream {
+    constructor (socket) {
+        super();
+        this.readable = this.writable = true;
+        this._timeout = 0;
+        this._keepalive = false;
+        this._writeState = true;
+        this._pending = [];
+        this._pendingCallbacks = [];
+        if (socket) this.attach(socket);
+    }
 }
-
-util.inherits(pluggableStream, stream.Stream);
 
 pluggableStream.prototype.pause = function () {
     if (this.targetsocket.pause) {
@@ -160,12 +160,13 @@ function pipe (cleartext, socket) {
     socket.on('close', onclose);
 }
 
-function pseudoTLSServer () {
-    EventEmitter.call(this);
+class pseudoTLSServer extends EventEmitter {
+    constructor () {
+        super();
+    }
 }
 
 if (ocsp) {
-    util.inherits(pseudoTLSServer, EventEmitter);
 
     var ocspCache = new ocsp.Cache();
     var pseudoServ = new pseudoTLSServer();
@@ -210,18 +211,14 @@ exports.ocsp = ocsp;
 function _getSecureContext (options) {
     if (options === undefined) options = {};
 
-    if (options.requestCert === undefined) {
-        options.requestCert = true;
-    }
+    if (options.requestCert === undefined) options.requestCert = true;
+
     if (options.rejectUnauthorized === undefined) {
         options.rejectUnauthorized = false;
     }
-    if (!options.sessionIdContext) {
-        options.sessionIdContext = 'haraka';
-    }
-    if (!options.sessionTimeout) {
-        // options.sessionTimeout = 1;
-    }
+
+    if (!options.sessionIdContext) options.sessionIdContext = 'haraka';
+    // if (!options.sessionTimeout) options.sessionTimeout = 1;
 
     return tls.createSecureContext(options);
 }
@@ -239,17 +236,19 @@ function createServer (cb) {
 
             if (!options) options = {};
 
-            if (!options.secureContext) {
+            options.isServer = true;
 
+            if (!options.secureContext) {
                 options.secureContext = _getSecureContext(options);
-                options.isServer = true;
-                if (options.enableOCSPStapling) {
-                    if (ocsp) {
-                        options.server = pseudoServ;
-                        pseudoServ._sharedCreds = options.secureContext;
-                    } else {
-                        log.logerror("OCSP Stapling cannot be enabled because the ocsp module is not loaded");
-                    }
+            }
+
+            if (options.enableOCSPStapling) {
+                if (ocsp) {
+                    options.server = pseudoServ;
+                    pseudoServ._sharedCreds = options.secureContext;
+                }
+                else {
+                    log.logerror("OCSP Stapling cannot be enabled because the ocsp module is not loaded");
                 }
             }
 
@@ -327,11 +326,12 @@ function connect (port, host, cb) {
 
         cleartext.on('secureConnect', function () {
             log.logdebug('client TLS secured.');
-            var cert = cleartext.getPeerCertificate();
-            if (cleartext.getCipher) {
-                var cipher = cleartext.getCipher();
-            }
-            if (cb2) cb2(cleartext.authorized, cleartext.authorizationError, cert, cipher);
+            if (cb2) cb2(
+                cleartext.authorized,
+                cleartext.authorizationError,
+                cleartext.getPeerCertificate(),
+                cleartext.getCipher()
+            );
         });
 
         // cleartext._controlReleased = true;


### PR DESCRIPTION
Changes proposed in this pull request:
* replace the discouraged util.inherits with `class Foo extends Bar` syntax
    * this change **looks** bigger than it is, due to an additional level of indention
* chunkemitter: remove Buffer.concat shim for node < 0.7.11
* fsync_writesteam: moved into ./outbound (only required once)
* tls_socket.createServer: always set `isServer=true` (a recent merge made it conditional)
* removed test for cleartext.getCipher, it *should* always be present

Checklist:
- [ ] docs updated
- [ ] tests updated