### PR TITLE
support INFO *and* LOGINFO as config settings

### DIFF
--- a/config/log.ini
+++ b/config/log.ini
@@ -1,7 +1,7 @@
 [main]
 
 ; level=data, protocol, debug, info, notice, warn, error, crit, alert, emerg
-level=protocol
+level=info
 
 ; prepend timestamps to log entries? This setting does NOT affect logs emitted
 ; by logging plugins (like syslog).

--- a/logger.js
+++ b/logger.js
@@ -27,7 +27,7 @@ logger.levels = {
 };
 
 for (var le in logger.levels) {
-    logger.levels[`LOG${le}`] = le;
+    logger.levels[`LOG${le}`] = logger.levels[le];
     logger['LOG' + le] = logger.levels[le];
 }
 

--- a/logger.js
+++ b/logger.js
@@ -27,6 +27,7 @@ logger.levels = {
 };
 
 for (var le in logger.levels) {
+    logger.levels[`LOG${le}`] = le;
     logger['LOG' + le] = logger.levels[le];
 }
 

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -39,6 +39,16 @@ exports.log = {
     },
 };
 
+exports.level = {
+    setUp : _set_up,
+    'both INFO and LOGINFO are log levels' : function (test) {
+        test.expect(2);
+        test.equal(this.logger.levels.INFO, 6);
+        test.equal(this.logger.levels.LOGINFO, 6);
+        test.done();
+    }
+}
+
 exports.would_log = {
     setUp : _set_up,
     tearDown : _tear_down,


### PR DESCRIPTION
Changes proposed in this pull request:
- support INFO *and* LOGINFO as config settings
- switch default log level to INFO


* [x] docs updated
* [x] tests updated