### PR TITLE
Fix typo

### DIFF
--- a/smtp_client.js
+++ b/smtp_client.js
@@ -271,7 +271,7 @@ class SMTPClient extends events.EventEmitter {
                     ` verified=${verified}` +
                     ((verifyError) ? ` error="${verifyError}"` : '') +
                     ((cert && cert.subject) ? ` cn="${cert.subject.CN}" organization="${cert.subject.O}"` : '') +
-                    ((cert && cert.issuer) ? ` issuer="${cert.issue.O}"` : '') +
+                    ((cert && cert.issuer) ? ` issuer="${cert.issuer.O}"` : '') +
                     ((cert && cert.valid_to) ? ` expires="${cert.valid_to}"` : '') +
                     ((cert && cert.fingerprint) ? ` fingerprint=${cert.fingerprint}` : ''));
         });


### PR DESCRIPTION
Fixes #
Fix a crash when logging is enabled.

```
2018-02-06T19:47:40.331Z [CRIT] [-] [core] TypeError: Cannot read property 'O' of undefined
2018-02-06T19:47:40.332Z [CRIT] [-] [core]     at socket.upgrade (/app/haraka/smtp_client.js:274:68)
2018-02-06T19:47:40.332Z [CRIT] [-] [core]     at TLSSocket.<anonymous> (/app/haraka/tls_socket.js:684:22)
2018-02-06T19:47:40.332Z [CRIT] [-] [core]     at emitNone (events.js:86:13)
2018-02-06T19:47:40.332Z [CRIT] [-] [core]     at TLSSocket.emit (events.js:185:7)
2018-02-06T19:47:40.332Z [CRIT] [-] [core]     at TLSSocket.<anonymous> (_tls_wrap.js:1109:16)
2018-02-06T19:47:40.332Z [CRIT] [-] [core]     at emitNone (events.js:91:20)
2018-02-06T19:47:40.332Z [CRIT] [-] [core]     at TLSSocket.emit (events.js:185:7)
2018-02-06T19:47:40.332Z [CRIT] [-] [core]     at TLSSocket._finishInit (_tls_wrap.js:610:8)
2018-02-06T19:47:40.332Z [CRIT] [-] [core]     at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:440:38)
```
