### PR TITLE
Replaced concatenated strings with template literals max_unrecognised…

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,8 @@
     * Fix ability to set log level to emerg #2128
 * Changes
     * config: replace ./config.js with haraka-config #2119
+    * Replaced concatenated strings with template literals max_unrecognised_commands.js #2171
+
 
 ## 2.8.16 - Sep 30, 2017
 

--- a/plugins/max_unrecognized_commands.js
+++ b/plugins/max_unrecognized_commands.js
@@ -13,7 +13,7 @@ exports.hook_connect = function (next, connection) {
 exports.hook_unrecognized_command = function (next, connection, cmd) {
     const plugin = this;
 
-    connection.results.add(plugin, {fail: "Unrecognized command: " + cmd, emit: true});
+    connection.results.add(plugin, {fail: `Unrecognized command: ${cmd}`, emit: true});
     connection.results.incr(plugin, {count: 1});
 
     const uc = connection.results.get('max_unrecognized_commands');


### PR DESCRIPTION
…_commands.js

Changes proposed in this pull request:
- Replaced concatenated strings with template literals max_unrecognised_commands.js

Checklist:
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
