### PR TITLE
build_todo() is part of the outbound/index.js api

### DIFF
--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -1267,7 +1267,6 @@ HMailItem.prototype.delivered_respond = function (retval, msg) {
 };
 
 function split_to_new_recipients (hmail, recipients, response, cb) {
-    var self = this;
     if (recipients.length === hmail.todo.rcpt_to.length) {
         // Split to new for no reason - increase refcount and return self
         hmail.refcount++;
@@ -1327,6 +1326,5 @@ function split_to_new_recipients (hmail, recipients, response, cb) {
 
     var new_todo = JSON.parse(JSON.stringify(hmail.todo));
     new_todo.rcpt_to = recipients;
-    self.build_todo(new_todo, ws, write_more);
-};
-
+    outbound.build_todo(new_todo, ws, write_more);
+}


### PR DESCRIPTION
Fixes a crash when handling an email for a non-existing user. This came up after getting over the first crash related to this case: https://github.com/haraka/Haraka/pull/2011

Not entirely sure if this is the correct fix, as it was not clear to me what the "todo" item would be.