### PR TITLE
only generate dhparam.pem once

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,12 @@
 'use strict';
 // smtp network server
 
+const daemon      = require('daemon');
+const fs          = require('fs');
+const os          = require('os');
+const path        = require('path');
+const tls         = require('tls');
+
 // let log = require('why-is-node-running');
 const tls_socket  = require('./tls_socket');
 const conn        = require('./connection');
@@ -8,12 +14,8 @@ const outbound    = require('./outbound');
 const async       = require('async');
 const cluster     = require('cluster');
 const constants   = require('haraka-constants');
-const daemon      = require('daemon');
-const os          = require('os');
-const path        = require('path');
-const tls         = require('tls');
 
-const Server        = exports;
+const Server      = exports;
 Server.logger     = require('./logger');
 Server.config     = require('haraka-config');
 Server.plugins    = require('./plugins');
@@ -71,7 +73,7 @@ Server.daemonize = function () {
         logger.lognotice('Daemonizing...');
     }
 
-    const log_fd = require('fs').openSync(c.daemon_log_file, 'a');
+    const log_fd = fs.openSync(c.daemon_log_file, 'a');
     daemon({ cwd: process.cwd(), stdout: log_fd });
 
     // We are the daemon from here on...

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -3,15 +3,18 @@
 /* Obtained and modified from http://js.5sh.net/starttls.js on 8/18/2011.   */
 /*--------------------------------------------------------------------------*/
 
-const async     = require('async');
-const tls       = require('tls');
-const util      = require('util');
+// node.js built-ins
+const cluster   = require('cluster');
 const net       = require('net');
-const openssl   = require('openssl-wrapper').exec;
 const path      = require('path');
 const spawn     = require('child_process').spawn;
 const stream    = require('stream');
+const tls       = require('tls');
+const util      = require('util');
 
+// npm packages
+const async     = require('async');
+const openssl   = require('openssl-wrapper').exec;
 exports.config  = require('haraka-config');  // exported for tests
 
 const log       = require('./logger');
@@ -509,6 +512,8 @@ exports.ensureDhparams = done => {
 
     const filePath = tlss.cfg.main.dhparam || 'dhparams.pem';
     const fpResolved = path.resolve(exports.config.root_path, filePath);
+
+    if (cluster.isWorker) return; // only once, on the master process
 
     log.loginfo(`Generating a 2048 bit dhparams file at ${fpResolved}`);
 


### PR DESCRIPTION
Currently, if dhparam.pem is missing, it is autogenerated. If Haraka is started in cluster mode, each process generates the file.

* This change restricts the autogeneration to the master process so it's only performed once.
* and arranges a few deps in source/alpha order