### PR TITLE
Travis ubuntu now has new enough gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,6 @@ matrix:
 services:
     - redis-server
 
-# these are required for building on node.js v4+
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
-env:
-  - "CXX=g++-4.8"
-# end: these are required for building on node.js v4+
-
 before_script:
 
 script:


### PR DESCRIPTION
Yay, we don't need these any more. This will speed up builds by quite a bit.