### PR TITLE
notes.queue -> notes.queue.wants w/get&set

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 * Changes
     * Permit log settings to be set w/o LOG prefix #2057
     * additional results storing in smtp_forward and quarantine #2067
+    * smtp_forward stores queue note at queue.wants #2083
 * New Features
     * TLS certificate directory (config/tls) #2032
     * plugins can specify a queue plugin & next_hop route #2067

--- a/plugins/queue/discard.js
+++ b/plugins/queue/discard.js
@@ -7,7 +7,9 @@ exports.register = function () {
 
 exports.discard = function (next, connection) {
     const txn = connection.transaction;
-    if (txn.notes.queue && txn.notes.queue !== 'discard') return next();
+
+    const q_wants = txn.notes.get('queue.wants');
+    if (q_wants && q_wants !== 'discard') return next();
 
     function discard () {
         connection.loginfo(this, 'discarding message');
@@ -17,7 +19,7 @@ exports.discard = function (next, connection) {
 
     if (connection.notes.discard)          return discard();
     if (txn.notes.discard)                 return discard();
-    if (txn.notes.queue === 'discard')     return discard();
+    if (q_wants === 'discard')             return discard();
     if (process.env.YES_REALLY_DO_DISCARD) return discard();
 
     // Allow other queue plugins to deliver

--- a/plugins/queue/lmtp.js
+++ b/plugins/queue/lmtp.js
@@ -39,7 +39,10 @@ exports.hook_get_mx = function (next, hmail, domain) {
 
 exports.hook_queue = function (next, connection) {
     const txn = connection.transaction;
-    if (txn.notes.queue && txn.notes.queue !== 'lmtp') return next();
+
+    const q_wants = txn.notes.get('queue.wants');
+    if (q_wants && q_wants !== 'lmtp') return next();
+
     txn.notes.using_lmtp = true;
     outbound.send_email(txn, next);
 }

--- a/plugins/queue/qmail-queue.js
+++ b/plugins/queue/qmail-queue.js
@@ -35,7 +35,9 @@ exports.hook_queue = function (next, connection) {
     var plugin = this;
 
     const txn = connection.transaction;
-    if (txn.notes.queue && txn.notes.queue !== 'qmail-queue') return next();
+
+    const q_wants = txn.notes.get('queue.wants');
+    if (q_wants && q_wants !== 'qmail-queue') return next();
 
     var qmail_queue = childproc.spawn(
         this.queue_exec, // process name

--- a/plugins/queue/quarantine.js
+++ b/plugins/queue/quarantine.js
@@ -63,7 +63,7 @@ function wants_quarantine (connection) {
     if (connection.transaction.notes.quarantine)
         return connection.transaction.notes.quarantine;
 
-    if (connection.transaction.notes.queue === 'quarantine')
+    if (connection.transaction.notes.get('queue.wants') === 'quarantine')
         return true;
 
     return false;


### PR DESCRIPTION
Changes proposed in this pull request:
- moves the "desired queue" location from queue to queue.wants
- use notes.get() and notes.set()

Checklist:
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
