### PR TITLE
Fix rfc2231 parsing code to cope with continuation

### DIFF
--- a/mailheader.js
+++ b/mailheader.js
@@ -168,7 +168,7 @@ function _decode_rfc2231 (params, str) {
 
 Header.prototype.decode_header = function decode_header (val) {
     // Fold continuations
-    val.replace(/\r?\n/g, '');
+    val = val.replace(/\r?\n/g, '');
 
     const rfc2231_params = {
         kv: {},

--- a/mailheader.js
+++ b/mailheader.js
@@ -100,6 +100,24 @@ function _decode_header (matched, encoding, lang, cte, data) {
 }
 
 function _decode_rfc2231 (params, str) {
+    /*
+    To explain the regexp below, the params are:
+
+    parameter := attribute "=" value
+
+    attribute := token
+                 ; Matching of attributes
+                 ; is ALWAYS case-insensitive.
+
+    token := 1*<any (US-ASCII) CHAR except SPACE, CTLs,
+                or tspecials>
+
+    tspecials :=  "(" / ")" / "<" / ">" / "@" /
+                  "," / ";" / ":" / "\" / <">
+                  "/" / "[" / "]" / "?" / "="
+                  ; Must be in quoted-string,
+                  ; to use within parameter values
+    */
     var sub_matches = /(([!#$%&'*+.0-9A-Zdiff^_`a-z{|}~-]*)\*)(\d*)=(\s*".*?[^\\]";?|\S*)/.exec(str);
     if (!sub_matches) {
         return;

--- a/mailheader.js
+++ b/mailheader.js
@@ -168,7 +168,7 @@ function _decode_rfc2231 (params, str) {
 
 Header.prototype.decode_header = function decode_header (val) {
     // Fold continuations
-    const = val.replace(/\r?\n/g, '');
+    val.replace(/\r?\n/g, '');
 
     const rfc2231_params = {
         kv: {},

--- a/tests/mailbody.js
+++ b/tests/mailbody.js
@@ -26,6 +26,9 @@ function _fill_body (body, quote) {
     body.parse_more(" title*0*=us-ascii'en'This%20is%20even%20more%20\n");
     body.parse_more(" title*1*=%2A%2A%2Afun%2A%2A%2A%20\n");
     body.parse_more(" title*2=\"isn't it!\"\n");
+    body.parse_more("Content-Disposition: inline; \n");
+    body.parse_more("  filename*0=\"marketron_lbasubmission_FTA Cricket Brentwood 3006445\n");
+    body.parse_more(" Jackso\"; filename*1=\"n TN_08282017.xlsx\"\n");
     body.parse_more("\n");
     body.parse_more("<p>This is some HTML, yo.<br>\n");
     body.parse_more("It's pretty rad.</p>\n");
@@ -244,12 +247,13 @@ exports.filters = {
 
 exports.rfc2231 = {
     'multi-value': function (test) {
-        test.expect(1);
+        test.expect(2);
 
         var body = new Body();
         _fill_body(body);
 
         test.ok(body.children[0].header.get_decoded('content-type').indexOf('URL="ftp://cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar";') > 0);
+        test.ok(body.children[1].header.get_decoded('content-disposition').indexOf('filename="marketron_lbasubmission_FTA Cricket Brentwood 3006445 Jackson TN_08282017.xlsx"') > 0);
         test.done();
     },
 

--- a/tests/mailheader.js
+++ b/tests/mailheader.js
@@ -32,7 +32,7 @@ exports.basic = {
         test.equal(h.lines().length, 12);
         test.equal(
             h.get_decoded('content-type'),
-            'multipart/alternative; boundary=Apple-Mail-F2C5DAD3-7EB3-409D-9FE0-135C9FD43B69'
+            'multipart/alternative;   boundary=Apple-Mail-F2C5DAD3-7EB3-409D-9FE0-135C9FD43B69'
         );
         test.done();
     },


### PR DESCRIPTION
Fixes a bug found by an emailitin.com user.

Basically this header:

```
Content-Disposition: attachment; \r
   filename*0="marketron_lbasubmission_FTA Cricket Brentwood 3006445\r
 Jackso"; filename*1="n TN_08282017.xlsx"\r
```

Would cause Haraka to fail to properly process the header.

Checklist:
- [ ] docs updated
- [x] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
