### PR TITLE
Header folding fix

### DIFF
--- a/mailheader.js
+++ b/mailheader.js
@@ -56,7 +56,7 @@ class Header {
     decode_header (val) {
         // unfold continuations, strip the leading
         // space char after the first line
-        let values = val.split(/[\r\n]+/);
+        const values = val.split(/[\r\n]+/);
         val = values.shift();
         while (values.length > 0) {
             val += values.shift().replace(/^[\s]/, '');

--- a/mailheader.js
+++ b/mailheader.js
@@ -54,8 +54,13 @@ class Header {
     }
 
     decode_header (val) {
-        // Fold continuations
-        val = val.replace(/\r?\n/g, '');
+        // unfold continuations, strip the leading
+        // space char after the first line
+        let values = val.split(/[\r\n]+/);
+        val = values.shift();
+        while (values.length > 0) {
+            val += values.shift().replace(/^[\s]/, '');
+        }
 
         const rfc2231_params = {
             kv: {},

--- a/tests/mailheader.js
+++ b/tests/mailheader.js
@@ -14,11 +14,11 @@ const lines = [
     'Content-Transfer-Encoding: 7bit',
     'Mime-Version: 1.0 (1.0)',
     'Subject: Re: Haraka Rocks!',
-    'X-Folded-QP: =?UTF-8?Q?=D0=BF=D1=80=D0=BE=D0=B1=D0=BD=D0=B8?=\r\n =?UTF-8?Q?_=D0=B5=D0=BC=D0=B0=D0=B8=D0=BB_1234?=\n  \tContinued',
     'Message-Id: <616DF75E-D799-4F3C-9901-1642B494C45D@gmail.com>',
     'Date: Thu, 31 Mar 2016 15:51:36 -0400',
     'To: The World <world@example.com>',
     'X-Mailer: iPhone Mail (13E233)',
+    'X-Folded-QP: =?UTF-8?Q?=D0=BF=D1=80=D0=BE=D0=B1=D0=BD=D0=B8?=\r\n =?UTF-8?Q?_=D0=B5=D0=BC=D0=B0=D0=B8=D0=BB_1234?=\n  \tContinued',
 ];
 
 for (let i=0; i<lines.length; i++) {
@@ -30,10 +30,10 @@ exports.basic = {
         test.expect(2);
         const h = new Header();
         h.parse(lines);
-        test.equal(h.lines().length, 12);
+        test.equal(h.lines().length, 13);
         test.equal(
             h.get_decoded('content-type'),
-            'multipart/alternative;   boundary=Apple-Mail-F2C5DAD3-7EB3-409D-9FE0-135C9FD43B69'
+            'multipart/alternative;  boundary=Apple-Mail-F2C5DAD3-7EB3-409D-9FE0-135C9FD43B69'
         );
         test.done();
     },
@@ -41,7 +41,7 @@ exports.basic = {
         test.expect(2);
         const h = new Header();
         h.parse(lines);
-        test.equal(h.lines().length, 12);
+        test.equal(h.lines().length, 13);
         const ct = h.get_decoded('content-type2');
         test.equal(ct, 'multipart/mixed; boundary="nqp=nb64=()I9WT8XjoN"');
         test.done();
@@ -56,7 +56,7 @@ exports.add_headers = {
         h.add('Foo', 'bar');
         test.equal(h.lines()[0], 'Foo: bar\n');
         h.add_end('Fizz', 'buzz');
-        test.equal(h.lines()[13], 'Fizz: buzz\n');
+        test.equal(h.lines()[14], 'Fizz: buzz\n');
         test.done();
     },
     add_utf8: function (test) {

--- a/tests/mailheader.js
+++ b/tests/mailheader.js
@@ -14,6 +14,7 @@ const lines = [
     'Content-Transfer-Encoding: 7bit',
     'Mime-Version: 1.0 (1.0)',
     'Subject: Re: Haraka Rocks!',
+    'X-Folded-QP: =?UTF-8?Q?=D0=BF=D1=80=D0=BE=D0=B1=D0=BD=D0=B8?=\r\n =?UTF-8?Q?_=D0=B5=D0=BC=D0=B0=D0=B8=D0=BB_1234?=\n  \tContinued',
     'Message-Id: <616DF75E-D799-4F3C-9901-1642B494C45D@gmail.com>',
     'Date: Thu, 31 Mar 2016 15:51:36 -0400',
     'To: The World <world@example.com>',
@@ -79,6 +80,13 @@ exports.continuations = {
         const h = new Header();
         h.parse(lines);
         test.ok(!/\n/.test(h.get_decoded('content-type')));
+        test.done();
+    },
+    leading_space_is_stripped_when_unfolding: function (test) {
+        test.expect(1);
+        const h = new Header();
+        h.parse(lines);
+        test.equal(h.get_decoded('X-Folded-QP'), "пробни емаил 1234 \tContinued");
         test.done();
     }
 }


### PR DESCRIPTION
When headers are continued on new lines, the first leading space is not removed from the header content.

This PR correctly strips the first space on folded header lines so that they are not present in the decoded header.


Checklist:
- [ ] docs updated
- [X] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
