### PR TITLE
connection: replace 3 ternaries with get_remote()

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -26,10 +26,9 @@ const rfc1869     = require('./rfc1869');
 const outbound    = require('./outbound');
 
 const hostname    = (os.hostname().split(/\./))[0];
-const version     = JSON.parse(
-    fs.readFileSync(path.join(__dirname, 'package.json'))).version;
-
-const states = constants.connection.state;
+const hpj         = fs.readFileSync(path.join(__dirname, 'package.json'));
+const version     = JSON.parse(hpj).version;
+const states      = constants.connection.state;
 
 
 // Load HAProxy hosts into an object for fast lookups
@@ -796,6 +795,18 @@ class Connection {
             }
         }
     }
+    get_remote (prop) {
+        switch (this.remote[prop]) {
+            case 'NXDOMAIN':
+            case 'DNSERROR':
+            case '':
+            case undefined:
+            case null:
+                return `[${this.remote.ip}]`;
+            default:
+                return `${this.remote[prop]} [${this.remote.ip}]`;
+        }
+    }
     helo_respond (retval, msg) {
         const self = this;
         switch (retval) {
@@ -825,9 +836,7 @@ class Connection {
                 // RFC5321 section 4.1.1.1
                 // Hostname/domain should appear after 250
                 this.respond(250, config.get('me') + " Hello " +
-                    ((this.remote.host && this.remote.host !== 'DNSERROR' &&
-                    this.remote.host !== 'NXDOMAIN') ? this.remote.host + ' ' : '') +
-                    "[" + this.remote.ip + "]" +
+                    this.get_remote('host') +
                     ", Haraka is at your service.");
         }
     }
@@ -862,9 +871,7 @@ class Connection {
                 // Hostname/domain should appear after 250
                 const response = [
                     config.get('me') + " Hello " +
-                    ((this.remote.host && this.remote.host !== 'DNSERROR' &&
-                    this.remote.host !== 'NXDOMAIN') ? this.remote.host + ' ' : '') +
-                    "[" + this.remote.ip + "]" +
+                    this.get_remote('host') +
                     ", Haraka is at your service.",
                     "PIPELINING",
                     "8BITMIME",
@@ -1415,10 +1422,8 @@ class Connection {
         const received_header = [
             'from ',
             this.hello.host, ' (',
-            // If no rDNS, don't display it
-            ((!/^(?:DNSERROR|NXDOMAIN)/.test(this.remote.info)) ? this.remote.info + ' ' : ''),
-            '[', this.remote.ip, '])',
-            "\n\t",
+            this.get_remote('info'),
+            ")\n\t",
             'by ',
             config.get('me')
         ]
@@ -1531,10 +1536,7 @@ class Connection {
             default:
                 cont = 1;
         }
-
-        if (!cont) {
-            return;
-        }
+        if (!cont) return;
 
         // We already checked for MAIL/RCPT in cmd_data
         this.respond(354, "go ahead, make my day", () => {

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -48,12 +48,10 @@ exports.connectionRaw = {
         test.done();
     },
     'has local object': function (test) {
-        test.expect(3);
-        test.deepEqual(this.connection.local, {
-            ip: null,
-            port: null,
-            host: null,
-        });
+        test.expect(4);
+        test.equal(this.connection.local.ip, null);
+        test.equal(this.connection.local.port, null);
+        // test.ok(this.connection.local.host, this.connection.local.host);
         // backwards compat, sunset v3.0.0
         test.equal(this.connection.local_ip, null);
         test.equal(this.connection.local_port, null);
@@ -201,6 +199,38 @@ exports.connectionPrivate = {
         test.expect(2);
         test.equal(true, this.connection.remote.is_private);
         test.equal(2525, this.connection.remote.port);
+        test.done();
+    },
+}
+
+exports.get_remote = {
+    setUp : _set_up,
+    tearDown : _tear_down,
+    'valid hostname': function (test) {
+        test.expect(1);
+        this.connection.remote.host='a.host.tld'
+        this.connection.remote.ip='172.16.199.198'
+        test.equal(this.connection.get_remote('host'), 'a.host.tld [172.16.199.198]');
+        test.done();
+    },
+    'no hostname': function (test) {
+        test.expect(1);
+        this.connection.remote.ip='172.16.199.198'
+        test.equal(this.connection.get_remote('host'), '[172.16.199.198]');
+        test.done();
+    },
+    'DNSERROR': function (test) {
+        test.expect(1);
+        this.connection.remote.host='DNSERROR'
+        this.connection.remote.ip='172.16.199.198'
+        test.equal(this.connection.get_remote('host'), '[172.16.199.198]');
+        test.done();
+    },
+    'NXDOMAIN': function (test) {
+        test.expect(1);
+        this.connection.remote.host='NXDOMAIN'
+        this.connection.remote.ip='172.16.199.198'
+        test.equal(this.connection.get_remote('host'), '[172.16.199.198]');
         test.done();
     },
 }


### PR DESCRIPTION
replace 3 multiline ternaries with `get_remote()`, which does the needful.