### PR TITLE
transaction.notes.queue

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,8 +2,10 @@
 
 * Changes
     * Permit log settings to be set w/o LOG prefix #2057
+    * additional results storing in smtp_forward and quarantine #2067
 * New Features
-    * TLS certificate directory (config/tls). #2032
+    * TLS certificate directory (config/tls) #2032
+    * plugins can specify a queue plugin & next_hop route #2067
 
 ## 2.8.14 - Jul 26, 2017
 

--- a/config/lmtp.ini
+++ b/config/lmtp.ini
@@ -1,0 +1,7 @@
+;
+; [main]
+; host=127.0.0.1
+
+; [example.com]
+; host=mail.example.com
+; port=24

--- a/docs/plugins/queue/lmtp.md
+++ b/docs/plugins/queue/lmtp.md
@@ -1,28 +1,26 @@
 queue/lmtp
 ========
 
-This plugin delivers mails to inbound domains via LMTP.
+This plugin delivers inbound mail via LMTP.
 
-Configuration
--------------
+## Configuration
 
-* `config/lmtp.ini`
-    This config file provides server address and port of LMTP server to deliver for different inbound domains.
-    Syntax is equal to that used in the config of the queue/smtp_forward plugin.
+LMTP is enabled by adding `queue/lmtp` to config/plugins. LMTP delivery is configured in `config/lmtp.ini` . By default, all inbound messages are forwarded to the host specified in the `[main]` section. Domain specific routes can be specified by creating additional sections with the same host/port or path options.
 
-    Example:
+### lmtp.ini
 
-    ```
-    ; defaults
-    host=localhost
-    port=24
+```ini
+; defaults
+host=localhost
+port=24
 
-    [example.com]
-    ; Goes elsewhere
-    host=10.1.1.1
-    port=2400
+[example1.com]
+; Goes elsewhere
+host=10.1.1.1
+port=2400
 
-    [blah.com]
-    ; Using unix domain sockets
-    path = /tmp/blah_com_socket
-    ```
+[example2.com]
+; Using unix domain sockets
+path = /tmp/blah_com_socket
+```
+

--- a/docs/plugins/queue/quarantine.md
+++ b/docs/plugins/queue/quarantine.md
@@ -6,7 +6,7 @@ directory, which will be created automatically if it does not already exist,
 a dated sub-folder is also added to the end of the path specified in YYYYMMDD
 format.
 
-It is designed to be used by other plugins which request the message be 
+It is designed to be used by other plugins which request the message be
 quarantined by setting a connection or transaction note that this plugin
 checks.
 
@@ -21,7 +21,7 @@ To ensure that only completely written files are present in the quarantine,
 the files are written to a temporary directory first and then hardlinked to
 the final destination before the temporary file is deleted.
 
-The temporary directory is 'quarantine_path/tmp' which defaults to: 
+The temporary directory is 'quarantine_path/tmp' which defaults to:
 /var/spool/haraka/quarantine/tmp.
 
 Upon start-up, any files present in the temporary directory are deleted
@@ -31,7 +31,7 @@ syncronously prior to any messages being accepted.
 Configuration
 -------------
 
-This plugin looks for 'quarantine.ini' in the config directory.  
+This plugin looks for 'quarantine.ini' in the config directory.
 
 * quarantine\_path                   (default: /var/spool/haraka/quarantine)
 

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -241,7 +241,7 @@ exports.send_trans_email = function (transaction, next) {
 
         async.forEachSeries(deliveries, function (deliv, cb) {
             var todo = new TODOItem(deliv.domain, deliv.rcpts, transaction);
-            todo.uuid = todo.uuid + '.' + todo_index;
+            todo.uuid = `${todo.uuid}.${todo_index}`;
             todo_index++;
             self.process_delivery(ok_paths, todo, hmails, cb);
         },

--- a/plugins/queue/discard.js
+++ b/plugins/queue/discard.js
@@ -6,16 +6,19 @@ exports.register = function () {
 }
 
 exports.discard = function (next, connection) {
-    var transaction = connection.transaction;
-    if (connection.notes.discard || transaction.notes.discard) {
+    const txn = connection.transaction;
+    if (txn.notes.queue && txn.notes.queue !== 'discard') return next();
+
+    function discard () {
         connection.loginfo(this, 'discarding message');
         // Pretend we delivered the message
         return next(OK);
     }
 
-    if (process.env.YES_REALLY_DO_DISCARD) {
-        return next(OK);
-    }
+    if (connection.notes.discard)          return discard();
+    if (txn.notes.discard)                 return discard();
+    if (txn.notes.queue === 'discard')     return discard();
+    if (process.env.YES_REALLY_DO_DISCARD) return discard();
 
     // Allow other queue plugins to deliver
     return next();

--- a/plugins/queue/lmtp.js
+++ b/plugins/queue/lmtp.js
@@ -1,34 +1,45 @@
 //queue/lmtp
 
-"use strict";
+'use strict';
 
-var outbound = require('./outbound');
+var outbound;
+
+exports.register = function () {
+    this.load_lmtp_ini();
+    outbound = this.haraka_require('outbound');
+}
+
+exports.load_lmtp_ini = function () {
+    var plugin = this;
+    plugin.cfg = plugin.config.get('lmtp.ini', function () {
+        plugin.load_lmtp_ini();
+    })
+}
 
 exports.hook_get_mx = function (next, hmail, domain) {
-    if (!hmail.todo.notes.using_lmtp) return next();
-    var config = this.config.get('lmtp.ini', 'ini');
-    var section = config[domain] || config.main;
-    var mx;
+    const plugin = this;
+    const notes = hmail.todo.notes;
+    if (!notes.using_lmtp) return next();
+
+    const mx = { using_lmtp: true, priority: 0, exchange: '127.0.0.1' };
+
+    const section = plugin.cfg[domain] || plugin.cfg.main;
     if (section.path) {
-        mx = {
-            priority: 0,
-            exchange: '127.0.0.1', // here to just pass dns lookups
-            path: section.path,
-            using_lmtp: true
-        };
+        Object.assign(mx, { path: section.path });
+        return next(OK, mx);
     }
-    else {
-        mx = {
-            priority: 0,
-            exchange: section.host || '127.0.0.1',
-            port: section.port || 24,
-            using_lmtp: true
-        };
-    }
+
+    Object.assign(mx, {
+        exchange: section.host || '127.0.0.1',
+        port: section.port || 24,
+    });
+
     return next(OK, mx);
 }
 
 exports.hook_queue = function (next, connection) {
-    connection.transaction.notes.using_lmtp = true;
-    outbound.send_email(connection.transaction, next);
+    const txn = connection.transaction;
+    if (txn.notes.queue && txn.notes.queue !== 'lmtp') return next();
+    txn.notes.using_lmtp = true;
+    outbound.send_email(txn, next);
 }

--- a/plugins/queue/quarantine.js
+++ b/plugins/queue/quarantine.js
@@ -4,9 +4,24 @@ var fs   = require('fs');
 var path = require('path');
 
 exports.register = function () {
-    this.register_hook('queue',          'quarantine');
-    this.register_hook('queue_outbound', 'quarantine');
+    const plugin = this;
+
+    plugin.load_quarantine_ini();
+
+    plugin.register_hook('queue',          'quarantine');
+    plugin.register_hook('queue_outbound', 'quarantine');
 };
+
+exports.hook_init_master = function (next, server) {
+    this.init_quarantine_dir(next);
+}
+
+exports.load_quarantine_ini = function () {
+    const plugin = this;
+    plugin.cfg = plugin.config.get('quarantine.ini', () => {
+        plugin.load_quarantine_ini();
+    })
+}
 
 // http://unknownerror.net/2011-05/16260-nodejs-mkdirs-recursion-create-directory.html
 var mkdirs = exports.mkdirs = function (dirpath, mode, callback) {
@@ -30,102 +45,101 @@ exports.hook_init_master = function (next) {
     // At start-up; delete any files in the temporary directory
     // NOTE: This is deliberately syncronous to ensure that this
     //       is completed prior to any messages being received.
-    var config = this.config.get('quarantine.ini');
-    var base_dir = (config.main.quarantine_path) ?
-        config.main.quarantine_path  :
-        '/var/spool/haraka/quarantine';
-    var tmp_dir = [ base_dir, 'tmp' ].join('/');
+    var tmp_dir = path.join(this.get_base_dir(), 'tmp');
     if (fs.existsSync(tmp_dir)) {
         var dirent = fs.readdirSync(tmp_dir);
         this.loginfo('Removing temporary files from: ' + tmp_dir);
         for (var i=0; i<dirent.length; i++) {
-            fs.unlinkSync([ tmp_dir, dirent[i] ].join('/'));
+            fs.unlinkSync(path.join(tmp_dir, dirent[i]));
         }
     }
     return next();
 };
 
+function wants_quarantine (connection) {
+    if (connection.notes.quarantine)
+        return connection.notes.quarantine;
+
+    if (connection.transaction.notes.quarantine)
+        return connection.transaction.notes.quarantine;
+
+    if (connection.transaction.notes.queue === 'quarantine')
+        return true;
+
+    return false;
+}
+
+exports.get_base_dir = function () {
+    if (this.cfg.main.quarantine_path) return this.cfg.main.quarantine_path;
+    return '/var/spool/haraka/quarantine';
+}
+
+exports.init_quarantine_dir = function (done) {
+    const plugin = this;
+    const tmp_dir = path.join(plugin.get_base_dir(), 'tmp');
+    mkdirs(tmp_dir, parseInt('0770', 8), function () {
+        plugin.loginfo(`created ${tmp_dir}`);
+        done();
+    });
+}
+
 exports.quarantine = function (next, connection) {
-    var transaction = connection.transaction;
-    if ((connection.notes.quarantine || transaction.notes.quarantine)) {
-        // Calculate date in YYYYMMDD format
-        var d = new Date();
-        var yyyymmdd = d.getFullYear() + zeroPad(d.getMonth()+1, 2)
-            + this.zeroPad(d.getDate(), 2);
-        var config = this.config.get('quarantine.ini');
-        var base_dir = (config.main.quarantine_path) ?
-            config.main.quarantine_path  :
-            '/var/spool/haraka/quarantine';
-        var dir;
-        // Allow either boolean or a sub-directory to be specified
-        if (connection.notes.quarantine) {
-            if (typeof(connection.notes.quarantine) !== 'boolean' &&
-                connection.notes.quarantine !== 1)
-            {
-                dir = connection.notes.quarantine;
-            }
-        }
-        else if (transaction.notes.quarantine) {
-            if (typeof(transaction.notes.quarantine) !== 'boolean' &&
-                transaction.notes.quarantine !== 1)
-            {
-                dir = transaction.notes.quarantine;
-            }
-        }
-        if (!dir) {
-            dir = yyyymmdd;
-        }
-        else {
-            dir = [ dir, yyyymmdd ].join('/');
-        }
-        var plugin = this;
-        // Create all the directories recursively if they do not exist first.
-        // Then write the file to a temporary directory first, once this is
-        // successful we hardlink the file to the final destination and then
-        // remove the temporary file to guarantee a complete file in the
-        // final destination.
-        mkdirs([ base_dir, 'tmp' ].join('/'), parseInt('0770', 8), function () {
-            mkdirs([ base_dir, dir ].join('/'), parseInt('0770', 8), function () {
-                var ws = fs.createWriteStream([ base_dir, 'tmp', transaction.uuid ].join('/'));
-                ws.on('error', function (err) {
-                    connection.logerror(plugin, 'Error writing quarantine file: ' + err.message);
-                    return next();
-                });
-                ws.on('close', function () {
-                    fs.link([ base_dir, 'tmp', transaction.uuid ].join('/'),
-                        [ base_dir, dir, transaction.uuid ].join('/'),
-                        function (err) {
-                            if (err) {
-                                connection.logerror(plugin, 'Error writing quarantine file: ' + err);
-                            }
-                            else {
-                                // Add a note to where we stored the message
-                                transaction.notes.quarantined = [ base_dir, dir, transaction.uuid ].join('/');
-                                connection.loginfo(plugin, 'Stored copy of message in quarantine: ' +
-                                                   [ base_dir, dir, transaction.uuid ].join('/'));
-                                // Now delete the temporary file
-                                fs.unlink([ base_dir, 'tmp', transaction.uuid ].join('/'), function () {});
-                            }
-                            // Using notes.quarantine_action to decide what to do after the message is quarantined.
-                            // Format can be either action = [ code, msg ] or action = code
-                            var action = (connection.notes.quarantine_action || transaction.notes.quarantine_action);
-                            if (Array.isArray(action)) {
-                                return next(action[0], action[1]);
-                            }
-                            else if (action) {
-                                return next(action);
-                            }
-                            else {
-                                return next();
-                            }
-                        }
-                    );
-                });
-                transaction.message_stream.pipe(ws, { line_endings: '\n' });
+    const plugin = this;
+
+    const quarantine = wants_quarantine(connection);
+    plugin.logdebug(`quarantine: ${quarantine}`);
+    if (!quarantine) return next();
+
+    // Calculate date in YYYYMMDD format
+    const d = new Date();
+    const yyyymmdd = d.getFullYear() + zeroPad(d.getMonth()+1, 2)
+        + this.zeroPad(d.getDate(), 2);
+
+    let subdir = yyyymmdd;
+    // Allow either boolean or a sub-directory to be specified
+
+    if (typeof quarantine !== 'boolean' && quarantine !== 1) {
+        subdir = path.join(quarantine, yyyymmdd);
+    }
+
+    const txn      = connection.transaction;
+    const base_dir = plugin.get_base_dir();
+    const msg_dir  = path.join(base_dir, subdir);
+    const tmp_path = path.join(base_dir, 'tmp', txn.uuid);
+    const msg_path = path.join(msg_dir, txn.uuid);
+
+    // Create all the directories recursively if they do not exist.
+    // Then write the file to a temporary directory first, once this is
+    // successful we hardlink the file to the final destination and then
+    // remove the temporary file to guarantee a complete file in the
+    // final destination.
+    mkdirs(msg_dir, parseInt('0770', 8), function () {
+        const ws = fs.createWriteStream(tmp_path);
+
+        ws.on('error', function (err) {
+            connection.logerror(plugin, 'Error writing quarantine file: ' + err.message);
+            return next();
+        });
+        ws.on('close', function () {
+            fs.link(tmp_path, msg_path, function (err) {
+                if (err) {
+                    connection.logerror(plugin, 'Error writing quarantine file: ' + err);
+                }
+                else {
+                    // Add a note to where we stored the message
+                    txn.notes.quarantined = msg_path;
+                    txn.results.add(plugin, { pass: msg_path, emit: true });
+                    // Now delete the temporary file
+                    fs.unlink(tmp_path, function () {});
+                }
+                // Using notes.quarantine_action to decide what to do after the message is quarantined.
+                // Format can be either action = [ code, msg ] or action = code
+                var action = (connection.notes.quarantine_action || txn.notes.quarantine_action);
+                if (!action) return next();
+                if (Array.isArray(action)) return next(action[0], action[1]);
+                return next(action);
             });
         });
-    }
-    else {
-        return next();
-    }
+        txn.message_stream.pipe(ws, { line_endings: '\n' });
+    });
 }

--- a/tests/plugins/queue/smtp_forward.js
+++ b/tests/plugins/queue/smtp_forward.js
@@ -22,7 +22,7 @@ function _setup (done) {
 }
 
 exports.loadingTLSConfig = {
-    'TLS enabled but no outbound config in tls.ini': function(test) {
+    'TLS enabled but no outbound config in tls.ini': function (test) {
         var plugin = new fixtures.plugin('queue/smtp_forward');
         test.expect(2);
 
@@ -68,7 +68,7 @@ exports.get_config = {
         test.expect(3);
         this.connection.transaction.rcpt_to.push(
             new Address('<matt@example.com>')
-            );
+        );
         var cfg = this.plugin.get_config(this.connection);
         test.equal(cfg.enable_tls, true);
         test.equal(cfg.one_message_per_rcpt, true);
@@ -79,7 +79,7 @@ exports.get_config = {
         test.expect(1);
         this.connection.transaction.rcpt_to.push(
             new Address('<matt@test.com>')
-            );
+        );
         test.deepEqual(this.plugin.get_config(this.connection), {
             host: '1.2.3.4',
             enable_tls: true,
@@ -92,7 +92,7 @@ exports.get_config = {
         test.expect(1);
         this.connection.transaction.rcpt_to.push(
             new Address('<matt@test1.com>')
-            );
+        );
         var cfg = this.plugin.get_config(this.connection);
         test.deepEqual(cfg, {
             host: '1.2.3.4',
@@ -105,13 +105,14 @@ exports.get_config = {
         this.connection.transaction.rcpt_to.push(
             new Address('<matt@test.com>'),
             new Address('<matt@test.com>')
-            );
+        );
         var cfg = this.plugin.get_config(this.connection);
         test.deepEqual(cfg.host, '1.2.3.4' );
         test.done();
     },
 };
 
+const hmail = { todo: { notes: {} } };
 exports.get_mx = {
     setUp : _setup,
     'returns no outbound route for undefined domains' : function (test) {
@@ -121,7 +122,7 @@ exports.get_mx = {
             test.deepEqual(mx, undefined);
             test.done();
         };
-        this.plugin.get_mx(cb, {}, 'undefined.com');
+        this.plugin.get_mx(cb, hmail, 'undefined.com');
     },
     'returns an outbound route for defined domains' : function (test) {
         test.expect(2);
@@ -134,6 +135,6 @@ exports.get_mx = {
             });
             test.done();
         };
-        this.plugin.get_mx(cb, {}, 'test.com');
+        this.plugin.get_mx(cb, hmail, 'test.com');
     },
 }

--- a/transaction.js
+++ b/transaction.js
@@ -1,11 +1,13 @@
-"use strict";
+'use strict';
 // An SMTP Transaction
+
+var util   = require('util');
+
+var utils  = require('haraka-utils');
 
 var config = require('./config');
 var Header = require('./mailheader').Header;
 var body   = require('./mailbody');
-var utils  = require('haraka-utils');
-var util   = require('util');
 var MessageStream = require('./messagestream');
 
 var MAX_HEADER_LINES = config.get('max_header_lines') || 1000;


### PR DESCRIPTION
**Background:** the smtp_forward plugin has support for selective forwarding. During the recipient phase, if the smtp_forward plugin acknowledges a recipient, it also specifies which forward path (smtp_forward or outbound) the transaction should take by setting transaction.notes.queue = [outbound | smtp_forward]. (See also #1472)  This works well for me. I smtp_forward a subset of mail to various servers and deliver the rest via outbound.

**Hopes:** Now I want to deliver a portion of that forwarded mail directly to dovecot via LMTP. Since dovecot doesn't know about legacy aliases, forwards, autoresponders, and lists, only a subset of messages can get routed via LMTP.  My qmd plugin knows the difference and can make the determination.

**The Problem:** There are two confounding factors:

1. The LMTP configuration is no more precise than a domain
2. The LMTP plugin wants to deliver all inbound mail

To resolve this I have ~~amended the LMTP plugin to also retrieve forward MX info from a transaction note.~~ adapted the queue selection logic from the smtp_forward plugin and made it applicable to all queue plugins.

This PR ~~changes the smtp_forward queue location from `transaction.notes.queue` to `transaction.queue.wants` and~~ extends the queue choice logic to the quarantine, discard, qmail-queue, and lmtp plugins. If nothing sets `transaction.notes.queue` (the default), then queue selection is left to plugin ordering, same as before.

Changes proposed in this pull request:
- smtp_forward:
    - upon success, save remote msg to results store
- LMTP
    - skip hook_queue when notes.queue is set and != 'lmtp'
    - add lmtp.ini example
- discard:
    - skip hook_queue when notes.queue is set and != 'discard'
    - discard when txn. notes.queue = discard (extends discard conditions)
- quarantine:
    - load .ini during register
    - init the quarantine dir at init_server
        - so if it fails, it happens at startup -vs- when first message arrives
        - saves a fs operation during every delivery
    - factored out wants_quarantine, extended with support for notes.queue
    - replaced numerous [path, segments].join('/') with path.join(seg1, set2)
    - results storing

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated