### PR TITLE
Replace string concatenations with template literals in bin/dkimverify

### DIFF
--- a/bin/dkimverify
+++ b/bin/dkimverify
@@ -24,10 +24,7 @@ const verifier = new DKIMVerifyStream(function (err, result, results) {
     if (err) console.log(err.message);
     if (Array.isArray(results)) {
         results.forEach(function (res) {
-            console.log('identity="' + res.identity + '" ' +
-                        'domain="' + res.domain + '" ' +
-                        'result=' + res.result + ' ' +
-                        ((res.error) ? '(' + res.error + ')' : ''));
+            console.log(`identity="${res.identity}" domain="${res.domain}" result=${res.result} ${(res.error) ? `(${res.error})` : ''}`);
         });
     }
     else {


### PR DESCRIPTION
updates #2129 

Changes proposed in this pull request:
- Use template literals in bin/dkimverify

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
