### PR TITLE
use WRITE_EXCL from haraka-constants

### DIFF
--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -1275,7 +1275,7 @@ function split_to_new_recipients (hmail, recipients, response, cb) {
     }
     var fname = _qfile.name();
     var tmp_path = path.join(queue_dir, _qfile.platformDOT + fname);
-    var ws = new FsyncWriteStream(tmp_path, { flags: WRITE_EXCL });
+    var ws = new FsyncWriteStream(tmp_path, { flags: constants.WRITE_EXCL });
     var err_handler = function (err, location) {
         logger.logerror("[outbound] Error while splitting to new recipients (" + location + "): " + err);
         hmail.todo.rcpt_to.forEach(function (rcpt) {

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -29,9 +29,6 @@ var queue_dir = queuelib.queue_dir;
 var temp_fail_queue = queuelib.temp_fail_queue;
 var delivery_queue = queuelib.delivery_queue;
 
-var core_consts = require('constants');
-var WRITE_EXCL  = core_consts.O_CREAT | core_consts.O_TRUNC | core_consts.O_WRONLY | core_consts.O_EXCL;
-
 exports.net_utils = net_utils;
 exports.config    = config;
 
@@ -279,7 +276,7 @@ exports.process_delivery = function (ok_paths, todo, hmails, cb) {
     logger.loginfo("[outbound] Processing domain: " + todo.domain);
     var fname = _qfile.name();
     var tmp_path = path.join(queue_dir, _qfile.platformDOT + fname);
-    var ws = new FsyncWriteStream(tmp_path, { flags: WRITE_EXCL });
+    var ws = new FsyncWriteStream(tmp_path, { flags: constants.WRITE_EXCL });
     ws.on('close', function () {
         var dest_path = path.join(queue_dir, fname);
         fs.rename(tmp_path, dest_path, function (err) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "semver"                : "~5.3.0",
     "sprintf-js"            : "~1.1.0",
     "haraka-tld"            : "*",
-    "haraka-constants"      : "*",
+    "haraka-constants"      : ">=1.0.4",
     "haraka-net-utils"      : ">=1.0.8",
     "haraka-results"        : "^2.0.0",
     "haraka-utils"          : "*",


### PR DESCRIPTION
Fixes #2008 

Changes proposed in this pull request:
- in `outbound/*`, drop import of `constants` from node
- in favor of declaring WRITE_EXCL in `haraka-constants`
- An alternative solution to #2009 
    - Closes #2009 
    - Fixes #2008
- [x] Depends on haraka/haraka-constants#6

Checklist:
- [ ] docs updated
- [x] tests updated