### PR TITLE
Add "origin" option to outbound.send_mail for better bounce tracking

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -65,6 +65,7 @@
         * outbound/hmail #2197
     * Automatically set connection.remote.is_private when connection.remote.ip is set #2192
     * Add remove_msgid and remove_date options to outbound.send_email #2209
+    * Add origin option to outbound.send_mail #2314
 
 
 ## 2.8.16 - Sep 30, 2017

--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -360,6 +360,7 @@ Where `options` is a Object that may contain the following keys:
 | `notes: { key: value}` | In case you need notes in the new transaction that `send_email()` creates. |
 | `remove_msgid: true`   | Remove any Message-Id header found in the message.  If you are reading a message in from the filesystem and you want to ensure that a generated Message-Id header is used in preference over the original.  This is useful if you are releasing mail from a quarantine. |
 | `remove_date: true`    | Remove any Date header found in the message.  If you are reading a message in from the filesystem and you want to ensure that a generated Date header is used in preference over the original.  This is useful if you are releasing mail from a quarantine. |
+| `origin: Object`       | Adds object as argument to logger.log calls inside outbound.send_email. Useful for tracking which Plugin/Connection/HMailItem object generated email. | 
 
 
     outbound.send_email(from, to, contents, outnext, { notes: transaction.notes });

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -1195,7 +1195,7 @@ class HMailItem extends events.EventEmitter {
                     return self.double_bounce("Unable to queue the bounce message. Not sending bounce!");
                 }
                 self.discard();
-            });
+            }, {origin: this});
         });
     }
 

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -80,12 +80,13 @@ exports.send_email = function () {
 
     const dot_stuffed = options.dot_stuffed ? options.dot_stuffed : false;
     const notes = options.notes ? options.notes : null;
+    const origin = options.origin ? options.origin : null;
 
-    logger.loginfo("[outbound] Sending email via params");
+    logger.loginfo("[outbound] Sending email via params", origin);
 
     const transaction = trans.createTransaction();
 
-    logger.loginfo(`[outbound] Created transaction: ${transaction.uuid}`);
+    logger.loginfo(`[outbound] Created transaction: ${transaction.uuid}`, origin);
 
     //Adding notes passed as parameter
     if (notes) {


### PR DESCRIPTION
Right now when bounce is generated there is no easy way to connect newly generated transaction with original so I've added new option to send_email that will be passed to log calls.

Changes proposed in this pull request:
- new "origin" option at outbound.send_email
- updated HMailItem to generate bounce with this option

Checklist:
- [x] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
