### PR TITLE
replaced concatenated strings with template literals in the plugins/auth/auth_ldap.js

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@
     * Fix ability to set log level to emerg #2128
 * Changes
     * config: replace ./config.js with haraka-config #2119
+    * replaced concatenated strings with template literals in the plugins/auth/auth_ldap.js #2158
 
 ## 2.8.16 - Sep 30, 2017
 

--- a/plugins/auth/auth_ldap.js
+++ b/plugins/auth/auth_ldap.js
@@ -7,7 +7,7 @@ exports.hook_capabilities = function (next, connection) {
     // Don't offer AUTH capabilities by default unless session is encrypted
     if (connection.tls.enabled) {
         const methods = [ 'LOGIN' ];
-        connection.capabilities.push('AUTH ' + methods.join(' '));
+        connection.capabilities.push(`AUTH ${methods.join(' ')}`);
         connection.notes.allowed_auth_methods = methods;
     }
     next();
@@ -36,7 +36,7 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
     });
 
     client.on('error', function (err) {
-        connection.loginfo('auth_ldap: client error ' + err.message);
+        connection.loginfo(`auth_ldap: client error ${err.message}`);
         cb(false);
     });
 
@@ -47,7 +47,7 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
         dn = dn.replace(/%u/g, user);
         client.bind(dn, passwd, function (err) {
             if (err) {
-                connection.loginfo("auth_ldap: (" + dn + ") " + err.message);
+                connection.loginfo(`auth_ldap: (${dn})  ${err.message}`);
                 return callback(false);
             }
             else {


### PR DESCRIPTION
Changes proposed in this pull request:
- replaced concatenated strings with template literals in the plugins/auth/auth_ldap.js


Checklist:
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
