### PR TITLE
replaces string concaternation with template literals on logger.js

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -103,8 +103,7 @@ logger.load_log_ini = function () {
 
 logger.colorize = function (color, str) {
     if (!util.inspect.colors[color]) { return str; }  // unknown color
-    return '\u001b[' + util.inspect.colors[color][0] + 'm' + str +
-           '\u001b[' + util.inspect.colors[color][1] + 'm';
+    return `\u001b[${util.inspect.colors[color][0]}m${str}\u001b[${util.inspect.colors[color][1]}m`;
 };
 
 logger.dump_logs = function (cb) {


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- Refactor logger.js to change all string concatenations to template literals.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
