### PR TITLE
Load logger in a setImmediate call

### DIFF
--- a/configfile.js
+++ b/configfile.js
@@ -6,6 +6,9 @@ var path = require('path');
 var yaml = require('js-yaml');
 
 var logger = getStubLogger();
+setImmediate(function () {
+    logger = require('./logger');
+});
 
 // for "ini" type files
 var regex = exports.regex = {
@@ -624,4 +627,3 @@ cfreader.load_binary_config = function (name, type) {
         }
     }
 };
-logger = require('./logger');


### PR DESCRIPTION
Fixes #1839 

Changes proposed in this pull request:
- Load logger in a setImmedate call to resolve circular deps issues

Hopefully this is a simpler fix than the one in #1839.

Checklist:
- [ ] docs updated
- [ ] tests updated
