### PR TITLE
smtp_forward: enable_outbound can be set per domain

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@
     * outbound/hmail: make haraka queue files human friendly #2231
     * plugins/rcpt_to.ldap -> haraka-plugin-rcpt-ldap #2144
     * plugins/auth/auth_ldap -> haraka-plugin-auth-ldap #2144
+    * plugins/smtp_forward: enable_outbound can be enabled/disabled for specific domains
     * auth_proxy: read TLS key and cert files from tls.ini #2212
     * README: typo fixes #2210
     * incorrect RCPT TO reply message #2227

--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -90,6 +90,9 @@ More specific forward routes for domains can be defined. More specific routes
 are only honored for SMTP connections with a single recipient or SMTP
 connections where every recipient host is identical.
 
+enable\_outbound can be set or unset on a per-domain level to enable or disable
+forwarding for specific domains.
+
     # default SMTP host
     host=1.2.3.4
     # auth_type=plain
@@ -108,6 +111,8 @@ connections where every recipient host is identical.
     [example3.com]
     host=1.2.3.6
 
+    [example4.com]
+    enable\_outbound=false
 
 # Split host forward routing
 

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -26,9 +26,7 @@ exports.register = function () {
 
     plugin.register_hook('queue', 'queue_forward');
 
-    if (plugin.cfg.main.enable_outbound) {
-        plugin.register_hook('queue_outbound', 'queue_forward');
-    }
+    plugin.register_hook('queue_outbound', 'queue_forward');
 };
 
 exports.load_smtp_forward_ini = function () {
@@ -42,6 +40,7 @@ exports.load_smtp_forward_ini = function () {
             '-main.check_sender',
             '-main.check_recipient',
             '*.enable_tls',
+            '*.enable_outbound'
         ],
     },
     function () {
@@ -60,6 +59,14 @@ exports.get_config = function (connection) {
     if (!plugin.cfg[dom]) return plugin.cfg.main;  // no specific route
 
     return plugin.cfg[dom];
+};
+
+exports.is_outbound_enabled = function (cfg) {
+    const plugin = this;
+
+    if ('enable_outbound' in cfg) return cfg.enable_outbound; // pick up per-domain flag if set
+
+    return plugin.cfg.main.enable_outbound; // follow the global configuration
 };
 
 exports.check_sender = function (next, connection, params) {
@@ -208,6 +215,11 @@ exports.queue_forward = function (next, connection) {
     }
 
     const cfg = plugin.get_config(connection);
+
+    if (connection.relaying && !plugin.is_outbound_enabled(cfg)) {
+        connection.logdebug(plugin, 'skipping, outbound disabled');
+        return next();
+    }
 
     smtp_client_mod.get_client_plugin(plugin, connection, cfg, function (err, smtp_client) {
         smtp_client.next = next;

--- a/tests/plugins/queue/smtp_forward.js
+++ b/tests/plugins/queue/smtp_forward.js
@@ -138,3 +138,37 @@ exports.get_mx = {
         this.plugin.get_mx(cb, hmail, 'test.com');
     },
 }
+
+exports.is_outbound_enabled = {
+    setUp : _setup,
+    'enable_outbound is true by default' : function (test) {
+        test.expect(1);
+        test.equal(this.plugin.is_outbound_enabled(this.plugin.cfg), true);
+        test.done();
+    },
+    'per-domain enable_outbound is true by default' : function (test) {
+        test.expect(1);
+        this.connection.transaction.rcpt_to = [ new Address('<postmaster@test.com>') ];
+        const cfg = this.plugin.get_config(this.connection);
+        test.equal(this.plugin.is_outbound_enabled(cfg), true);
+        test.done();
+    },
+    'per-domain enable_outbound can be set to false' : function (test) {
+        test.expect(1);
+        this.plugin.cfg['test.com'].enable_outbound = false;
+        this.connection.transaction.rcpt_to = [ new Address('<postmaster@test.com>') ];
+        const cfg = this.plugin.get_config(this.connection);
+        test.equal(this.plugin.is_outbound_enabled(cfg), false);
+        test.done();
+    },
+    'per-domain enable_outbound is true even if top level is false' : function (test) {
+        test.expect(1);
+        this.plugin.cfg.main.enable_outbound = false; // this will be ignored
+        this.plugin.cfg['test.com'].enable_outbound = true;
+        this.connection.transaction.rcpt_to = [ new Address('<postmaster@test.com>') ];
+        const cfg = this.plugin.get_config(this.connection);
+        test.equal(this.plugin.is_outbound_enabled(cfg), true);
+        test.done();
+    }
+}
+


### PR DESCRIPTION
Fixes #
enable_outbound can be set per domain

Changes proposed in this pull request:
When haraka is managing multiple domains, it is sometimes desirable to use the mail relay only for specific domains. By making the enable_outbound flag per domain, we can disable the relay and use Haraka's internal MX based delivery.

Checklist:
[X] docs updated
[X] tests updated
[X ] Changes updated

