### PR TITLE
Fix auth plugin failure when re-selecting auth method

### DIFF
--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -167,6 +167,8 @@ exports.select_auth_method = function (next, connection, method) {
         return next();
     }
 
+    if (connection.notes.authenticating) return next(DENYDISCONNECT, 'bad protocol');
+
     connection.notes.authenticating = true;
     connection.notes.auth_method = method;
 


### PR DESCRIPTION
When sending the following sequence of commands, the auth plugin fails
since it tries to decode an undefined value as base64:

    AUTH LOGIN Z2lyaXNo
    334 UGFzc3dvcmQ6
    AUTH LOGIN
    500 Unrecognized command # at this point plugin has failed

Fixes #1999

Fixes #

Changes proposed in this pull request:
- 
- 
- 

Checklist:
- [ ] docs updated
- [x] tests updated
