### PR TITLE
RabbitMQ: fix encoding of user and password when creating connection

### DIFF
--- a/plugins/queue/rabbitmq_amqplib.js
+++ b/plugins/queue/rabbitmq_amqplib.js
@@ -40,7 +40,7 @@ exports.init_amqp_connection = function () {
     var autoDelete = cfg.autoDelete === "true" || false;
     deliveryMode = cfg.deliveryMode || 2;
 
-    amqp.connect("amqp://"+user+":"+password+"@"+host+":"+port+vhost, function (err, conn){
+    amqp.connect("amqp://"+encodeURIComponent(user)+":"+encodeURIComponent(password)+"@"+host+":"+port+vhost, function (err, conn){
         if (err) {
             plugin.logerror("Connection to rabbitmq failed: " + err);
             return;


### PR DESCRIPTION
When connecting to RabbitMQ with username or password
containing special characters connection was refused.

Changes proposed in this pull request:
- wrap `username` and `password` in connection string with `encodeURIComponent()`
