### PR TITLE
add transaction.queue for queue plugins

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
     * Permit log settings to be set w/o LOG prefix #2057
 * New Features
     * TLS certificate directory (config/tls). #2032
+    * transaction.queue.wants #2079
 
 ## 2.8.14 - Jul 26, 2017
 

--- a/docs/Transaction.md
+++ b/docs/Transaction.md
@@ -166,7 +166,7 @@ Store results of processing in a structured format. See [docs/Results](http://ha
 
 An object populated with queue related data, including:
 
-    * **wants** Default: undefined.
+* transaction.queue.wants (Default: undefined)
 
-    The name of a queue plugin. When using more than one queue plugin, plugins can set this property to specify which one should enqueue the transaction.
+The name of a queue plugin. When using more than one queue plugin, plugins can set this property to specify which one should enqueue the transaction.
 

--- a/docs/Transaction.md
+++ b/docs/Transaction.md
@@ -21,7 +21,7 @@ An Array of `Address` objects of recipients from the RCPT TO command.
 
 * transaction.message\_stream
 
-A node.js Readable Stream object for the message. 
+A node.js Readable Stream object for the message.
 
 You use it like this:
 
@@ -161,3 +161,12 @@ body in the same encoding.
 * transaction.results
 
 Store results of processing in a structured format. See [docs/Results](http://haraka.github.io/manual/Results.html)
+
+* transaction.queue
+
+An object populated with queue related data, including:
+
+    * **wants** Default: undefined.
+
+    The name of a queue plugin. When using more than one queue plugin, plugins can set this property to specify which one should enqueue the transaction.
+

--- a/outbound/todo.js
+++ b/outbound/todo.js
@@ -8,6 +8,7 @@ function TODOItem (domain, recipients, transaction) {
     this.mail_from = transaction.mail_from;
     this.message_stream = transaction.message_stream;
     this.notes = transaction.notes;
+    this.queue = transaction.queue;
     this.uuid = transaction.uuid;
     return this;
 }

--- a/plugins/queue/discard.js
+++ b/plugins/queue/discard.js
@@ -7,7 +7,11 @@ exports.register = function () {
 
 exports.discard = function (next, connection) {
     var transaction = connection.transaction;
-    if (transaction.queue.wants && transaction.queue.wants !== 'discard') return next();
+
+    if (transaction.queue.wants) {
+        if (transaction.queue.wants === 'discard') return next(OK);
+        return next();
+    }
 
     if (connection.notes.discard || transaction.notes.discard) {
         connection.loginfo(this, 'discarding message');

--- a/plugins/queue/discard.js
+++ b/plugins/queue/discard.js
@@ -7,6 +7,8 @@ exports.register = function () {
 
 exports.discard = function (next, connection) {
     var transaction = connection.transaction;
+    if (transaction.queue.wants && transaction.queue.wants !== 'discard') return next();
+
     if (connection.notes.discard || transaction.notes.discard) {
         connection.loginfo(this, 'discarding message');
         // Pretend we delivered the message

--- a/plugins/queue/lmtp.js
+++ b/plugins/queue/lmtp.js
@@ -29,6 +29,8 @@ exports.hook_get_mx = function (next, hmail, domain) {
 }
 
 exports.hook_queue = function (next, connection) {
+    const txn = connection.transaction;
+    if (txn.queue.wants && txn.queue.wants !== 'lmtp') return next();
     connection.transaction.notes.using_lmtp = true;
     outbound.send_email(connection.transaction, next);
 }

--- a/plugins/queue/qmail-queue.js
+++ b/plugins/queue/qmail-queue.js
@@ -33,6 +33,10 @@ exports.load_qmail_queue_ini = function () {
 
 exports.hook_queue = function (next, connection) {
     var plugin = this;
+
+    const txn = connection.transaction;
+    if (txn.queue.wants && txn.queue.wants !== 'qmail-queue') return next();
+
     var qmail_queue = childproc.spawn(
         this.queue_exec, // process name
         [],              // arguments

--- a/plugins/queue/quarantine.js
+++ b/plugins/queue/quarantine.js
@@ -45,9 +45,23 @@ exports.hook_init_master = function (next) {
     return next();
 };
 
+function wants_quarantine (connection) {
+    if (connection.notes.quarantine)
+        return connection.notes.quarantine;
+
+    if (connection.transaction.notes.quarantine)
+        return connection.transaction.notes.quarantine;
+
+    if (connection.transaction.queue.wants === 'quarantine')
+        return true;
+
+    return false;
+}
+
 exports.quarantine = function (next, connection) {
+
     var transaction = connection.transaction;
-    if ((connection.notes.quarantine || transaction.notes.quarantine)) {
+    if (wants_quarantine(connection)) {
         // Calculate date in YYYYMMDD format
         var d = new Date();
         var yyyymmdd = d.getFullYear() + zeroPad(d.getMonth()+1, 2)

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -98,13 +98,13 @@ exports.set_queue = function (connection, queue_wanted, domain) {
     var dst_host = dom_cfg.host || plugin.cfg.main.host;
     if (dst_host) queue_wanted += ':' + dst_host;
 
-    if (!connection.transaction.notes.queue) {
-        connection.transaction.notes.queue = queue_wanted;
+    if (!connection.transaction.queue.wants) {
+        connection.transaction.queue.wants = queue_wanted;
         return true;
     }
 
     // multiple recipients with same destination
-    if (connection.transaction.notes.queue === queue_wanted) {
+    if (connection.transaction.queue.wants === queue_wanted) {
         return true;
     }
 
@@ -192,7 +192,7 @@ exports.queue_forward = function (next, connection) {
     var plugin = this;
     var txn = connection.transaction;
 
-    if (txn.notes.queue && !/^smtp_forward/.test(txn.notes.queue))
+    if (txn.queue.wants && !/^smtp_forward/.test(txn.queue.wants))
         return next();
 
     var cfg = plugin.get_config(connection);

--- a/transaction.js
+++ b/transaction.js
@@ -37,6 +37,9 @@ function Transaction () {
     this.data_post_start = null;
     this.data_post_delay = 0;
     this.encoding = 'utf8';
+    this.queue = {
+        wants: null,    // smtp_forward, quarantine, outbound, lmtp, etc.
+    };
 }
 
 exports.Transaction = Transaction;


### PR DESCRIPTION
This is a lite version of #2067 

Changes proposed:
- adds transaction.queue object (to extend queue plugins without having to `if (txn.notes.queue && txn.notes.queue.$var)` or creating a mess of `if (txn.notes.queue_$var)`.
- `queue.wants` is a plugin name.
    - when defined, plugins that *aren't* that name skip queueing
        - this adds an "off switch" to on-by-default plugins: deliver, lmtp, qmail-queue, smtp_*, rabbit_*
    - when defined, plugins that *are* that name are enabled
        - this adds an `on` switch to off-by-default plugins: discard, quarantine
- greatly simplifies coordination when 3+ queue plugins are enabled

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated