### PR TITLE
Update qmail-queue.js

### DIFF
--- a/plugins/queue/qmail-queue.js
+++ b/plugins/queue/qmail-queue.js
@@ -51,7 +51,7 @@ exports.hook_queue = function (next, connection) {
 
     qmail_queue.on('exit', finished);
 
-    connection.transaction.message_stream.pipe(qmail_queue.stdin);
+    connection.transaction.message_stream.pipe(qmail_queue.stdin, { line_endings: '\n' });
 
     qmail_queue.stdin.on('close', function () {
         if (!connection.transaction) {


### PR DESCRIPTION
qmail-queue binary Adds a Received: header with bare LF. Haraka sets CRLF by default resulting in mixed line endings which break header processing in some e-mail clients.
messagestream can convert CRLF to LF on the fly when calling qmail-send.

Fixes #

Changes proposed in this pull request:
- 
- 
- 

Checklist:
- [ ] docs updated
- [ ] tests updated
