### PR TITLE
Support the new address-rfc2822

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "address-rfc2821"       : "^1.1.1",
-    "address-rfc2822"       : "*",
+    "address-rfc2822"       : "^2.0.0",
     "async"                 : "~2.4.0",
     "daemon"                : "~1.1.0",
     "generic-pool"          : "~2.5.0",

--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -309,7 +309,7 @@ exports.get_sender_domain = function (txn) {
     if (!addrs || ! addrs.length) { return domain; }
 
     // If From has a single address, we're done
-    if (addrs.length === 1) {
+    if (addrs.length === 1 && addrs[0].host) {
         var fromHost = addrs[0].host();
         if (fromHost) {
             // don't attempt to lower a null or undefined value #1575

--- a/tests/plugins/dkim_sign.js
+++ b/tests/plugins/dkim_sign.js
@@ -85,7 +85,7 @@ exports.get_sender_domain = {
     },
     'from header, RFC 5322 odd': function (test) {
         test.expect(1);
-        this.connection.transaction.header.add('From', 'Pete(A nice \) chap) <pete(his account)@silly.test(his host)>');
+        this.connection.transaction.header.add('From', 'Pete(A nice \\) chap) <pete(his account)@silly.test(his host)>');
         var r = this.plugin.get_sender_domain(this.connection.transaction);
         test.equal('silly.test', r);
         test.done();


### PR DESCRIPTION
New module supports Groups, which have no host method

Fixes #1969

