### PR TITLE
dkim: revert destructuring assignment, it handles null badly

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -1085,7 +1085,7 @@ class Connection {
             return;
         }
         const rcpt = this.transaction.rcpt_to[this.transaction.rcpt_to.length - 1];
-        const dmsg = `recipient rcpt.format()`;
+        const dmsg = `recipient ${rcpt.format()}`;
         if (retval !== constants.ok) {
             this.lognotice(
                 dmsg,

--- a/dkim.js
+++ b/dkim.js
@@ -498,12 +498,13 @@ class DKIMVerifyStream extends Stream {
                     this._in_body = true;
                     // Parse the headers
                     for (let h=0; h<this.headers.length; h++) {
-                        const [ , header_name] = /^([^: ]+):\s*((:?.|[\r\n])*)/.exec(this.headers[h]);
-                        if (header_name) {
-                            const hn = header_name.toLowerCase();
-                            if (!this.header_idx[hn]) this.header_idx[hn] = [];
-                            this.header_idx[hn].push(this.headers[h]);
-                        }
+                        const match = /^([^: ]+):\s*((:?.|[\r\n])*)/.exec(this.headers[h]);
+                        if (!match) continue;
+                        const header_name = match[1];
+                        if (!header_name) continue;
+                        const hn = header_name.toLowerCase();
+                        if (!this.header_idx[hn]) this.header_idx[hn] = [];
+                        this.header_idx[hn].push(this.headers[h]);
                     }
                     if (!this.header_idx['dkim-signature']) {
                         this._no_signatures_found = true;


### PR DESCRIPTION
- correct a crasher due to destructuring assignment's lack of null handling
- add missing `${}` around a string literal

fixes #2286
