### PR TITLE
dhparams: use filePath, b/c cfg unset

### DIFF
--- a/tls_socket.js
+++ b/tls_socket.js
@@ -507,7 +507,7 @@ exports.ensureDhparams = function (done) {
     }
 
     let filePath = path.resolve(exports.config.root_path, 'dhparams.pem');
-    log.loginfo(`Generating a 2048 bit dhparams file`);
+    log.loginfo(`Generating a 2048 bit dhparams file at ${filePath}`);
 
     let o = spawn('openssl', ['dhparam', '-out', `${filePath}`, '2048']);
     o.stdout.on('data', data => {
@@ -525,7 +525,7 @@ exports.ensureDhparams = function (done) {
         }
 
         log.loginfo(`Saved to ${filePath}`);
-        let content = tlss.config.get(tlss.cfg.main.dhparam, 'binary');
+        let content = tlss.config.get(filePath, 'binary');
 
         tlss.saveOpt('*', 'dhparam', content);
         done(null, certsByHost['*'].dhparam);

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -506,7 +506,8 @@ exports.ensureDhparams = function (done) {
         return done(null, certsByHost['*'].dhparam);
     }
 
-    let filePath = path.resolve(exports.config.root_path, 'dhparams.pem');
+    let filePath = tlss.cfg.main.dhparam;
+    if (!filePath) filePath = path.resolve(exports.config.root_path, 'dhparams.pem');
     log.loginfo(`Generating a 2048 bit dhparams file at ${filePath}`);
 
     let o = spawn('openssl', ['dhparam', '-out', `${filePath}`, '2048']);
@@ -516,7 +517,7 @@ exports.ensureDhparams = function (done) {
     })
 
     o.stderr.on('data', data => {
-        // this is the status crap that `openssl dhparam` spews as it works
+        // this is the status gibberish `openssl dhparam` spews as it works
     })
 
     o.on('close', code => {


### PR DESCRIPTION
Changes proposed in this pull request:
- when generating a dhparams.pem file, assure filePath is set

