### PR TITLE
require node LTS version (6+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,15 @@ node_js:
 #   - "0.8"     # no longer supported by iconv
 #   - "0.10"    # no longer maintained by node.js (2016-10-31)
 #   - "0.12"    # no longer maintained by node.js (2016-12-31)
-    - "4"
+#   - "4"       # LTS ended 2017-04-01 (crit maint only)
 #   - "5"       # no longer maintained by node.js (see node 7)
-    - "6"
+    - "6"       # LTS until 2018-04
+    - "7"
 
 services:
     - redis-server
     
-# these are required for building on node.js v4
+# these are required for building on node.js v4+
 addons:
   apt:
     sources:
@@ -20,7 +21,7 @@ addons:
       - g++-4.8
 env:
   - "CXX=g++-4.8"
-# end: these are required for building on node.js v4
+# end: these are required for building on node.js v4+
 
 before_script:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  nodejs_version: "4"
+  nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,7 @@ environment:
 
 # Install scripts. (runs after repo cloning)
 install:
-  # Get the latest stable version of Node.js
-# - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version
   - npm install
   - choco install redis-64
   - redis-server --service-install

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "haraka.js",
   "engines": {
-    "node": ">= v4.7.3"
+    "node": ">= v6.10.0"
   },
   "dependencies": {
     "address-rfc2821"       : "*",


### PR DESCRIPTION
Changes proposed in this pull request:
- drop node.js v4 support
- add node.js v6 testing
- add node.js v7 testing
