### PR TITLE
outbound cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 
 services:
     - redis-server
-    
+
 # these are required for building on node.js v4+
 addons:
   apt:

--- a/outbound/client_pool.js
+++ b/outbound/client_pool.js
@@ -1,12 +1,12 @@
 "use strict";
 
-const generic_pool = require('generic-pool');
+var generic_pool = require('generic-pool');
 
-const sock         = require('../line_socket');
-const server       = require('../server');
-const logger       = require('../logger');
+var sock         = require('../line_socket');
+var server       = require('../server');
+var logger       = require('../logger');
 
-const cfg          = require('./config');
+var cfg          = require('./config');
 
 function _create_socket (port, host, local_addr, is_unix_socket, callback) {
     var socket = is_unix_socket ? sock.connect({path: host}) :
@@ -26,7 +26,7 @@ function _create_socket (port, host, local_addr, is_unix_socket, callback) {
     });
     socket.once('error', function (err) {
         socket.end();
-        var name = 'outbound::' + port + ':' + host + ':' + local_addr + ':' + cfg.pool_timeout;
+        var name = `outbound::${port}:${host}:${local_addr}:${cfg.pool_timeout}`;
         if (server.notes.pool && server.notes.pool[name]) {
             delete server.notes.pool[name];
         }
@@ -42,7 +42,7 @@ function _create_socket (port, host, local_addr, is_unix_socket, callback) {
 function get_pool (port, host, local_addr, is_unix_socket, max) {
     port = port || 25;
     host = host || 'localhost';
-    var name = 'outbound::' + port + ':' + host + ':' + local_addr + ':' + cfg.pool_timeout;
+    var name = `outbound::${port}:${host}:${local_addr}:${cfg.pool_timeout}`;
     if (!server.notes.pool) {
         server.notes.pool = {};
     }
@@ -67,7 +67,7 @@ function get_pool (port, host, local_addr, is_unix_socket, max) {
                     logger.logwarn("[outbound] Socket got an error while shutting down: " + err);
                 });
                 socket.once('end', function () {
-                    logger.loginfo("[outbound] Remote end half closed juring destroy()");
+                    logger.loginfo("[outbound] Remote end half closed during destroy()");
                     socket.destroy();
                 })
                 if (!socket.writable) return;
@@ -114,7 +114,7 @@ exports.release_client = function (socket, port, host, local_addr, error) {
     logger.logdebug("[outbound] release_client: " + host + ":" + port + " to " + local_addr);
 
     var pool_timeout = cfg.pool_timeout;
-    var name = 'outbound::' + port + ':' + host + ':' + local_addr + ':' + pool_timeout;
+    var name = `outbound:: ${port}:${host}:${local_addr}:${pool_timeout}`;
 
     if (cfg.pool_concurrency_max == 0) {
         return sockend();

--- a/outbound/client_pool.js
+++ b/outbound/client_pool.js
@@ -1,10 +1,12 @@
 "use strict";
 
-var generic_pool = require('generic-pool');
-var sock         = require('../line_socket');
-var server       = require('../server');
-var logger       = require('../logger');
-var cfg          = require('./config');
+const generic_pool = require('generic-pool');
+
+const sock         = require('../line_socket');
+const server       = require('../server');
+const logger       = require('../logger');
+
+const cfg          = require('./config');
 
 function _create_socket (port, host, local_addr, is_unix_socket, callback) {
     var socket = is_unix_socket ? sock.connect({path: host}) :

--- a/outbound/fsync_writestream.js
+++ b/outbound/fsync_writestream.js
@@ -1,10 +1,9 @@
 'use strict';
 
 var fs      = require('fs');
-var util    = require('util');
 
 class FsyncWriteStream extends fs.WriteStream {
-    constructor(path, options) {
+    constructor (path, options) {
         super(path, options);
     }
 }

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -40,8 +40,7 @@ var cfg = require('./config');
 /////////////////////////////////////////////////////////////////////////////
 // HMailItem - encapsulates an individual outbound mail item
 
-var dummy_func = function () {};
-
+function dummy_func () {}
 
 class HMailItem extends events.EventEmitter {
     constructor (filename, filePath, notes) {
@@ -116,7 +115,7 @@ HMailItem.prototype.read_todo = function () {
         var todo_len = (buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3];
         var td_reader = fs.createReadStream(self.path, {encoding: 'utf8', start: 4, end: todo_len + 3});
         self.data_start = todo_len + 4;
-        var todo = '';
+        let todo = '';
         td_reader.on('data', function (str) {
             todo += str;
             if (Buffer.byteLength(todo) === todo_len) {

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -1,5 +1,5 @@
 "use strict";
-var util         = require('util');
+
 var events       = require('events');
 var fs           = require('fs');
 var dns          = require('dns');
@@ -7,7 +7,6 @@ var path         = require('path');
 var net          = require('net');
 
 var Address     = require('address-rfc2821').Address;
-
 var constants   = require('haraka-constants');
 var net_utils   = require('haraka-net-utils');
 var utils       = require('haraka-utils');
@@ -36,8 +35,6 @@ setImmediate(function () {
     delivery_queue = queuelib.delivery_queue;
 });
 
-var mx = require('./mx_lookup');
-var _qfile = require('./qfile');
 var cfg = require('./config');
 
 /////////////////////////////////////////////////////////////////////////////
@@ -613,7 +610,7 @@ HMailItem.prototype.try_deliver_host_on_socket = function (mx, host, port, socke
         if (success) {
             var reason = response.join(' ');
             self.delivered(host, port, (mx.using_lmtp ? 'LMTP' : 'SMTP'), mx.exchange,
-                           reason, ok_recips, fail_recips, bounce_recips, secured, authenticated);
+                reason, ok_recips, fail_recips, bounce_recips, secured, authenticated);
         }
         else {
             self.discard();

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -14,16 +14,14 @@ var logger      = require('../logger');
 var config      = require('../config');
 var trans       = require('../transaction');
 var plugins     = require('../plugins');
-var DSN         = require('../dsn');
 var FsyncWriteStream = require('./fsync_writestream');
-var server      = require('../server');
 
 var cfg         = require('./config');
 var queuelib    = require('./queue');
 var HMailItem   = require('./hmail');
 var TODOItem    = require('./todo');
 var pools       = require('./client_pool');
-var _qfile      = require('./qfile');
+var _qfile = exports.qfile = require('./qfile');
 
 var queue_dir = queuelib.queue_dir;
 var temp_fail_queue = queuelib.temp_fail_queue;
@@ -44,7 +42,6 @@ exports._add_file = queuelib._add_file;
 exports.stats = queuelib.stats;
 exports.drain_pools = pools.drain_pools;
 
-var _qfile = exports.qfile = require('./qfile');
 
 process.on('message', function (msg) {
     if (msg.event && msg.event === 'outbound.load_pid_queue') {

--- a/outbound/queue.js
+++ b/outbound/queue.js
@@ -5,11 +5,10 @@ var path        = require('path');
 var fs          = require('fs');
 var Address     = require('address-rfc2821').Address;
 
-var TimerQueue  = require('../timer_queue');
 var config      = require('../config');
 var logger      = require('../logger');
-var server      = require('../server');
 
+var TimerQueue  = require('./timer_queue');
 var HMailItem   = require('./hmail');
 var cfg         = require('./config');
 var _qfile      = require('./qfile');

--- a/outbound/timer_queue.js
+++ b/outbound/timer_queue.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-var logger = require('./logger');
+var logger = require('../logger');
 
 function TQTimer (fire_time, cb) {
     this.fire_time = fire_time;

--- a/outbound/tls.js
+++ b/outbound/tls.js
@@ -4,11 +4,12 @@ var net_utils   = require('haraka-net-utils');
 
 exports.config = require('../config');
 
+// TODO: replace this with newer tls_ini loading in tls_socket
 exports.get_tls_options = function (mx) {
-    
+
     var tls_options = net_utils.tls_ini_section_with_defaults('outbound');
     tls_options.servername = mx.exchange;
-    
+
     if (tls_options.key) {
         if (Array.isArray(tls_options.key)) {
             tls_options.key = tls_options.key[0];

--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
   },
   "greenkeeper": {
     "ignore": [
-      "generic-pool",
-      "nodemailer"
+      "generic-pool"
     ]
   },
   "bin": {
@@ -77,7 +76,7 @@
   },
   "scripts": {
     "test": "node run_tests",
-    "lint": "node node_modules/.bin/eslint *.js plugins/*.js plugins/*/*.js tests/*.js tests/*/*.js bin/haraka bin/spf bin/dkimverify",
+    "lint": "node node_modules/.bin/eslint *.js outbound/*.js plugins/*.js plugins/*/*.js tests/*.js tests/*/*.js bin/haraka bin/spf bin/dkimverify",
     "lintfix": "node node_modules/.bin/eslint --fix *.js plugins/*.js plugins/*/*.js tests/*.js tests/*/*.js bin/haraka bin/spf bin/dkimverify",
     "cover": "NODE_ENV=cov node node_modules/.bin/istanbul cov run_tests"
   }


### PR DESCRIPTION
Changes proposed in this pull request:
- enable lint for outbound/*.js
    - whitespace fixes
    - remove redundant module loads
- move ./timer_queue to outbound/timer_queue
- remove nodemailer from greenkeeper ignore (we already upgraded to nodemailer latest)
