### PR TITLE
Allow "Unknown Result" and Socket Error to Try Next Host

### DIFF
--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -213,7 +213,7 @@ exports.hook_data_post = function (next, connection) {
                        'Connection to ' + host + ' failed: ' + err.message);
                 return try_next_host();
             }
-            
+
             // If an error occurred after connection and there are other hosts left to try,
             // then try those before returning DENYSOFT.
             if (hosts.length) {
@@ -295,14 +295,14 @@ exports.hook_data_post = function (next, connection) {
                 // Continue as StreamMaxLength default is 25Mb
                 return next();
             }
-            
-            // The current host returned an unknown result.  If other hosts are available, 
+
+            // The current host returned an unknown result.  If other hosts are available,
             // then try those before returning a DENYSOFT.
             if (hosts.length) {
                 connection.logwarn(plugin, 'unknown result: "' + result + '" from host ' + host);
                 socket.destroy();
                 return try_next_host();
-            }          
+            }
             txn.results.add(plugin, { err: 'unknown result: "' + result + '" from host ' + host });
             if (!plugin.cfg.reject.error) return next();
             return next(DENYSOFT, 'Error running virus scanner');

--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -213,8 +213,14 @@ exports.hook_data_post = function (next, connection) {
                        'Connection to ' + host + ' failed: ' + err.message);
                 return try_next_host();
             }
-
-            if (txn) txn.results.add(plugin, {err: err });
+            
+            // If an error occurred after connection and there are other hosts left to try,
+            // then try those before returning DENYSOFT.
+            if (hosts.length) {
+                connection.logwarn(plugin, 'error on host ' + host + ': ' + err.message);
+                return try_next_host();
+            }
+            if (txn) txn.results.add(plugin, {err: 'error on host ' + host + ': ' + err.message });
             if (!plugin.cfg.reject.error) return next();
             return next(DENYSOFT, 'Virus scanner error');
         });
@@ -289,8 +295,15 @@ exports.hook_data_post = function (next, connection) {
                 // Continue as StreamMaxLength default is 25Mb
                 return next();
             }
-
-            txn.results.add(plugin, { err: 'unknown result: ' + result });
+            
+            // The current host returned an unknown result.  If other hosts are available, 
+            // then try those before returning a DENYSOFT.
+            if (hosts.length) {
+                connection.logwarn(plugin, 'unknown result: "' + result + '" from host ' + host);
+                socket.destroy();
+                return try_next_host();
+            }          
+            txn.results.add(plugin, { err: 'unknown result: "' + result + '" from host ' + host });
             if (!plugin.cfg.reject.error) return next();
             return next(DENYSOFT, 'Error running virus scanner');
         });


### PR DESCRIPTION
Fixes #1924

Changes proposed in this pull request:
- If multiple hosts are listed for clamd and an "unknown result" is returned or a socket error occurs after connection, then attempt to try remaining hosts before returning DENYSOFT.

