### PR TITLE
1861 binary log

### DIFF
--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -232,7 +232,9 @@ exports.hook_data_post = function (next, connection) {
 
         var result = '';
         socket.on('line', function (line) {
-            connection.logprotocol(plugin, 'C:' + line.split('').filter(function(x) { var n = x.charCodeAt(0); return 31 < n && 127 > n  }).join('') );
+            connection.logprotocol(plugin, 'C:' + line.split('').filter((x) => {
+                return 31 < x.charCodeAt(0) && 127 > x.charCodeAt(0)
+            }).join('') );
             result = line.replace(/\r?\n/, '');
         });
 

--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -232,7 +232,7 @@ exports.hook_data_post = function (next, connection) {
 
         var result = '';
         socket.on('line', function (line) {
-            connection.logprotocol(plugin, 'C:' + line);
+            connection.logprotocol(plugin, 'C:' + line.replace(/\x00/,''));
             result = line.replace(/\r?\n/, '');
         });
 

--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -232,7 +232,7 @@ exports.hook_data_post = function (next, connection) {
 
         var result = '';
         socket.on('line', function (line) {
-            connection.logprotocol(plugin, 'C:' + line.replace(/\x00/,''));
+            connection.logprotocol(plugin, 'C:' + line.split('').filter(function(x) { var n = x.charCodeAt(0); return 31 < n && 127 > n  }).join('') );
             result = line.replace(/\r?\n/, '');
         });
 


### PR DESCRIPTION
don't emit binary characters into the logs.

- I intend to self merge and close this issue, unless someone has a good reason why binary data in the log files is actually useful.
- I'm also going to address the original issue at the other end, and tell grep to always assume the log file is ascii (`grep --text`). 
    - done. [haraka/haraka-plugin-log-reader#11]

closes #1861 