### PR TITLE
Corrected config file name in docs

### DIFF
--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -79,7 +79,7 @@ Configuration
 
   * check_recipient=false
 
-    By default, Haraka accepts no emails until a recipient plugin has been configured to accept mails for a domain. The simplest common case is the in_host_list plugin with a list of domains in config/host_host. An alternative is to set `check_recipient=true` and list each domain in a definition block in smtp_forward.ini (see Per-Domain Configuration). An example for two domains:
+    By default, Haraka accepts no emails until a recipient plugin has been configured to accept mails for a domain. The simplest common case is the in_host_list plugin with a list of domains in config/host_list. An alternative is to set `check_recipient=true` and list each domain in a definition block in smtp_forward.ini (see Per-Domain Configuration). An example for two domains:
 
     [example.com]
     [example.net]


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- corrected spelling of config/host_list
