### PR TITLE
Use tls socket ini

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,8 @@
 
 * Changes
     * Permit log settings to be set w/o LOG prefix #2057
+* New Features
+    * TLS certificate directory (config/tls). #2032
 
 ## 2.8.14 - Jul 26, 2017
 

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -23,7 +23,7 @@ exports.shutdown = function () {
 exports.load_tls_ini = function () {
     let plugin = this;
 
-    plugin.cfg = plugin.net_utils.load_tls_ini(function () {
+    plugin.cfg = tls_socket.load_tls_ini(function () {
         plugin.load_tls_ini();
     });
 }

--- a/server.js
+++ b/server.js
@@ -318,6 +318,7 @@ Server.createServer = function (params) {
 };
 
 Server.load_default_tls_config = function (done) {
+    // this fn exists solely for testing
     if (Server.config.root_path != tls_socket.config.root_path) {
         logger.loginfo('resetting tls_config.config path');
         tls_socket.config = tls_socket.config.module_config(path.dirname(Server.config.root_path));


### PR DESCRIPTION
Changes proposed in this pull request:
- plugins/tls needs to call load_tls_ini from tls_socket (not net_utils)
- related to haraka/haraka-net-utils#23

Checklist:
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
