### PR TITLE
tls: remove interim variables

### DIFF
--- a/server.js
+++ b/server.js
@@ -297,22 +297,18 @@ Server.get_smtp_server = function (host, port, inactivity_timeout) {
     var conn_cb = function (client) {
         client.setTimeout(inactivity_timeout);
         var connection = conn.createConnection(client, server);
-        if (server.has_tls) {
-            var cipher = client.getCipher();
-            var authorized = client.authorized;
-            var authorizationError = client.authorizationError;
-            var cert = client.getPeerCertificate();
 
-            connection.set('hello', 'host', undefined);
-            connection.set('tls', 'enabled', true);
-            connection.set('tls', 'cipher', cipher);
-            connection.notes.tls = {
-                authorized: authorized,
-                authorizationError: authorizationError,
-                peerCertificate: cert,
-                cipher: cipher
-            };
-        }
+        if (!server.has_tls) return;
+
+        connection.set('hello', 'host', undefined);
+        connection.set('tls', 'enabled', true);
+        connection.set('tls', 'cipher', client.getCipher());
+        connection.notes.tls = {
+            authorized: client.authorized,
+            authorizationError: client.authorizationError,
+            peerCertificate: client.getPeerCertificate(),
+            cipher: client.getCipher(),
+        };
     };
 
     if (port !== '465') {

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -235,21 +235,15 @@ function createServer (cb) {
             cryptoSocket.removeAllListeners('data');
 
             if (!options) options = {};
-
             options.isServer = true;
 
             if (!options.secureContext) {
                 options.secureContext = _getSecureContext(options);
             }
 
-            if (options.enableOCSPStapling) {
-                if (ocsp) {
-                    options.server = pseudoServ;
-                    pseudoServ._sharedCreds = options.secureContext;
-                }
-                else {
-                    log.logerror("OCSP Stapling cannot be enabled because the ocsp module is not loaded");
-                }
+            if (options.enableOCSPStapling && ocsp) {
+                options.server = pseudoServ;
+                pseudoServ._sharedCreds = options.secureContext;
             }
 
             var cleartext = new tls.TLSSocket(cryptoSocket, options);

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -146,9 +146,6 @@ function pipe (cleartext, socket) {
     cleartext.socket = socket;
 
     function onerror (e) {
-        if (cleartext._controlReleased) {
-            cleartext.emit('error', e);
-        }
     }
 
     function onclose () {
@@ -256,16 +253,13 @@ function createServer (cb) {
 
             cleartext.on('secure', function () {
                 log.logdebug('TLS secured.');
-                var cert = cleartext.getPeerCertificate();
-                if (cleartext.getCipher) {
-                    var cipher = cleartext.getCipher();
-                }
                 socket.emit('secure');
                 if (cb2) cb2(cleartext.authorized,
-                    cleartext.authorizationError, cert, cipher);
+                    cleartext.authorizationError,
+                    cleartext.getPeerCertificate(),
+                    cleartext.getCipher()
+                    );
             });
-
-            // cleartext._controlReleased = true;
 
             socket.cleartext = cleartext;
 
@@ -328,7 +322,6 @@ function connect (port, host, cb) {
             );
         });
 
-        // cleartext._controlReleased = true;
         socket.cleartext = cleartext;
 
         if (socket._timeout) {


### PR DESCRIPTION
- server/tls upgrade: remove interim TLS vars
- only emit OCSP not loaded error at startup (vs every connection)
- remove unused _controlReleased