### PR TITLE
Adding ENOTFOUND to also check A record

### DIFF
--- a/outbound/mx_lookup.js
+++ b/outbound/mx_lookup.js
@@ -23,7 +23,7 @@ exports.lookup_mx = function lookup_mx (domain, cb) {
     let wrap_mx = function (a) { return a; };
     const process_dns = function (err, addresses) {
         if (err) {
-            if (err.code === 'ENODATA') {
+            if (err.code === 'ENODATA' || err.code === 'ENOTFOUND') {
                 // Most likely this is a hostname with no MX record
                 // Drop through and we'll get the A record instead.
                 return 0;


### PR DESCRIPTION
I've found problem when working with Docker DNS system - please see https://github.com/docker/libnetwork/issues/2026 

Since docker implements only basic records, it responds to any MX request with NXDOMAIN (ENOTFOUND at node) so it is basicaly impossible to create two communicating containers with haraka. It is bug of Docker only (I have not seen any other DNS servers doing same thing) so please close if you think Haraka should remain strict at this...

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
