### PR TITLE
Use the  sunset keyword in version specific code blocks

### DIFF
--- a/server.js
+++ b/server.js
@@ -233,7 +233,8 @@ Server.receiveAsMaster = function (command, params) {
 }
 
 function messageHandler (worker, msg, handle) {
-    if (arguments.length === 2) { // Node < v6
+    // sunset Haraka v3 (Node < 6)
+    if (arguments.length === 2) {
         handle = msg;
         msg = worker;
         worker = undefined;


### PR DESCRIPTION
Because `sunset` is the keyword we'll grep for (if we follow our instructions) when doing a semver major release.
