### PR TITLE
add openssl-wrapper as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "haraka-results"        : "^2.0.0",
     "haraka-tld"            : "*",
     "haraka-utils"          : "*",
-    "mkdirp"                : "~0.5.1"
+    "mkdirp"                : "~0.5.1",
+    "openssl-wrapper"       : "^0.3.4"
   },
   "optionalDependencies": {
     "haraka-plugin-access"  : "*",


### PR DESCRIPTION
- used in tls_socket.js. Required by the TLS cert dir that extracts cert data from the .pem files.
- it should have come over with the TLS consolidation to tls_socket.js
- syntax cleanups in tls_socket.js