### PR TITLE
remove logging line

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -80,7 +80,6 @@ Plugin.prototype._get_plugin_path = function () {
     plugin.hasPackageJson = false;
     var name = plugin.name;
     if (/^haraka\-plugin\-/.test(name)) {
-        logger.lognotice("the haraka-plugin- prefix is not required in config/plugins");
         name = name.replace(/^haraka\-plugin\-/, '');
     }
 


### PR DESCRIPTION
the prefix is not required in config/plugins as the message states, but it is required for an NPM packaged plugin that requires another NPM packaged plugin. It is then spurious.