### PR TITLE
Typo in config file name

### DIFF
--- a/docs/plugins/queue/rabbitmq_amqplib.md
+++ b/docs/plugins/queue/rabbitmq_amqplib.md
@@ -10,7 +10,7 @@ Dependency
 Configuration
 -------------
 
-* `config/rabbitmq_amqplib.ini` - Connection, exchange and queue settings
+* `config/rabbitmq.ini` - Connection, exchange and queue settings
     
     Example:
 


### PR DESCRIPTION
Actual this is typo in plugin source - it uses "ini" file from another plugin called rabbitmq . So, in fact, no one of the plugins uses config file with name "rabbitmq_amqplib.ini" . This cause error (default values for the plugin) if you trying use the official documentation.

Fixes #

Changes proposed in this pull request:
- fix typo in documentation
- 
- 

Checklist:
- [x] docs updated
- [ ] tests updated
