### PR TITLE
Fix smtp_client error handling

### DIFF
--- a/smtp_client.js
+++ b/smtp_client.js
@@ -157,9 +157,12 @@ class SMTPClient extends events.EventEmitter {
                     error = '';
                 }
                 // msg is e.g. "errored" or "timed out"
-                // error is e.g. "Error: connect ECONNREFUSE"
+                // error is e.g. "Error: connect ECONNREFUSED"
                 const errMsg = `${client.uuid}: [${client.host}:${client.port}] ` +
                     `SMTP connection ${msg} ${error}`;
+                if (client.state === STATE.ACTIVE) {
+                    client.emit('error', errMsg);
+                }
                 switch (client.state) {
                     case STATE.ACTIVE:
                     case STATE.IDLE:
@@ -167,10 +170,6 @@ class SMTPClient extends events.EventEmitter {
                         client.destroy();
                         break;
                     default:
-                }
-                if (client.state === STATE.ACTIVE) {
-                    client.emit('error', errMsg);
-                    return;
                 }
                 if ((msg === 'errored' || msg === 'timed out')
                       && client.state === STATE.DESTROYED){


### PR DESCRIPTION
I found this issue when tracing a problem in some code where I was using smtp_client.

I had a case of an SMTP host that was down, but my `smtp_client.on('error')` code block was not being called and therefore `next()` wasn't being called, so the plugin always timed out instead of being correctly trapped.

The issue was that the `switch()` block would always call `client.destroy()` which would in turn set the state to `STATE.DESTROYED` so the `if (client.state === STATE.ACTIVE)` would never ever be true.

I've therefore re-ordered the statements and removed the return as calling `client.destroy()` should not do any other harm.

This fixed my issue.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
