### PR TITLE
connection: set this.local properties

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -529,11 +529,9 @@ class Connection {
 
         let mess;
         let buf = '';
-        const hostname = os.hostname().split('.').shift();
 
         while ((mess = messages.shift())) {
-            let _uuid='';
-            if (uuid) _uuid=`[${uuid}@${hostname}] `;
+            const _uuid = uuid ? `[${uuid}@${os.hostname().split('.').shift()}] ` : '';
             const line = `${code}${(messages.length ? "-" : " ")}${_uuid}${mess}`;
             this.logprotocol(`S: ${line}`);
             buf = `${buf}${line}\r\n`;
@@ -1415,27 +1413,18 @@ class Connection {
             }
         }
 
-        const received_header = [
-            'from ',
-            `${this.hello.host} (`,
-            this.get_remote('info'),
-            ")\n\t",
-            `by ${this.local.host}`
-        ]
+        let received_header = `from ${this.hello.host} (${this.get_remote('info')})\n\tby ${this.local.host}`
 
-        if (!this.header_hide_version) {
-            received_header.push(' (Haraka/', version, ')');
-        }
-        received_header.push(
-            ' with ', smtp,
-            ' id ', this.transaction.uuid,
-            "\n\t",
-            'envelope-from ', this.transaction.mail_from.format(),
-            ((this.authheader) ? ` ${this.authheader.replace(/\r?\n\t?$/, '')}` : ''),
-            ((sslheader) ? `\n\t${sslheader.replace(/\r?\n\t?$/,'')}` : ''),
-            ";\n\t", utils.date_to_str(new Date())
-        )
-        return received_header.join('');
+        if (!this.header_hide_version) received_header += ` (Haraka/${version})`
+
+        received_header += ` with ${smtp} id ${this.transaction.uuid}\n\tenvelope-from ${this.transaction.mail_from.format()}`;
+
+        if (this.authheader) received_header += ` ${this.authheader.replace(/\r?\n\t?$/, '')}`
+        if (sslheader)       received_header += `\n\t${sslheader.replace(/\r?\n\t?$/,'')}`
+
+        received_header += `;\n\t${utils.date_to_str(new Date())}`
+
+        return received_header;
     }
     auth_results (message) {
         // http://tools.ietf.org/search/rfc7001

--- a/connection.js
+++ b/connection.js
@@ -61,7 +61,7 @@ class Connection {
         this.local = {           // legacy property locations
             ip: null,            // c.local_ip
             port: null,          // c.local_port
-            host: config.get('me') || os.hostname(),
+            host: config.get('me'),
         };
         this.remote = {
             ip:   null,          // c.remote_ip

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -48,10 +48,10 @@ exports.connectionRaw = {
         test.done();
     },
     'has local object': function (test) {
-        test.expect(4);
+        test.expect(5);
         test.equal(this.connection.local.ip, null);
         test.equal(this.connection.local.port, null);
-        // test.ok(this.connection.local.host, this.connection.local.host);
+        test.ok(this.connection.local.host, this.connection.local.host);
         // backwards compat, sunset v3.0.0
         test.equal(this.connection.local_ip, null);
         test.equal(this.connection.local_port, null);


### PR DESCRIPTION
Changes proposed in this pull request:
- ~~default to os.hostname() when config/me does not exist~~
    - previously, if config/me didn't exist: `220 null ESMTP Haraka 2.8.16 ready`
- replace most concat strings with template literals
- replace some anon callbacks with arrow functions

Checklist:
- [x] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated