### PR TITLE
handle case where OCSP server is unavailable

### DIFF
--- a/tls_socket.js
+++ b/tls_socket.js
@@ -174,6 +174,9 @@ if (ocsp) {
             if (err) {
                 return cb2(err);
             }
+            if (uri === null) {   // not working OCSP server
+                return cb2();
+            }
 
             var req = ocsp.request.generate(cert, issuer);
             var options = {


### PR DESCRIPTION
this likely fixes #1855

Changes proposed in this pull request:
- if we don't get a URI from ocsp.getOCSPURI, bail out
- see indutny/ocsp#10
