### PR TITLE
New plugin for the Virtual MTA management

### DIFF
--- a/docs/plugins/relay.md
+++ b/docs/plugins/relay.md
@@ -118,7 +118,7 @@ Example:
     [domains]
     test.com = { "action": "accept" }
 
-I think of *accept* as the equivalent of qmail's *rcpthosts*, or a misplaced Haraka `rcpt_to.*` plugin. The *accept* mechanism is another way to tell Haraka that a particular domain is one we accept mail for. The difference between this and and the [rcpt_to.in_host_list](http://haraka.github.io/manual/plugins/rcpt_to.in_host_list.html) plugin is that this one also enables relaying.
+I think of *accept* as the equivalent of qmail's *rcpthosts*, or a misplaced Haraka `rcpt_to.*` plugin. The *accept* mechanism is another way to tell Haraka that a particular domain is one we accept mail for. The difference between this and the [rcpt_to.in_host_list](http://haraka.github.io/manual/plugins/rcpt_to.in_host_list.html) plugin is that this one also enables relaying.
 
     * continue (mails are subject to further checks)
 

--- a/docs/plugins/virtual_mta.md
+++ b/docs/plugins/virtual_mta.md
@@ -1,23 +1,26 @@
 virtual_mta
 ========
 
-This plugin is made to work with Outbound HARAKA server. The use of 'virtual_mta'
+This plugin is made to work with 'Outbound HARAKA server'. The use of 'virtual_mta'
 plugin will gives you the ability and the full control to add and administer
 as many virtual MTAs and IP addresses as you need, allowing you to create enormous
-potential sending capacity. So you could send every email with specific/customized
-VMTA ('IP/HOST') just by adding the 'x-vmta' parameter to the mail 'header' when the
-value of this parameter should be predefined in the config file, e.g :
+potential sending capacity.
+
+You could send every email with specific/customized VMTA ('IP/HOST') just by
+assigning your emails to the appropriate VMTA by adding the `x-vmta` header to your
+emails (The value of `x-vmta` parameter should be pre-defined in the config file),
+e.g :
 
 
 Subject: xxxx
 From: xxxx
 ...
-x-vmta: mta_name_1       <<----------- You should add this line to your header
+x-vmta: mta_name_1       <<----------- Just add the param to your header
 ...
 
 
-The 'mta_name_1' in the previous example is one of the VMTA's you should define in
-the configuration file 'vmta.ini' with simple format as shown in the 'Configuration'
+The 'mta_name_1' in the previous example is one of the VMTAs you should pre-define in
+your configuration file `vmta.ini` with simple format as shown in the 'Configuration'
 section bellow.
 
 Configuration
@@ -40,6 +43,15 @@ host = HOST_2
 Usage
 -----
 To enable the **virtual_mta** plugin, add an entry (virtual_mta) to the `config/plugins`.
+
+
+Test
+----
+After enabling the plugin you could test it simply using the smtp transaction tester light-tool
+'swaks' using the following command line :
+
+swaks -f youremail@yourdomain.com -t test@example.com -add-header "x-vmta: your_vmta_name"  \
+  -s localhost -p 587 -au testuser -ap testpassword
 
 
 NOTE

--- a/docs/plugins/virtual_mta.md
+++ b/docs/plugins/virtual_mta.md
@@ -1,0 +1,51 @@
+virtual_mta
+========
+
+This plugin is made to work with Outbound HARAKA server. The use of 'virtual_mta'
+plugin will gives you the ability and the full control to add and administer
+as many virtual MTAs and IP addresses as you need, allowing you to create enormous
+potential sending capacity. So you could send every email with specific/customized
+VMTA ('IP/HOST') just by adding the 'x-vmta' parameter to the mail 'header' when the
+value of this parameter should be predefined in the config file, e.g :
+
+
+Subject: xxxx
+From: xxxx
+...
+x-vmta: mta_name_1       <<----------- You should add this line to your header
+...
+
+
+The 'mta_name_1' in the previous example is one of the VMTA's you should define in
+the configuration file 'vmta.ini' with simple format as shown in the 'Configuration'
+section bellow.
+
+Configuration
+-------------
+
+- First of all you should create the config file `config/vmta.ini`
+
+- In the config file you could simply add the virtual MTA information as the sample
+bellow shown, every VMTA has name and 'IP/HOST' :
+
+[mta_name_1]
+ip = IP_1
+host = HOST_1
+
+[mta_name_2]
+ip = IP_2
+host = HOST_2
+
+
+Usage
+-----
+To enable the **virtual_mta** plugin, add an entry (virtual_mta) to the `config/plugins`.
+
+
+NOTE
+----
+The passed parameter 'x-vmta' will be automatically removed from the header so the
+delivered email's header will not contain the parameter.
+
+
+

--- a/plugins/virtual_mta.js
+++ b/plugins/virtual_mta.js
@@ -1,0 +1,76 @@
+// virtual_mta
+//------------
+// documentation via: `haraka -h virtual_mta`
+
+var outbound	= require('./outbound');
+var constants   = require('haraka-constants');
+var config      = require('./config');
+var ip          = require("ip").address(); //Main ip of local server
+var host 	    = require('os').hostname().replace(/\\/, '\\057').replace(/:/, '\\072'); //Server hostname
+var vmta = null; 
+var cfg;
+
+exports.register = function () {
+    var plugin = this;
+
+    plugin.loginfo('VMTA configs are fully loaded.');
+    cfg = plugin.config.get('vmta.ini', function () {
+        // This closure will be run for each detected update of my_plugin.ini
+        // Re-run the outer function again
+        plugin.register();
+    });
+    plugin.loginfo('cfg=' + JSON.stringify(cfg));
+};
+
+exports.hook_queue_outbound = function (next, connection) {
+    var plugin      = this;
+    var transaction = connection.transaction;
+
+    plugin.loginfo("");
+    plugin.loginfo("----------- virtual_mta plugin LOG START -----------");
+
+    if( transaction.header.headers.hasOwnProperty('x-vmta') )
+    {
+        //Get 'x-vmta' from the header
+        vmta = transaction.header.headers['x-vmta'][0].replace("\n", "");
+
+        //Check if The specified VMTA is defined in the config file
+        if( cfg.hasOwnProperty(vmta) ){
+            //Get 'vmta' parameter from the config file
+            connection.transaction.notes.outbound_ip   = cfg[vmta].ip;
+            connection.transaction.notes.outbound_helo = cfg[vmta].host;
+
+            //Remove parameter from the header
+            transaction.remove_header('x-vmta');
+
+            plugin.loginfo("'x-vmta' Found : "+vmta);
+        }else{
+            plugin.logerror("The specified Virtual VMTA '"+vmta+"' does not exist.");
+            return next(DENY, "The specified Virtual VMTA '"+vmta+"' does not exist.");
+        }
+    }else{
+        connection.transaction.notes.outbound_ip   = ip;
+        connection.transaction.notes.outbound_helo = host;
+
+        plugin.loginfo("No 'x-vmta' Found.");
+    }
+
+    plugin.loginfo("Outbound IP : "+connection.transaction.notes.outbound_ip);
+    plugin.loginfo("Outbound HOST : "+connection.transaction.notes.outbound_helo);
+
+    outbound.send_email(connection.transaction, function(retval, msg) {
+        switch(retval) {
+            case constants.ok:
+                return next(OK, msg);
+                break;
+            case constants.deny:
+                return next(DENY, msg);
+                break;
+            default:
+                return next(DENYSOFT, msg);
+        }
+    });
+
+    plugin.loginfo("----------- virtual_mta plugin LOG END -----------");
+    plugin.loginfo("");
+};

--- a/plugins/virtual_mta.js
+++ b/plugins/virtual_mta.js
@@ -4,7 +4,6 @@
 
 var outbound	= require('./outbound');
 var constants   = require('haraka-constants');
-var config      = require('./config');
 var ip          = require('ip').address(); //Main ip of local server
 var host 	    = require('os').hostname().replace(/\\/, '\\057').replace(/:/, '\\072'); //Server hostname
 var vmta        = null;

--- a/plugins/virtual_mta.js
+++ b/plugins/virtual_mta.js
@@ -57,18 +57,7 @@ exports.hook_queue_outbound = function (next, connection) {
     plugin.loginfo("Outbound IP : "+connection.transaction.notes.outbound_ip);
     plugin.loginfo("Outbound HOST : "+connection.transaction.notes.outbound_helo);
 
-    outbound.send_email(connection.transaction, function (retval, msg) {
-        switch (retval) {
-            case constants.ok:
-                return next(OK, msg);
-                break;
-            case constants.deny:
-                return next(DENY, msg);
-                break;
-            default:
-                return next(DENYSOFT, msg);
-        }
-    });
+    outbound.send_email(connection.transaction, next);
 
     plugin.loginfo("----------- virtual_mta plugin LOG END -----------");
     plugin.loginfo("");

--- a/plugins/virtual_mta.js
+++ b/plugins/virtual_mta.js
@@ -29,13 +29,13 @@ exports.hook_queue_outbound = function (next, connection) {
     plugin.loginfo("");
     plugin.loginfo("----------- virtual_mta plugin LOG START -----------");
 
-    if( transaction.header.headers.hasOwnProperty("x-vmta") )
+    if ( transaction.header.headers.hasOwnProperty("x-vmta") )
     {
         //Get 'x-vmta' from the header
         vmta = transaction.header.headers["x-vmta"][0].replace("\n", "");
 
         //Check if The specified VMTA is defined in the config file
-        if( cfg.hasOwnProperty(vmta) ){
+        if ( cfg.hasOwnProperty(vmta) ){
             //Get 'vmta' parameter from the config file
             connection.transaction.notes.outbound_ip   = cfg[vmta].ip;
             connection.transaction.notes.outbound_helo = cfg[vmta].host;
@@ -44,11 +44,11 @@ exports.hook_queue_outbound = function (next, connection) {
             transaction.remove_header("x-vmta");
 
             plugin.loginfo("'x-vmta' Found '"+vmta+"'");
-        }else{
+        } else {
             plugin.logerror("The specified Virtual VMTA '"+vmta+"' does not exist.");
             return next(DENY, "The specified Virtual VMTA '"+vmta+"' does not exist.");
         }
-    }else{
+    } else {
         connection.transaction.notes.outbound_ip   = ip;
         connection.transaction.notes.outbound_helo = host;
 
@@ -58,8 +58,8 @@ exports.hook_queue_outbound = function (next, connection) {
     plugin.loginfo("Outbound IP : "+connection.transaction.notes.outbound_ip);
     plugin.loginfo("Outbound HOST : "+connection.transaction.notes.outbound_helo);
 
-    outbound.send_email(connection.transaction, function(retval, msg) {
-        switch(retval) {
+    outbound.send_email(connection.transaction, function (retval, msg) {
+        switch (retval) {
             case constants.ok:
                 return next(OK, msg);
                 break;

--- a/plugins/virtual_mta.js
+++ b/plugins/virtual_mta.js
@@ -5,21 +5,21 @@
 var outbound	= require('./outbound');
 var constants   = require('haraka-constants');
 var config      = require('./config');
-var ip          = require("ip").address(); //Main ip of local server
+var ip          = require('ip').address(); //Main ip of local server
 var host 	    = require('os').hostname().replace(/\\/, '\\057').replace(/:/, '\\072'); //Server hostname
-var vmta = null; 
+var vmta        = null;
 var cfg;
 
 exports.register = function () {
     var plugin = this;
 
-    plugin.loginfo('VMTA configs are fully loaded.');
-    cfg = plugin.config.get('vmta.ini', function () {
+    plugin.loginfo("VMTA configs are fully loaded from 'vmta.ini'.");
+    cfg = plugin.config.get("vmta.ini", function () {
         // This closure will be run for each detected update of my_plugin.ini
         // Re-run the outer function again
         plugin.register();
     });
-    plugin.loginfo('cfg=' + JSON.stringify(cfg));
+    plugin.loginfo(cfg);
 };
 
 exports.hook_queue_outbound = function (next, connection) {
@@ -29,10 +29,10 @@ exports.hook_queue_outbound = function (next, connection) {
     plugin.loginfo("");
     plugin.loginfo("----------- virtual_mta plugin LOG START -----------");
 
-    if( transaction.header.headers.hasOwnProperty('x-vmta') )
+    if( transaction.header.headers.hasOwnProperty("x-vmta") )
     {
         //Get 'x-vmta' from the header
-        vmta = transaction.header.headers['x-vmta'][0].replace("\n", "");
+        vmta = transaction.header.headers["x-vmta"][0].replace("\n", "");
 
         //Check if The specified VMTA is defined in the config file
         if( cfg.hasOwnProperty(vmta) ){
@@ -41,9 +41,9 @@ exports.hook_queue_outbound = function (next, connection) {
             connection.transaction.notes.outbound_helo = cfg[vmta].host;
 
             //Remove parameter from the header
-            transaction.remove_header('x-vmta');
+            transaction.remove_header("x-vmta");
 
-            plugin.loginfo("'x-vmta' Found : "+vmta);
+            plugin.loginfo("'x-vmta' Found '"+vmta+"'");
         }else{
             plugin.logerror("The specified Virtual VMTA '"+vmta+"' does not exist.");
             return next(DENY, "The specified Virtual VMTA '"+vmta+"' does not exist.");


### PR DESCRIPTION
An additional plugin that  will gives the users the ability to add and administer as many virtual MTAs and IP addresses as they need, allowing them to create enormous potential sending capacity. The plugin is so simple based on the VMTA entries defined in the config file 'vmta.ini'.
