### PR TITLE
move connection states into haraka-constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "npid"                  : "~0.4.0",
     "semver"                : "~5.4.0",
     "sprintf-js"            : "~1.1.0",
-    "haraka-constants"      : ">=1.0.4",
+    "haraka-constants"      : ">=1.0.5",
     "haraka-dsn"            : "*",
     "haraka-net-utils"      : ">=1.0.10",
     "haraka-notes"          : "*",

--- a/plugins.js
+++ b/plugins.js
@@ -11,7 +11,6 @@ const constants   = require('haraka-constants');
 
 // local modules
 const logger      = require('./logger');
-const states      = require('./connection').states;
 exports.config  = require('./config');
 
 exports.registered_hooks = {};
@@ -517,7 +516,7 @@ plugins.run_next_hook = function (hook, object, params) {
 
 function client_disconnected (object) {
     if (object.constructor.name === 'Connection' &&
-        object.state >= states.DISCONNECTING) {
+        object.state >= constants.connection.state.DISCONNECTING) {
         object.logdebug('client has disconnected');
         return true;
     }

--- a/tests/outbound.js
+++ b/tests/outbound.js
@@ -137,7 +137,7 @@ exports.get_tls_options = {
         done();
     },
     tearDown: function (done) {
-        process.env.HARAKA_TEST_DIR='';
+        delete process.env.HARAKA_TEST_DIR;
         done();
     },
     'gets TLS properties from tls.ini.outbound': function (test) {

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -64,6 +64,7 @@ exports.get_timeout = {
         });
     },
     tearDown : function (done) {
+        delete process.env.WITHOUT_CONFIG_CACHE;
         fs.unlink(toPath, done);
     },
     '0s' : function (test) {
@@ -90,11 +91,11 @@ exports.get_timeout = {
 
 exports.plugin_paths = {
     setUp : function (done) {
-        process.env.HARAKA = '';
+        delete process.env.HARAKA;
         done();
     },
     tearDown : function (done) {
-        process.env.HARAKA = '';
+        delete process.env.HARAKA;
         done();
     },
     'CORE plugin: (tls)' : function (test) {
@@ -205,11 +206,11 @@ exports.plugin_paths = {
 
 exports.plugin_config = {
     setUp : function (done) {
-        process.env.HARAKA = '';
+        delete process.env.HARAKA;
         done();
     },
     tearDown : function (done) {
-        process.env.HARAKA = '';
+        delete process.env.HARAKA;
         done();
     },
     'CORE plugin: (tls)' : function (test) {

--- a/tests/server.js
+++ b/tests/server.js
@@ -155,8 +155,8 @@ function _setupServer (done) {
 }
 
 function _tearDownServer (done) {
-    process.env.YES_REALLY_DO_DISCARD='';
-    process.env.HARAKA_TEST_DIR='';
+    delete process.env.YES_REALLY_DO_DISCARD;
+    delete process.env.HARAKA_TEST_DIR;
     this.server.stopListeners();
     this.server.plugins.registered_hooks = {};
     setTimeout(() => {


### PR DESCRIPTION
Changes proposed in this pull request:
- move connection states into haraka-constants
- use shorthand version of states
- after tests run, delete the process.env.* they manipulate

I moved the connection state constants into haraka-constants because they created race conditions in the test suite. Especially [right here](https://github.com/haraka/Haraka/blob/afd53239fb76e8818791e8f7cdb273ffa45b4865/plugins.js#L14). The symptom was: `./run_tests tests/server.js` would work fine on its own, but when run after other tests, blow up upon disconnect because `states` in plugin.js wasn't defined.

I also discovered a little bug in plugins.js that this fixes:

`if (object.state >= states.DISCONNECTING)`

That may not have worked as intended because `states.DISCONNECTING` didn't exist. In connection.js it was only defined as states.STATE_DISCONNECTING. It's more natural to drop the redundant STATE prefix so that's what I did in the [haraka-constants PR](https://github.com/haraka/haraka-constants/pull/8/files). It can be referenced either way now. #