### PR TITLE
doc: add note that smtp_forward only supports STARTTLS

### DIFF
--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -52,7 +52,10 @@ Configuration
     from the tls plugin. If key and cert are provided in the the outbound section of the tls plugin,
     that certificate will be used as a TLS Client Certificate.
 
-  * auth\_type=[plain|login]
+    This option controls the use of TLS via `STARTTLS`. This plugin does not work with
+    SMTP over TLS.
+
+  * auth\_type=[plain\|login]
 
     Enable PLAIN or LOGIN SMTP AUTH.  This is required to enable AUTH.
 


### PR DESCRIPTION
Checklist:
- [X] docs updated
- [ ] tests updated
