### PR TITLE
Set remote.is_private automatically when remote.ip is set

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,7 +18,7 @@
     * replaced concatenated strings with template literals in the plugins/relay_acl.js #2177
     * replaced concatenated strings with template literals in the connection.js #2129
     * replaced concatenated strings with template literals in plugins/toobusy.js #2186
-
+    * Automatically set connection.remote.is_private when connection.remote.ip is set #2192
 
 
 ## 2.8.16 - Sep 30, 2017

--- a/connection.js
+++ b/connection.js
@@ -238,14 +238,13 @@ class Connection {
         }
     }
     set (obj, prop, val) {
-        const self = this;
         if (!this[obj]) this.obj = {};   // initialize
 
         this[obj][prop] = val;  // normalized property location
 
         // Set is_private automatically when remote.ip is set
         if (obj === 'remote' && prop === 'ip') {
-            self.set('remote', 'is_private', net_utils.is_private_ip(self.remote.ip));
+            this.set('remote', 'is_private', net_utils.is_private_ip(this.remote.ip));
         }
 
         // sunset 3.0.0

--- a/connection.js
+++ b/connection.js
@@ -238,7 +238,7 @@ class Connection {
         }
     }
     set (obj, prop, val) {
-        var self = this;
+        const self = this;
         if (!this[obj]) this.obj = {};   // initialize
 
         this[obj][prop] = val;  // normalized property location

--- a/connection.js
+++ b/connection.js
@@ -150,7 +150,6 @@ class Connection {
         }
         self.set('remote', 'ip', ipaddr.process(ip).toString());
         self.set('remote', 'port', self.client.remotePort);
-        self.set('remote', 'is_private', net_utils.is_private_ip(self.remote.ip));
         self.results.add({name: 'remote'}, self.remote);
 
         self.lognotice(
@@ -239,9 +238,15 @@ class Connection {
         }
     }
     set (obj, prop, val) {
+        var self = this;
         if (!this[obj]) this.obj = {};   // initialize
 
         this[obj][prop] = val;  // normalized property location
+
+        // Set is_private automatically when remote.ip is set
+        if (obj === 'remote' && prop === 'ip') {
+            self.set('remote', 'is_private', net_utils.is_private_ip(self.remote.ip));
+        }
 
         // sunset 3.0.0
         if (obj === 'hello' && prop === 'verb') {
@@ -1193,7 +1198,6 @@ class Connection {
             self.set('remote', 'ip', src_ip);
             self.set('remote', 'port', parseInt(src_port, 10));
             self.set('remote', 'host', null);
-            self.set('remote', 'is_private', net_utils.is_private_ip(src_ip));
             self.set('hello', 'host', null);
             plugins.run_hooks('connect_init', self);
         });


### PR DESCRIPTION
Set connection.remote.is_private automatically whenever connection.remote.ip is set.

I noticed that when a host uses XCLIENT, the is_private property isn't set, so reflects the original value - rather than just settings it in xclient.js, I decided it made more sense to do it automagically so there's no way it can happen elsewhere.

Checklist:
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
