### PR TITLE
SMTPS port

### DIFF
--- a/docs/CoreConfig.md
+++ b/docs/CoreConfig.md
@@ -23,8 +23,8 @@ The list of plugins to load
 
   Keys:
 
-  * port - the port to use (default: 25)
-  * listen\_address - default: 0.0.0.0 (i.e. all addresses)
+  * listen\_host, port - the host and port to listen on (default: ::0 and 25)
+  * listen - (default: [::0]:25) Comma separated IP:Port addresses to listen on
   * inactivity\_time - how long to let clients idle in seconds (default: 300)
   * nodes - if [cluster][1] is available, specifies how
     many processes to fork off. Can be the string "cpus" to fork off as many

--- a/server.js
+++ b/server.js
@@ -362,6 +362,7 @@ Server.get_smtp_server = function (host, port, inactivity_timeout, done) {
     }
     else {
         server = tls_socket.createServer(onConnect);
+        server.has_tls = false;
         Server.listeners.push(server);
         done(server);
     }

--- a/server.js
+++ b/server.js
@@ -41,6 +41,7 @@ Server.load_smtp_ini = function () {
         daemon_log_file: '/var/log/haraka.log',
         daemon_pid_file: '/var/run/haraka.pid',
         force_shutdown_timeout: 30,
+        smtps_port: 465,
     };
 
     for (const key in defaults) {
@@ -345,10 +346,10 @@ Server.get_smtp_server = function (host, port, inactivity_timeout, done) {
         });
     }
 
-    if (port === '465') {
+    if (port === Server.cfg.main.smtps_port) {
         logger.loginfo('getting SocketOpts for SMTPS server');
         tls_socket.getSocketOpts('*', opts => {
-            logger.loginfo(`Creating TLS server on ${host}:465`);
+            logger.loginfo(`Creating TLS server on ${host}:${Server.cfg.main.smtps_port}`);
             server = tls.createServer(opts, onConnect);
             tls_socket.addOCSP(server);
             server.has_tls=true;
@@ -380,7 +381,7 @@ Server.setup_smtp_listeners = function (plugins2, type, inactivity_timeout) {
                 new Error('Invalid "listen" format in smtp.ini'));
 
             const host = hp[1];
-            const port = hp[2];
+            const port = parseInt(hp[2], 10);
 
             Server.get_smtp_server(host, port, inactivity_timeout, (server) => {
                 if (!server) return listenerDone();

--- a/tests/server.js
+++ b/tests/server.js
@@ -100,23 +100,22 @@ exports.get_smtp_server = {
         done();
     },
     'gets a net server object': function (test) {
-        let server;
-        try { server = this.server.get_smtp_server('0.0.0.0', 2501, 10); }
-        catch (ignore) {
-            test.done();
-            return;
-        }
-        if (!server) {   // can't bind to IP/port (fails on Travis)
-            console.error('unable to bind to 0.0.0.0:2501')
-            // test.expect(0);
-            test.done();
-            return;
-        }
-        test.expect(2);
-        test.ok(server);
-        server.getConnections(function (err, count) {
-            test.equal(0, count);
-            test.done();
+        this.server.get_smtp_server('0.0.0.0', 2501, 10, (server) => {
+            if (!server) {
+                console.error('unable to bind to 0.0.0.0:2501');
+                // test.expect(0);
+                if (process.env.CI) { // can't bind to IP/port (fails on Travis)
+                    test.done();
+                    return;
+                }
+            }
+            test.expect(3);
+            test.ok(server);
+            test.equal(server.has_tls, false);
+            server.getConnections(function (err, count) {
+                test.equal(0, count);
+                test.done();
+            });
         });
     }
 };

--- a/tests/server.js
+++ b/tests/server.js
@@ -97,7 +97,7 @@ exports.get_smtp_server = {
         this.server.config = this.config.module_config(path.resolve('tests'));
         this.server.plugins.config = this.config.module_config(path.resolve('tests'));
 
-        done();
+        this.server.load_default_tls_config(() => done());
     },
     'gets a net server object': function (test) {
         this.server.get_smtp_server('0.0.0.0', 2501, 10, (server) => {
@@ -112,6 +112,26 @@ exports.get_smtp_server = {
             test.expect(3);
             test.ok(server);
             test.equal(server.has_tls, false);
+            server.getConnections(function (err, count) {
+                test.equal(0, count);
+                test.done();
+            });
+        });
+    },
+    'gets a TLS net server object': function (test) {
+        this.server.cfg.main.smtps_port = 2502;
+        this.server.get_smtp_server('0.0.0.0', 2502, 10, (server) => {
+            if (!server) {
+                console.error('unable to bind to 0.0.0.0:2502');
+                // test.expect(0);
+                if (process.env.CI) { // can't bind to IP/port (fails on Travis)
+                    test.done();
+                    return;
+                }
+            }
+            test.expect(3);
+            test.ok(server);
+            test.equal(server.has_tls, true);
             server.getConnections(function (err, count) {
                 test.equal(0, count);
                 test.done();


### PR DESCRIPTION
Fixes #2268

Changes proposed in this pull request:
- SMTPS port is now configurable using the `smtps_port` option in smtp.ini
- Fix get_smtp_server test (it is incorrectly passing now)

Checklist:
- [ X ] docs updated
- [ X ] tests updated
- [ X ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
