### PR TITLE
only apply default tls key/cert paths when undefined

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@
     * Replace console.log with stdout #2100
     * ES6: replace var with const or let  #2073
 * Fixes
+    * tls: only apply default key/cert paths when undefined #2111
     * haraka was adding TLS header on non-TLS connection #2103
     * dkim_verify: fix formatting of auth results #2107
     * smtp_forward: consistently use queue.wants #2107

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -330,6 +330,7 @@ exports.load_default_opts = function () {
     const cfg = certsByHost['*'];
 
     if (cfg.dhparam && typeof cfg.dhparam === 'string') {
+        log.logdebug(`loading dhparams from ${cfg.dhparam}`);
         tlss.saveOpt('*', 'dhparam', tlss.config.get(cfg.dhparam, 'binary'));
     }
 

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -293,7 +293,8 @@ exports.applySocketOpts = function (name) {
             tlss.saveOpt(name, opt, tlss.cfg[name][opt]);
             return;
         }
-        else if (tlss.cfg.main[opt] !== undefined) {
+
+        if (tlss.cfg.main[opt] !== undefined) {
             // if the setting exists in tls.ini [main]
             // then save it to the certsByHost options
             tlss.saveOpt(name, opt, tlss.cfg.main[opt]);

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -513,7 +513,7 @@ exports.ensureDhparams = function (done) {
 
     log.loginfo(`Generating a 2048 bit dhparams file at ${fpResolved}`);
 
-    const o = spawn('openssl', ['dhparam', '-out', `${fpResolved}`, '1024']);
+    const o = spawn('openssl', ['dhparam', '-out', `${fpResolved}`, '2048']);
     o.stdout.on('data', data => {
         // normally empty output
         log.logdebug(data);

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -291,11 +291,13 @@ exports.applySocketOpts = function (name) {
         if (tlss.cfg[name] && tlss.cfg[name][opt] !== undefined) {
             // if the setting exists in tls.ini [name]
             tlss.saveOpt(name, opt, tlss.cfg[name][opt]);
+            return;
         }
         else if (tlss.cfg.main[opt] !== undefined) {
             // if the setting exists in tls.ini [main]
             // then save it to the certsByHost options
             tlss.saveOpt(name, opt, tlss.cfg.main[opt]);
+            return;
         }
 
         // defaults
@@ -506,11 +508,12 @@ exports.ensureDhparams = function (done) {
         return done(null, certsByHost['*'].dhparam);
     }
 
-    let filePath = tlss.cfg.main.dhparam;
-    if (!filePath) filePath = path.resolve(exports.config.root_path, 'dhparams.pem');
-    log.loginfo(`Generating a 2048 bit dhparams file at ${filePath}`);
+    const filePath = tlss.cfg.main.dhparam || 'dhparams.pem';
+    const fpResolved = path.resolve(exports.config.root_path, filePath);
 
-    const o = spawn('openssl', ['dhparam', '-out', `${filePath}`, '2048']);
+    log.loginfo(`Generating a 2048 bit dhparams file at ${fpResolved}`);
+
+    const o = spawn('openssl', ['dhparam', '-out', `${fpResolved}`, '1024']);
     o.stdout.on('data', data => {
         // normally empty output
         log.logdebug(data);
@@ -525,7 +528,7 @@ exports.ensureDhparams = function (done) {
             return done('Error code: ' + code);
         }
 
-        log.loginfo(`Saved to ${filePath}`);
+        log.loginfo(`Saved to ${fpResolved}`);
         const content = tlss.config.get(filePath, 'binary');
 
         tlss.saveOpt('*', 'dhparam', content);


### PR DESCRIPTION
Fixes #2108

Changes proposed in this pull request:
- only apply default tls key/cert paths when undefined in tls.ini
- permit dhparams.pem file to be in a directory
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated