### PR TITLE
disable graceful for SIGTERM

### DIFF
--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -334,7 +334,7 @@ folder of the same name that will not take preference, so avoid using names
 similar to core modules.
 
 Plugins loaded as modules do not have the special `require()`. To load
-a core Haraka module you must use `this.haraka_require('name')`. 
+a core Haraka module you must use `this.haraka_require('name')`.
 This should also be preferred for plain JS plugins, as the
 `./` hack is likely to be removed in the future.
 
@@ -347,10 +347,10 @@ Module plugins support default config in their local `config` directory. See the
 
 ## Shutdown
 
-On shutdown and graceful reload, Haraka will call a plugin's `shutdown` method.
+On graceful reload, Haraka will call a plugin's `shutdown` method.
 
 This is so you can clear any timers or intervals, or shut down any connections
-to remote servers.
+to remote servers. See [Issue 2024](https://github.com/haraka/Haraka/issues/2024).
 
 e.g.
 

--- a/haraka.js
+++ b/haraka.js
@@ -42,7 +42,7 @@ process.on('uncaughtException', function (err) {
 });
 
 var shutting_down = false;
-['SIGTERM', 'SIGINT'].forEach(function (sig) {
+['SIGINT'].forEach(function (sig) {
     process.on(sig, function () {
         if (shutting_down) return process.exit(1);
         shutting_down = true;


### PR DESCRIPTION
An alternative to #2025. Per @baudehlo suggestion in #2024, this just disables graceful for SIGTERM. That way a `kill $PID` does what admins expect (kill it!) and a `kill -s INT` will do a graceful shutdown.

Fixes #2025 revert additions of graceful code
Fixes #2024 Remove or rework graceful shutdown code

Changes proposed in this pull request:
- add comment referencing #2024
- disable graceful shutdown for SIGTERM.

Checklist:
- [x] docs updated
