### PR TITLE
Fixes loading outbound under cluster.

### DIFF
--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -20,14 +20,19 @@ var DSN         = require('../dsn');
 
 var client_pool = require('./client_pool');
 var _qfile      = require('./qfile');
-var queuelib    = require('./queue');
 var mx_lookup   = require('./mx_lookup');
 var outbound    = require('./index');
 var obtls       = require('./tls');
 
-var queue_dir = queuelib.queue_dir;
-var temp_fail_queue = queuelib.temp_fail_queue;
-var delivery_queue = queuelib.delivery_queue;
+var queue_dir;
+var temp_fail_queue;
+var delivery_queue;
+setImmediate(function () {
+    var queuelib    = require('./queue');
+    queue_dir = queuelib.queue_dir;
+    temp_fail_queue = queuelib.temp_fail_queue;
+    delivery_queue = queuelib.delivery_queue;
+});
 
 var mx = require('./mx_lookup');
 var _qfile = require('./qfile');
@@ -63,7 +68,6 @@ class HMailItem extends events.EventEmitter {
 }
 
 module.exports = HMailItem;
-
 
 logger.add_log_methods(HMailItem.prototype, "outbound");
 

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -18,10 +18,10 @@ var DSN         = require('../dsn');
 var FsyncWriteStream = require('./fsync_writestream');
 var server      = require('../server');
 
-var HMailItem   = require('./hmail');
-var TODOItem    = require('./todo');
 var cfg         = require('./config');
 var queuelib    = require('./queue');
+var HMailItem   = require('./hmail');
+var TODOItem    = require('./todo');
 var pools       = require('./client_pool');
 
 var queue_dir = queuelib.queue_dir;

--- a/outbound/queue.js
+++ b/outbound/queue.js
@@ -52,7 +52,7 @@ exports.get_stats = function () {
 };
 
 exports.list_queue = function (cb) {
-    this._load_cur_queue(null, "_list_file", cb);
+    exports._load_cur_queue(null, "_list_file", cb);
 };
 
 exports._stat_file = function (file, cb) {
@@ -61,8 +61,8 @@ exports._stat_file = function (file, cb) {
 };
 
 exports.stat_queue = function (cb) {
-    var self = this;
-    this._load_cur_queue(null, "_stat_file", function (err) {
+    var self = exports;
+    exports._load_cur_queue(null, "_stat_file", function (err) {
         if (err) return cb(err);
         return cb(null, self.stats());
     });
@@ -72,12 +72,12 @@ exports.load_queue = function (pid) {
     // Initialise and load queue
     // This function is called first when not running under cluster,
     // so we create the queue directory if it doesn't already exist.
-    this.ensure_queue_dir();
-    this._load_cur_queue(pid, "_add_file");
+    exports.ensure_queue_dir();
+    exports._load_cur_queue(pid, "_add_file");
 };
 
 exports._load_cur_queue = function (pid, cb_name, cb) {
-    var self = this;
+    var self = exports;
     logger.loginfo("[outbound] Loading outbound queue from ", queue_dir);
     fs.readdir(queue_dir, function (err, files) {
         if (err) {
@@ -92,7 +92,7 @@ exports._load_cur_queue = function (pid, cb_name, cb) {
 };
 
 exports.load_queue_files = function (pid, cb_name, files, callback) {
-    var self = this;
+    var self = exports;
     if (files.length === 0) return;
 
     if (cfg.disabled && cb_name === '_add_file') {
@@ -267,7 +267,7 @@ exports.flush_queue = function (domain, pid) {
 
 exports.load_pid_queue = function (pid) {
     logger.loginfo("[outbound] Loading queue for pid: " + pid);
-    this.load_queue(pid);
+    exports.load_queue(pid);
 };
 
 exports.ensure_queue_dir = function () {
@@ -288,11 +288,11 @@ exports.ensure_queue_dir = function () {
 };
 
 exports._add_file = function (hmail) {
-    if (hmail.next_process < this.cur_time) {
+    if (hmail.next_process < exports.cur_time) {
         delivery_queue.push(hmail);
     }
     else {
-        temp_fail_queue.add(hmail.next_process - this.cur_time, function () {
+        temp_fail_queue.add(hmail.next_process - exports.cur_time, function () {
             delivery_queue.push(hmail);
         });
     }
@@ -301,7 +301,7 @@ exports._add_file = function (hmail) {
 exports.scan_queue_pids = function (cb) {
     // Under cluster, this is called first by the master so
     // we create the queue directory if it doesn't exist.
-    this.ensure_queue_dir();
+    exports.ensure_queue_dir();
 
     fs.readdir(queue_dir, function (err, files) {
         if (err) {


### PR DESCRIPTION
I don't really understand why this stuff broke.

It seems to be a bug in node's require() caching, frankly.

When loading modules they would return {} before actually
being loaded. This appears to be due to recursive requires.

This might fix #1933

Please test

Fixes #1933 - maybe

Changes proposed in this pull request:
- 
- 
- 

Checklist:
- [ ] docs updated
- [ ] tests updated
