### PR TITLE
 Replace all string concaternation with template literals on plugins/data.frc533_header_checks.js  file

### DIFF
--- a/plugins/data.rfc5322_header_checks.js
+++ b/plugins/data.rfc5322_header_checks.js
@@ -17,16 +17,14 @@ exports.hook_data_post = function (next, connection) {
     // Headers that MUST be present
     for (let i=0,l=required_headers.length; i < l; i++) {
         if (header.get_all(required_headers[i]).length === 0) {
-            return next(DENY, "Required header '" + required_headers[i] +
-                                "' missing");
+            return next(DENY, `Required header '${required_headers[i]}' missing`);
         }
     }
 
     // Headers that MUST be unique if present
     for (let i=0,l=singular_headers.length; i < l; i++) {
         if (header.get_all(singular_headers[i]).length > 1) {
-            return next(DENY, "Message contains non-unique '" +
-                                singular_headers[i] + "' header");
+            return next(DENY, `Message contains non-unique '${singular_headers[i]}' header`);
         }
     }
 


### PR DESCRIPTION
 Replace all string concaternation with template literals on plugins/data.frc533_header_checks.js  file

Fixes #2129 

Checklist:
- [X] docs updated
- [X] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
