### PR TITLE
Base64 encoding

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -422,7 +422,9 @@ Body.prototype.parse_attachment = function (line) {
 Body.prototype.decode_qp = utils.decode_qp;
 
 Body.prototype.decode_base64 = function (line) {
-    let to_process = this.decode_accumulator + line.trim();
+    // Remove all whitespace (such as newlines and errant spaces) from base64
+    // before combining it with any previously unprocessed data.
+    let to_process = this.decode_accumulator + line.trim().replace(/[\s]+/g,'');
 
     // Sometimes base64 data lines will not be aligned with
     // byte boundaries. This is because each char in base64

--- a/tests/mail_specimen/base64-root-part.txt
+++ b/tests/mail_specimen/base64-root-part.txt
@@ -1,0 +1,23 @@
+MIME-Version: 1.0
+Content-Type: text/html;
+Content-Transfer-Encoding: base64
+
+    PCFET0NUWVBFIGh0bWw+CjxodG1sPgo
+8aGVhZD4KCTx0aXRsZT5UaGlzIGlzIG
+EgdGVzdDwvdGl0bGU+CjwvaGVhZD4KP
+GJvZHk+Cgk8Yj5UaGlzIGlzIG9ubHkg
+YSB0ZXN0PC9iPgoJPHA+CglUaGlzIGR
+vY3VtZW50IGRlc2NyaWJlcyB0aGUgY2 
+   9tbW9ubHkgdXNlZCBiYXNlIDY0LCBiY
+XNlIDMyLCBhbmQgYmFzZQoJMTYgZW5j
+b2Rpbmcgc2NoZW1lcy4gIEl0IGFsc28
+gZGlzY3Vzc2VzIHRoZSB1c2Ugb2YgbG
+    luZS1mZWVkcyBpbgoJZW5jb2RlZCBkY
+XRhLCB1c2Ugb2YgcGFkZGluZyBpbiBl
+bmNvZGVkIGRhdGEsIHVzZSBvZiBub24
+tYWxwaGFiZXQKCWNoYXJhY3RlcnMgaW
+4gZW5jb2RlZCBkYXRhLCB1c2Ugb2YgZ
+GlmZmVyZW50IGVuY29kaW5nIGFscGhh
+YmV0cywgYW5kCgljYW5vbmljYWwgZW5
+jb2RpbmdzLgoJPC9wPgo8L2JvZHk+Cj
+wvaHRtbD4=

--- a/tests/transaction.js
+++ b/tests/transaction.js
@@ -155,4 +155,16 @@ exports.base64_handling = {
         }
         test.done();
     },
+
+    'base64-root-html-decodes-correct-number-of-bytes': function (test) {
+        const self = this;
+
+        const parsed_attachments = {};
+        self.transaction.parse_body = true;
+        const specimen_path = path.join(__dirname, 'mail_specimen', 'base64-root-part.txt');
+        write_file_data_to_transaction(self.transaction, specimen_path);
+
+        test.equal(self.transaction.body.bodytext.length, 425);
+        test.done();
+    },
 }


### PR DESCRIPTION
Fixes #2180 

Changes proposed in this pull request:
- Fixes issue when base64 is passed as a mutliline string to the decode function (when a `text/*` part is encoded as base64)

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
