### PR TITLE
fixed issue with logging redis DB errors

### DIFF
--- a/plugins/greylist.js
+++ b/plugins/greylist.js
@@ -546,7 +546,9 @@ exports.promote_to_white = function (connection, grey_rec, cb) {
             throw err;
         }
         plugin.db.expire(white_key, white_ttl, function (err2, result2) {
-            plugin.lognotice(`DB error: ${util.inspect(err2)}`);
+            if (err2) {
+                plugin.lognotice(`DB error: ${util.inspect(err2)}`);
+            }
             return cb(err2, result2);
         });
     });


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- Resolve unnecessary log entries. This plugin was creating a log entry for every greylist DB key that was promoted to white, even when err2 was equal to null.


Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated