### PR TITLE
Fix crash when 'AUTH LOGIN' is sent after a successful auth

### DIFF
--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -129,9 +129,6 @@ exports.check_user = function (next, connection, credentials, method) {
             fail: plugin.name + '/' + method,
         });
 
-        connection.notes.auth_login_userlogin = null;
-        connection.notes.auth_login_asked_login = false;
-
         var delay = Math.pow(2, connection.notes.auth_fails - 1);
         if (plugin.timeout && delay >= plugin.timeout) {
             delay = plugin.timeout - 1;
@@ -231,6 +228,10 @@ exports.auth_login = function (next, connection, params) {
             connection.notes.auth_login_userlogin,
             utils.unbase64(params[0])
         ];
+
+        connection.notes.auth_login_userlogin = null;
+        connection.notes.auth_login_asked_login = false;
+
         return plugin.check_user(next, connection, credentials,
             AUTH_METHOD_LOGIN);
     }

--- a/tests/plugins/auth/auth_base.js
+++ b/tests/plugins/auth/auth_base.js
@@ -319,6 +319,39 @@ exports.auth_login = {
         var params = ['AUTH','LOGIN', utils.base64('test')];
         this.connection.notes.allowed_auth_methods = ['PLAIN','LOGIN'];
         this.plugin.hook_unrecognized_command(next, this.connection, params);
+    },
+
+
+    'AUTH LOGIN, reauthentication': function (test) {
+        test.expect(9);
+
+        var next3 = function (code) {
+            test.equal(code, OK);
+
+            test.done();
+        };
+
+        var next2 = function (code) {
+            test.equal(code, OK);
+            test.equal(this.connection.relaying, true);
+            test.equal(this.connection.notes.auth_login_userlogin, null);
+            test.equal(this.connection.notes.auth_login_asked_login , false);
+
+            this.plugin.hook_unrecognized_command(next3, this.connection, ['AUTH','LOGIN']);
+        }.bind(this);
+
+        var next = function (code) {
+            test.equal(code, OK);
+            test.equal(this.connection.relaying, false);
+            test.equal(this.connection.notes.auth_login_userlogin, 'test');
+            test.equal(this.connection.notes.auth_login_asked_login , true);
+
+            this.plugin.hook_unrecognized_command(next2, this.connection, [utils.base64('testpass')]);
+        }.bind(this);
+
+        var params = ['AUTH','LOGIN', utils.base64('test')];
+        this.connection.notes.allowed_auth_methods = ['PLAIN','LOGIN'];
+        this.plugin.hook_unrecognized_command(next, this.connection, params);
     }
 };
 


### PR DESCRIPTION
A successful login leaves the connection.notes.auth_login_*
properties set. When an AUTH LOGIN command is sent again, the state
of those variables confuses the code.

The fix is to reset the state variables after an AUTH LOGIN flow.

Fixes #2038

Checklist:
- [ ] docs updated
- [X] tests updated
