### PR TITLE
disable naïve comment stripping

### DIFF
--- a/mailheader.js
+++ b/mailheader.js
@@ -48,8 +48,8 @@ Header.prototype.parse = function (lines) {
     }
 
     // Now add decoded versions
-    Object.keys(this.headers).forEach(function (key2) {
-        self.headers[key2].forEach(function (val2) {
+    Object.keys(this.headers).forEach((key2) => {
+        self.headers[key2].forEach((val2) => {
             self._add_header_decode(key2, val2, 'push');
         })
     })
@@ -157,6 +157,7 @@ Header.prototype.decode_header = function decode_header (val) {
         cur_enc: '',
         cur_lang: '', // Secondary languages are ignored for our purposes
     };
+
     val = val.replace(/\n[ \t]+([^\n]*)/g, _decode_rfc2231(rfc2231_params));
     for (var key in rfc2231_params.keys) {
         val = val + ' ' + key + '="';

--- a/mailheader.js
+++ b/mailheader.js
@@ -172,7 +172,9 @@ Header.prototype.decode_header = function decode_header (val) {
 
     // remove end carriage return
     val = val.replace(/\r?\n$/, '');
-    val = val.replace(/\([^\)]*\)/, ''); // strip 822 comments in the most basic way - does not support nested comments
+
+    // strip 822 comments in the most basic way - does not support nested comments
+    // val = val.replace(/\([^\)]*\)/, '');
 
     if (Iconv && !/^[\x00-\x7f]*$/.test(val)) {
         // 8 bit values in the header

--- a/tests/mailheader.js
+++ b/tests/mailheader.js
@@ -10,6 +10,7 @@ var lines = [
     'From: Matt Sergeant <helpme@gmail.com>',
     'Content-Type: multipart/alternative;',
     '   boundary=Apple-Mail-F2C5DAD3-7EB3-409D-9FE0-135C9FD43B69',
+    'Content-Type2: multipart/mixed; boundary="nqp=nb64=()I9WT8XjoN"',
     'Content-Transfer-Encoding: 7bit',
     'Mime-Version: 1.0 (1.0)',
     'Subject: Re: Haraka Rocks!',
@@ -28,8 +29,20 @@ exports.basic = {
         test.expect(2);
         var h = new Header();
         h.parse(lines);
-        test.equal(h.lines().length, 11);
-        test.ok(/multipart\/alternative;\s+boundary=Apple-Mail-F2C5DAD3-7EB3-409D-9FE0-135C9FD43B69/.test(h.get_decoded('content-type')));
+        test.equal(h.lines().length, 12);
+        test.equal(
+            h.get_decoded('content-type'),
+            'multipart/alternative; boundary=Apple-Mail-F2C5DAD3-7EB3-409D-9FE0-135C9FD43B69'
+        );
+        test.done();
+    },
+    'content type w/parens': function (test) {
+        test.expect(2);
+        var h = new Header();
+        h.parse(lines);
+        test.equal(h.lines().length, 12);
+        var ct = h.get_decoded('content-type2');
+        test.equal(ct, 'multipart/mixed; boundary="nqp=nb64=()I9WT8XjoN"');
         test.done();
     }
 }
@@ -42,7 +55,7 @@ exports.add_headers = {
         h.add('Foo', 'bar');
         test.equal(h.lines()[0], 'Foo: bar\n');
         h.add_end('Fizz', 'buzz');
-        test.equal(h.lines()[12], 'Fizz: buzz\n');
+        test.equal(h.lines()[13], 'Fizz: buzz\n');
         test.done();
     },
     add_utf8: function (test) {


### PR DESCRIPTION
fixes #1874

- adds a test with parens in a header
- disables naïve comment stripping
    - at least until it can be implemented better (with a proper header parser)

Checklist:
- [x] tests updated
