### PR TITLE
Run dumped logs through plugins not console

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -56,13 +56,7 @@ logger.colorize = function (color, str) {
 logger.dump_logs = function (cb) {
     while (logger.deferred_logs.length > 0) {
         var log_item = logger.deferred_logs.shift();
-        var color = logger.colors[log_item.level];
-        if (color && stdout_is_tty) {
-            console.log(logger.colorize(color, log_item.data));
-        }
-        else {
-            console.log(log_item.data);
-        }
+        plugins.run_hooks('log', logger, log_item);
     }
     // Run callback after flush
     if (cb) process.stdout.write('', cb);

--- a/outbound/config.js
+++ b/outbound/config.js
@@ -15,8 +15,6 @@ function load_config () {
     }, function () {
         load_config();
     }).main;
-    
-    console.log(config.get('outbound.ini'));
 
     // legacy config file support. Remove in Haraka 4.0
     if (!cfg.disabled && config.get('outbound.disabled')) {


### PR DESCRIPTION
Fixes #1914 

Changes proposed in this pull request:
- In dump_logs() run that dumping through plugins

Checklist:
- [ ] docs updated
- [ ] tests updated
