### PR TITLE
Fix undefined FsyncWriteStream var

### DIFF
--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -17,13 +17,14 @@ var config      = require('../config');
 var plugins     = require('../plugins');
 var Header      = require('../mailheader').Header;
 var DSN         = require('../dsn');
-var FsyncWriteStream = require('./fsync_writestream');
 
 var client_pool = require('./client_pool');
 var _qfile      = require('./qfile');
 var mx_lookup   = require('./mx_lookup');
 var outbound    = require('./index');
 var obtls       = require('./tls');
+
+var FsyncWriteStream = require('./fsync_writestream');
 
 var queue_dir;
 var temp_fail_queue;

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -17,6 +17,7 @@ var config      = require('../config');
 var plugins     = require('../plugins');
 var Header      = require('../mailheader').Header;
 var DSN         = require('../dsn');
+var FsyncWriteStream = require('./fsync_writestream');
 
 var client_pool = require('./client_pool');
 var _qfile      = require('./qfile');


### PR DESCRIPTION
This is the obvious fix to using an undefined var FsyncWriteStream in `split_to_new_recipients`.  If you'd prefer some other refactoring fix, then let me know.
