### PR TITLE
Fix docs for `Address` objects

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@
     * replaced concatenated strings with template literals in dkim.js #2216
     * replaced concatenated strings with template literals in smtp_client.js #2129
     * Automatically set connection.remote.is_private when connection.remote.ip is set #2192
+    * Fix docs for `Address` objects #2224
 
 
 ## 2.8.16 - Sep 30, 2017

--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -123,8 +123,8 @@ The ToDo Object
 The `todo` object contains information about how to deliver this mail. Keys
 you may be interested in are:
 
-* rcpt_to - an Array of Address objects - the rfc.2821 recipients of this mail
-* mail_from - an Address object - the rfc.2821 sender of this mail
+* rcpt_to - an Array of `Address`[1] objects - the rfc.2821 recipients of this mail
+* mail_from - an `Address`[1] object - the rfc.2821 sender of this mail
 * domain - the domain this mail is going to (see `always_split` above)
 * notes - the original transaction.notes for this mail, also contains the
   following useful keys:
@@ -234,7 +234,7 @@ that received the message and will typically contain the remote queue ID and
 message being delivered.
 * `port` - Port number that the message was delivered to.
 * `mode` - Shows whether SMTP or LMTP was used to deliver the mail.
-* `ok_recips` - an Address array containing all of the recipients that were
+* `ok_recips` - an `Address`[1] array containing all of the recipients that were
 successfully delivered to.
 * `secured` - A boolean denoting if the connection used TLS or not.
 
@@ -361,3 +361,5 @@ In case you need notes in the new transaction that `send_email()` creates, you s
 ```notes``` option, like so:
 
     outbound.send_email(from, to, contents, outnext, { notes: transaction.notes });
+
+[1]: `Address` objects are address-rfc2821 objects. See https://github.com/haraka/node-address-rfc2821

--- a/docs/Transaction.md
+++ b/docs/Transaction.md
@@ -13,11 +13,11 @@ where N increments for each transaction on this connection.
 
 * transaction.mail\_from
 
-The value of the MAIL FROM command as an `Address` object.
+The value of the MAIL FROM command as an `Address`[1] object.
 
 * transaction.rcpt\_to
 
-An Array of `Address` objects of recipients from the RCPT TO command.
+An Array of `Address`[1] objects of recipients from the RCPT TO command.
 
 * transaction.message\_stream
 
@@ -161,3 +161,5 @@ body in the same encoding.
 * transaction.results
 
 Store results of processing in a structured format. See [docs/Results](http://haraka.github.io/manual/Results.html)
+
+[1]: `Address` objects are address-rfc2821 objects. See https://github.com/haraka/node-address-rfc2821


### PR DESCRIPTION
Fixes #2220

Changes proposed in this pull request:
- Link references to `Address` objects to the node module behind them.

Checklist:
- [x] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
