### PR TITLE
Consistent end of function declaration semicolon

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -7,4 +7,7 @@ plugins:
 
 root: true
 
+rules:
+  semi-style: [error, last]
+
 extends: ["eslint:recommended", "plugin:haraka/recommended"]

--- a/attachment_stream.js
+++ b/attachment_stream.js
@@ -104,4 +104,4 @@ class AttachmentStream extends Stream {
 
 exports.createStream = function (header) {
     return new AttachmentStream (header);
-};
+}

--- a/bin/haraka
+++ b/bin/haraka
@@ -41,7 +41,7 @@ const knownOpts = {
     "dump-stream": Boolean,
     "skip-deny":   Boolean,
     "set-relay":   Boolean,
-};
+}
 const shortHands = {
     "v": ["--version"],
     "h": ["--help"],
@@ -52,7 +52,7 @@ const shortHands = {
     "f": ["--force"],
     "o": ["--order"],
     "t": ["--test"],
-};
+}
 const parsed = nopt(knownOpts, shortHands, process.argv, 2);
 
 const usage = [

--- a/connection.js
+++ b/connection.js
@@ -1585,7 +1585,7 @@ class Connection {
 
         // Warn if we hit the maximum parsed header lines limit
         if (this.transaction.header_lines.length >= trans.MAX_HEADER_LINES) {
-            this.logwarn(`Incoming message reached maximum parsing limit of ${max_lines} header lines`);
+            this.logwarn(`Incoming message reached maximum parsing limit of ${trans.MAX_HEADER_LINES} header lines`);
         }
 
         this.auth_results_clean();   // rename old A-R headers
@@ -1846,7 +1846,7 @@ exports.Connection = Connection;
 
 exports.createConnection = (client, server) => {
     return new Connection(client, server);
-};
+}
 
 // copy logger methods into Connection:
 for (const key in logger) {

--- a/http/Gruntfile.js
+++ b/http/Gruntfile.js
@@ -4,8 +4,8 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-bower-install-simple');
     grunt.loadNpmTasks('grunt-bower');
 
-    var bpSrc = [];
-    var bpDest = [];
+    const bpSrc = [];
+    const bpDest = [];
     [
         "404.html",
         "apple-touch-icon.png",
@@ -69,4 +69,4 @@ module.exports = function (grunt) {
     });
 
     grunt.registerTask('default', ['bower-install-simple', 'bower']);
-};
+}

--- a/line_socket.js
+++ b/line_socket.js
@@ -52,4 +52,4 @@ exports.connect = function (port, host, cb) {
     const sock = tls_socket.connect(options, cb);
     setup_line_processor(sock);
     return sock;
-};
+}

--- a/logger.js
+++ b/logger.js
@@ -47,7 +47,7 @@ logger.levels = {
     CRIT:     2,
     ALERT:    1,
     EMERG:    0,
-};
+}
 
 for (const le in logger.levels) {
     logger.levels[`LOG${le}`] = logger.levels[le];
@@ -57,7 +57,7 @@ for (const le in logger.levels) {
 logger.formats = {
     DEFAULT: "DEFAULT",
     LOGFMT: "LOGFMT",
-};
+}
 
 logger.loglevel      = logger.levels.WARN;
 logger.format        = logger.formats.DEFAULT;
@@ -75,7 +75,7 @@ logger.colors = {
     "CRIT" : "red",
     "ALERT" : "red",
     "EMERG" : "red",
-};
+}
 
 const stdout_is_tty = tty.isatty(process.stdout.fd);
 
@@ -104,7 +104,7 @@ logger.load_log_ini = function () {
 logger.colorize = function (color, str) {
     if (!util.inspect.colors[color]) { return str; }  // unknown color
     return `\u001b[${util.inspect.colors[color][0]}m${str}\u001b[${util.inspect.colors[color][1]}m`;
-};
+}
 
 logger.dump_logs = function (cb) {
     while (logger.deferred_logs.length > 0) {
@@ -114,7 +114,7 @@ logger.dump_logs = function (cb) {
     // Run callback after flush
     if (cb) process.stdout.write('', cb);
     return true;
-};
+}
 
 if (!util.isFunction) {
     util.isFunction = function (functionToCheck) {
@@ -155,7 +155,7 @@ logger.log = function (level, data) {
 
     plugins.run_hooks('log', logger, item );
     return true;
-};
+}
 
 logger.log_respond = function (retval, msg, data) {
     // any other return code is irrelevant
@@ -172,7 +172,7 @@ logger.log_respond = function (retval, msg, data) {
 
     process.stdout.write(`${timestamp_string}${data.data}\n`);
     return true;
-};
+}
 
 logger.set_loglevel = function (level) {
     if (level === undefined || level === null) return;
@@ -204,7 +204,7 @@ logger.set_format = function (format) {
         this.log('WARN', `invalid log format: ${format} defaulting to DEFAULT`);
         logger.format = logger.formats.DEFAULT;
     }
-};
+}
 
 logger._init_loglevel = function () {
     const self = this;
@@ -219,7 +219,7 @@ logger._init_loglevel = function () {
 logger.would_log = function (level) {
     if (logger.loglevel < level) { return false; }
     return true;
-};
+}
 
 logger.set_timestamps = function (value) {
     logger.timestamps = !!value;
@@ -235,7 +235,7 @@ logger._init_timestamps = function () {
     // If we've already been toggled to true by the cfg, we should respect
     // this.
     self.set_timestamps(logger.timestamps || _timestamps);
-};
+}
 
 logger._init();
 
@@ -307,7 +307,7 @@ logger.log_if_level = function (level, key, plugin) {
                 return true;
         }
     };
-};
+}
 
 logger.add_log_methods = function (object, plugin) {
     if (!object) return;
@@ -317,7 +317,7 @@ logger.add_log_methods = function (object, plugin) {
         if (object[fname]) continue;  // already added
         object[fname] = logger.log_if_level(level, 'LOG'+level, plugin);
     }
-};
+}
 
 logger.add_log_methods(logger);
 

--- a/outbound/fsync_writestream.js
+++ b/outbound/fsync_writestream.js
@@ -40,7 +40,7 @@ FsyncWriteStream.prototype.close = function (cb) {
             }
         });
     }
-};
+}
 
 module.exports = FsyncWriteStream;
 

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -170,7 +170,7 @@ exports.send_email = function () {
     }
 
     this.send_trans_email(transaction, next);
-};
+}
 
 function stream_line_reader (stream, transaction, cb) {
     let current_data = '';
@@ -286,7 +286,7 @@ exports.send_trans_email = function (transaction, next) {
     }
 
     plugins.run_hooks('pre_send_trans_email', connection);
-};
+}
 
 exports.process_delivery = function (ok_paths, todo, hmails, cb) {
     const self = this;
@@ -321,7 +321,7 @@ exports.process_delivery = function (ok_paths, todo, hmails, cb) {
     self.build_todo(todo, ws, function () {
         todo.message_stream.pipe(ws, { line_endings: '\r\n', dot_stuffing: true, ending_dot: false });
     });
-};
+}
 
 exports.build_todo = function (todo, ws, write_more) {
 
@@ -339,7 +339,7 @@ exports.build_todo = function (todo, ws, write_more) {
     }
 
     ws.once('drain', write_more);
-};
+}
 
 // Replacer function to exclude items from the queue file header
 function exclude_from_json (key, value) {

--- a/outbound/mx_lookup.js
+++ b/outbound/mx_lookup.js
@@ -62,4 +62,4 @@ exports.lookup_mx = function lookup_mx (domain, cb) {
             cb(err2);
         });
     });
-};
+}

--- a/outbound/qfile.js
+++ b/outbound/qfile.js
@@ -96,4 +96,4 @@ const _qfile = module.exports = {
     },
 
     platformDOT : platform_dot
-};
+}

--- a/outbound/queue.js
+++ b/outbound/queue.js
@@ -48,16 +48,16 @@ let queue_count = 0;
 
 exports.get_stats = function () {
     return in_progress + '/' + exports.delivery_queue.length() + '/' + exports.temp_fail_queue.length();
-};
+}
 
 exports.list_queue = function (cb) {
     exports._load_cur_queue(null, "_list_file", cb);
-};
+}
 
 exports._stat_file = function (file, cb) {
     queue_count++;
     setImmediate(cb);
-};
+}
 
 exports.stat_queue = function (cb) {
     const self = exports;
@@ -65,7 +65,7 @@ exports.stat_queue = function (cb) {
         if (err) return cb(err);
         return cb(null, self.stats());
     });
-};
+}
 
 exports.load_queue = function (pid) {
     // Initialise and load queue
@@ -73,7 +73,7 @@ exports.load_queue = function (pid) {
     // so we create the queue directory if it doesn't already exist.
     exports.ensure_queue_dir();
     exports._load_cur_queue(pid, "_add_file");
-};
+}
 
 exports._load_cur_queue = function (pid, cb_name, cb) {
     const self = exports;
@@ -88,7 +88,7 @@ exports._load_cur_queue = function (pid, cb_name, cb) {
 
         self.load_queue_files(pid, cb_name, files, cb);
     });
-};
+}
 
 exports.load_queue_files = function (pid, cb_name, files, callback) {
     const self = exports;
@@ -200,7 +200,7 @@ exports.load_queue_files = function (pid, cb_name, files, callback) {
             }
         }, callback);
     }
-};
+}
 
 exports.stats = function () {
     // TODO: output more data here
@@ -210,7 +210,7 @@ exports.stats = function () {
     };
 
     return results;
-};
+}
 
 exports._list_file = function (file, cb) {
     const tl_reader = fs.createReadStream(path.join(queue_dir, file), {start: 0, end: 3});
@@ -245,7 +245,7 @@ exports._list_file = function (file, cb) {
             }
         });
     });
-};
+}
 
 exports.flush_queue = function (domain, pid) {
     if (domain) {
@@ -262,12 +262,12 @@ exports.flush_queue = function (domain, pid) {
     else {
         temp_fail_queue.drain();
     }
-};
+}
 
 exports.load_pid_queue = function (pid) {
     logger.loginfo("[outbound] Loading queue for pid: " + pid);
     exports.load_queue(pid);
-};
+}
 
 exports.ensure_queue_dir = function () {
     // No reason not to do this stuff syncronously -
@@ -284,7 +284,7 @@ exports.ensure_queue_dir = function () {
             throw err;
         }
     }
-};
+}
 
 exports._add_file = function (hmail) {
     if (hmail.next_process < exports.cur_time) {
@@ -295,7 +295,7 @@ exports._add_file = function (hmail) {
             delivery_queue.push(hmail);
         });
     }
-};
+}
 
 exports.scan_queue_pids = function (cb) {
     // Under cluster, this is called first by the master so
@@ -328,4 +328,4 @@ exports.scan_queue_pids = function (cb) {
 
         return cb(null, Object.keys(pids));
     });
-};
+}

--- a/outbound/tls.js
+++ b/outbound/tls.js
@@ -45,4 +45,4 @@ exports.get_tls_options = function (mx) {
     }
 
     return tls_options;
-};
+}

--- a/plugins.js
+++ b/plugins.js
@@ -340,7 +340,7 @@ plugins.load_plugins = function (override) {
     }
 
     logger.dump_logs(); // now logging plugins are loaded.
-};
+}
 
 plugins.load_plugin = function (name) {
     logger.loginfo(`Loading plugin: ${name}`);
@@ -352,7 +352,7 @@ plugins.load_plugin = function (name) {
 
     plugins.registered_plugins[name] = plugin;
     return plugin;
-};
+}
 
 // Set in server.js; initialized to empty object
 // to prevent it from blowing up any unit tests.
@@ -370,7 +370,7 @@ plugins._load_and_compile_plugin = function (name) {
     }
     plugin._compile();
     return plugin;
-};
+}
 
 plugins._register_plugin = function (plugin) {
     plugin.register();
@@ -384,7 +384,7 @@ plugins._register_plugin = function (plugin) {
     }
 
     return plugin;
-};
+}
 
 plugins.run_hooks = function (hook, object, params) {
     if (client_disconnected(object) && !is_required_hook(hook)) {
@@ -420,7 +420,7 @@ plugins.run_hooks = function (hook, object, params) {
     }
 
     plugins.run_next_hook(hook, object, params);
-};
+}
 
 plugins.run_next_hook = function (hook, object, params) {
     if (client_disconnected(object) && !is_required_hook(hook)) {
@@ -510,7 +510,7 @@ plugins.run_next_hook = function (hook, object, params) {
         }
         callback();
     }
-};
+}
 
 function client_disconnected (object) {
     if (object.constructor.name === 'Connection' &&

--- a/plugins/aliases.js
+++ b/plugins/aliases.js
@@ -6,7 +6,7 @@ exports.register = function () {
     this.inherits('queue/discard');
 
     this.register_hook('rcpt','aliases');
-};
+}
 
 exports.aliases = function (next, connection, params) {
     const plugin = this;
@@ -78,7 +78,7 @@ exports.aliases = function (next, connection, params) {
     }
 
     next();
-};
+}
 
 function _drop (plugin, connection, rcpt) {
     connection.logdebug(plugin, `marking ${rcpt} for drop`);

--- a/plugins/attachment.js
+++ b/plugins/attachment.js
@@ -27,7 +27,7 @@ exports.register = function () {
     this.load_attachment_ini();
     this.register_hook('data_post', 'wait_for_attachment_hooks');
     this.register_hook('data_post', 'check_attachments');
-};
+}
 
 exports.load_attachment_ini = function () {
     const plugin = this;
@@ -40,7 +40,7 @@ exports.load_attachment_ini = function () {
     plugin.archive_max_depth = plugin.cfg.main.archive_max_depth || 5;
     plugin.archive_exts = options_to_array(plugin.cfg.main.archive_extensions) ||
         default_archive_extns;
-};
+}
 
 exports.find_bsdtar_path = function (cb) {
     let found = false;
@@ -60,7 +60,7 @@ exports.find_bsdtar_path = function (cb) {
         });
         if (i===0) cb(new Error('bsdtar not found'));
     });
-};
+}
 
 exports.hook_init_master = exports.hook_init_child = function (next) {
     const plugin = this;
@@ -75,7 +75,7 @@ exports.hook_init_master = exports.hook_init_child = function (next) {
         }
         return next();
     });
-};
+}
 
 function options_to_array (options) {
     if (!options) return false;
@@ -252,7 +252,7 @@ exports.unarchive_recursive = function (connection, f, archive_file_name, cb) {
     }, plugin.cfg.timeout);
 
     listFiles(f, archive_file_name);
-};
+}
 
 exports.start_attachment = function (connection, ctype, filename, body, stream) {
     const plugin = this;
@@ -399,7 +399,7 @@ exports.hook_data = function (next, connection) {
         plugin.start_attachment(connection, ctype, filename, body, stream);
     });
     return next();
-};
+}
 
 exports.check_attachments = function (next, connection) {
     const txn = connection.transaction;
@@ -468,7 +468,7 @@ exports.check_attachments = function (next, connection) {
     }
 
     return next();
-};
+}
 
 exports.check_items_against_regexps = function (items, regexps) {
     if ((regexps && Array.isArray(regexps) && regexps.length > 0) &&
@@ -492,7 +492,7 @@ exports.check_items_against_regexps = function (items, regexps) {
         }
     }
     return false;
-};
+}
 
 exports.wait_for_attachment_hooks = function (next, connection) {
     const txn = connection.transaction;
@@ -503,4 +503,4 @@ exports.wait_for_attachment_hooks = function (next, connection) {
     else {
         next();
     }
-};
+}

--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -19,12 +19,12 @@ exports.hook_capabilities = function (next, connection) {
     connection.capabilities.push(`AUTH ${methods.join(' ')}`);
     connection.notes.allowed_auth_methods = methods;
     next();
-};
+}
 
 // Override this at a minimum. Run cb(passwd) to provide a password.
 exports.get_plain_passwd = function (user, connection, cb) {
     return cb();
-};
+}
 
 exports.hook_unrecognized_command = function (next, connection, params) {
     const plugin = this;
@@ -45,7 +45,7 @@ exports.hook_unrecognized_command = function (next, connection, params) {
         return plugin.auth_plain(next, connection, params);
     }
     return next();
-};
+}
 
 exports.check_plain_passwd = function (connection, user, passwd, cb) {
     const callback = function (plain_pw) {
@@ -62,7 +62,7 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
     else {
         throw 'Invalid number of arguments for get_plain_passwd';
     }
-};
+}
 
 exports.check_cram_md5_passwd = function (connection, user, passwd, cb) {
     const callback = function (plain_pw) {
@@ -87,7 +87,7 @@ exports.check_cram_md5_passwd = function (connection, user, passwd, cb) {
     else {
         throw 'Invalid number of arguments for get_plain_passwd';
     }
-};
+}
 
 exports.check_user = function (next, connection, credentials, method) {
     const plugin = this;
@@ -152,7 +152,7 @@ exports.check_user = function (next, connection, credentials, method) {
         plugin.check_cram_md5_passwd(connection, credentials[0], credentials[1],
             passwd_ok);
     }
-};
+}
 
 exports.select_auth_method = function (next, connection, method) {
     const split = method.split(/\s+/);
@@ -176,7 +176,7 @@ exports.select_auth_method = function (next, connection, method) {
     if (method === AUTH_METHOD_CRAM_MD5) {
         return this.auth_cram_md5(next, connection);
     }
-};
+}
 
 exports.auth_plain = function (next, connection, params) {
     const plugin = this;
@@ -200,7 +200,7 @@ exports.auth_plain = function (next, connection, params) {
             return;
         }
     }
-};
+}
 
 exports.auth_login = function (next, connection, params) {
     const plugin = this;
@@ -238,7 +238,7 @@ exports.auth_login = function (next, connection, params) {
         connection.notes.auth_login_asked_login = true;
         return next(OK);
     });
-};
+}
 
 exports.auth_cram_md5 = function (next, connection, params) {
     const plugin = this;
@@ -255,8 +255,8 @@ exports.auth_cram_md5 = function (next, connection, params) {
         connection.notes.auth_ticket = ticket;
         return next(OK);
     });
-};
+}
 
 exports.hexi = function (number) {
     return String(Math.abs(parseInt(number)).toString(16));
-};
+}

--- a/plugins/auth/auth_bridge.js
+++ b/plugins/auth/auth_bridge.js
@@ -3,14 +3,14 @@
 exports.register = function () {
     this.inherits('auth/auth_proxy');
     this.load_flat_ini();
-};
+}
 
 exports.load_flat_ini = function () {
     const plugin = this;
     plugin.cfg = plugin.config.get('smtp_bridge.ini', function () {
         plugin.load_flat_ini();
     });
-};
+}
 
 exports.check_plain_passwd = function (connection, user, passwd, cb) {
     let host = this.cfg.main.host;
@@ -18,4 +18,4 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
         host = `${host}:${this.cfg.main.port}`;
     }
     this.try_auth_proxy(connection, host, user, passwd, cb);
-};
+}

--- a/plugins/auth/auth_proxy.js
+++ b/plugins/auth/auth_proxy.js
@@ -7,14 +7,14 @@ exports.register = function () {
     const plugin = this;
     plugin.inherits('auth/auth_base');
     plugin.load_tls_ini();
-};
+}
 
 exports.load_tls_ini = function () {
     const plugin = this;
     plugin.tls_cfg = plugin.config.get('tls.ini', function () {
         plugin.load_tls_ini();
     });
-};
+}
 
 
 exports.hook_capabilities = function (next, connection) {
@@ -24,7 +24,7 @@ exports.hook_capabilities = function (next, connection) {
         connection.notes.allowed_auth_methods = methods;
     }
     next();
-};
+}
 
 exports.check_plain_passwd = function (connection, user, passwd, cb) {
     let domain;
@@ -45,7 +45,7 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
     }
 
     this.try_auth_proxy(connection, config.domains[domain].split(/[,; ]/), user, passwd, cb);
-};
+}
 
 exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
     if (!hosts || (hosts && !hosts.length)) return cb(false);
@@ -222,4 +222,4 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
                 throw new Error("[auth/auth_proxy] unknown command: " + command);
         }
     });
-};
+}

--- a/plugins/auth/auth_vpopmaild.js
+++ b/plugins/auth/auth_vpopmaild.js
@@ -6,14 +6,14 @@ exports.register = function () {
     const plugin = this;
     plugin.inherits('auth/auth_base');
     plugin.load_vpop_ini();
-};
+}
 
 exports.load_vpop_ini = function () {
     const plugin = this;
     plugin.cfg = plugin.config.get('auth_vpopmaild.ini', function () {
         plugin.load_vpop_ini();
     });
-};
+}
 
 exports.hook_capabilities = function (next, connection) {
     if (!connection.tls.enabled) { return next(); }
@@ -26,7 +26,7 @@ exports.hook_capabilities = function (next, connection) {
     connection.notes.allowed_auth_methods = methods;
 
     return next();
-};
+}
 
 exports.check_plain_passwd = function (connection, user, passwd, cb) {
     const plugin = this;
@@ -58,7 +58,7 @@ exports.check_plain_passwd = function (connection, user, passwd, cb) {
         connection.loginfo(plugin, 'AUTH user="' + user + '" success=' + auth_success);
         return cb(auth_success);
     });
-};
+}
 
 exports.get_sock_opts = function (user) {
     const plugin = this;
@@ -81,7 +81,7 @@ exports.get_sock_opts = function (user) {
 
     plugin.logdebug('sock: ' + plugin.sock_opts.host + ':' + plugin.sock_opts.port);
     return plugin.sock_opts;
-};
+}
 
 exports.get_vpopmaild_socket = function (user) {
     const plugin = this;
@@ -104,7 +104,7 @@ exports.get_vpopmaild_socket = function (user) {
         plugin.logdebug('vpopmail connected');
     });
     return socket;
-};
+}
 
 exports.get_plain_passwd = function (user, connection, cb) {
     const plugin = this;
@@ -157,4 +157,4 @@ exports.get_plain_passwd = function (user, connection, cb) {
     socket.on('end', function () {
         cb(plain_pass ? plain_pass.toString() : plain_pass);
     });
-};
+}

--- a/plugins/auth/flat_file.js
+++ b/plugins/auth/flat_file.js
@@ -4,14 +4,14 @@ exports.register = function () {
     const plugin = this;
     plugin.inherits('auth/auth_base');
     plugin.load_flat_ini();
-};
+}
 
 exports.load_flat_ini = function () {
     const plugin = this;
     plugin.cfg = plugin.config.get('auth_flat_file.ini', function () {
         plugin.load_flat_ini();
     });
-};
+}
 
 exports.hook_capabilities = function (next, connection) {
     const plugin = this;
@@ -31,7 +31,7 @@ exports.hook_capabilities = function (next, connection) {
         connection.notes.allowed_auth_methods = methods;
     }
     next();
-};
+}
 
 exports.get_plain_passwd = function (user, connection, cb) {
     const plugin = this;
@@ -39,4 +39,4 @@ exports.get_plain_passwd = function (user, connection, cb) {
         return cb(plugin.cfg.users[user].toString());
     }
     return cb();
-};
+}

--- a/plugins/avg.js
+++ b/plugins/avg.js
@@ -13,7 +13,7 @@ exports.register = function () {
     const plugin = this;
 
     plugin.load_avg_ini();
-};
+}
 
 exports.load_avg_ini = function () {
     const plugin = this;
@@ -26,13 +26,13 @@ exports.load_avg_ini = function () {
     }, function () {
         plugin.load_avg_ini();
     });
-};
+}
 
 exports.get_tmp_file = function (transaction) {
     const plugin = this;
     const tmpdir  = plugin.cfg.main.tmpdir || '/tmp';
     return path.join(tmpdir, `${transaction.uuid}.tmp`);
-};
+}
 
 exports.hook_data_post = function (next, connection) {
     const plugin = this;
@@ -161,4 +161,4 @@ exports.hook_data_post = function (next, connection) {
     });
 
     connection.transaction.message_stream.pipe(ws, { line_endings: '\r\n' });
-};
+}

--- a/plugins/backscatterer.js
+++ b/plugins/backscatterer.js
@@ -2,7 +2,7 @@
 
 exports.register = function () {
     this.inherits('dns_list_base');
-};
+}
 
 exports.hook_mail = function (next, connection, params) {
     const user = ((params[0] && params[0].user) ?
@@ -22,4 +22,4 @@ exports.hook_mail = function (next, connection, params) {
     }
 
     this.first(connection.remote.ip, [ 'ips.backscatterer.org' ], resultCb);
-};
+}

--- a/plugins/bounce.js
+++ b/plugins/bounce.js
@@ -7,7 +7,7 @@ const SPF = require('./spf').SPF;
 // Override logging in SPF module
 SPF.prototype.log_debug = function (str) {
     return exports.logdebug(str);
-};
+}
 
 exports.register = function () {
     const plugin = this;
@@ -21,7 +21,7 @@ exports.register = function () {
     plugin.register_hook('data',      'bounce_spf_enable');
     plugin.register_hook('data_post', 'bounce_spf');
     plugin.register_hook('data_post', 'non_local_msgid');
-};
+}
 
 exports.load_bounce_bad_rcpt = function () {
     const plugin = this;
@@ -36,7 +36,7 @@ exports.load_bounce_bad_rcpt = function () {
     }
 
     plugin.cfg.invalid_addrs = invalids;
-};
+}
 
 exports.load_bounce_ini = function () {
     const plugin = this;
@@ -69,7 +69,7 @@ exports.load_bounce_ini = function () {
         plugin.logerror('bounce.ini is out of date, please update!');
         plugin.cfg.check.reject_all=true;
     }
-};
+}
 
 exports.reject_all = function (next, connection, params) {
     const plugin = this;
@@ -84,7 +84,7 @@ exports.reject_all = function (next, connection, params) {
     connection.transaction.results.add(plugin,
         {fail: 'bounces_accepted', emit: true });
     return next(DENY, 'No bounces accepted here');
-};
+}
 
 exports.single_recipient = function (next, connection) {
     const plugin = this;
@@ -123,7 +123,7 @@ exports.single_recipient = function (next, connection) {
     if (!plugin.cfg.reject.single_recipient) return next();
 
     return next(DENY, 'this bounce message does not have 1 recipient');
-};
+}
 
 exports.empty_return_path = function (next, connection) {
     const plugin = this;
@@ -159,7 +159,7 @@ exports.empty_return_path = function (next, connection) {
 
     transaction.results.add(plugin, {fail: 'empty_return_path', emit: true });
     return next(DENY, 'bounce with non-empty Return-Path (RFC 3834)');
-};
+}
 
 exports.bad_rcpt = function (next, connection) {
     const plugin = this;
@@ -178,7 +178,7 @@ exports.bad_rcpt = function (next, connection) {
 
     transaction.results.add(plugin, {pass: 'bad_rcpt'});
     return next();
-};
+}
 
 exports.has_null_sender = function (connection, mail_from) {
     const plugin = this;
@@ -197,7 +197,7 @@ exports.has_null_sender = function (connection, mail_from) {
 
     transaction.results.add(plugin, {isa: 'no'});
     return false;
-};
+}
 
 const message_id_re = /^Message-ID:\s*(<?[^>]+>?)/mig;
 
@@ -289,7 +289,7 @@ exports.non_local_msgid = function (next, connection) {
     //         {fail: 'Message-ID not local', emit: true });
     // if (!plugin.cfg.reject.non_local_msgid) return next();
     // return next(DENY, "bounce with non-local Message-ID (RFC 3834)");
-};
+}
 
 // Lazy regexp to get IPs from Received: headers in bounces
 const received_re = net_utils.get_ipany_re('^Received:[\\s\\S]*?[\\[\\(](?:IPv6:)?', '[\\]\\)]');

--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -65,7 +65,7 @@ exports.load_excludes = function () {
     // Make the new lists visible
     plugin.skip_list_exclude = new_skip_list_exclude;
     plugin.skip_list = new_skip_list;
-};
+}
 
 exports.load_clamd_ini = function () {
     const plugin = this;
@@ -137,13 +137,13 @@ exports.load_clamd_ini = function () {
         plugin.cfg.main.only_with_attachments =
             plugin.cfg.main.only_with_attachment ? true : false;
     }
-};
+}
 
 exports.register = function () {
     const plugin = this;
     plugin.load_excludes();
     plugin.load_clamd_ini();
-};
+}
 
 exports.hook_data = function (next, connection) {
     const plugin = this;
@@ -158,7 +158,7 @@ exports.hook_data = function (next, connection) {
     });
 
     return next();
-};
+}
 
 exports.hook_data_post = function (next, connection) {
     const plugin = this;
@@ -313,7 +313,7 @@ exports.hook_data_post = function (next, connection) {
 
     // Start the process
     try_next_host();
-};
+}
 
 function clamd_connect (socket, host) {
     let match;

--- a/plugins/connect.asn.js
+++ b/plugins/connect.asn.js
@@ -1,4 +1,4 @@
 
 exports.register = function () {
     this.lognotice("the plugin connect.asn has been replaced by 'asn'. Please update config/plugins");
-};
+}

--- a/plugins/connect.fcrdns.js
+++ b/plugins/connect.fcrdns.js
@@ -2,5 +2,5 @@
 
 exports.register = function () {
     this.logerror('deprecated! Moved to https://github.com/haraka/haraka-plugin-fcrdns');
-};
+}
 

--- a/plugins/connect.geoip.js
+++ b/plugins/connect.geoip.js
@@ -1,4 +1,4 @@
 
 exports.register = function () {
     this.lognotice("the plugin connect.geoip has been replaced by 'geoip'. Please update config/plugins");
-};
+}

--- a/plugins/connect.p0f.js
+++ b/plugins/connect.p0f.js
@@ -2,4 +2,4 @@
 
 exports.register = function () {
     this.logerror('This plugin has moved. See https://github.com/haraka/haraka-plugin-p0f');
-};
+}

--- a/plugins/connect.rdns_access.js
+++ b/plugins/connect.rdns_access.js
@@ -24,7 +24,7 @@ exports.register = function () {
     this.logerror(this, "plugin deprecated. see 'haraka -h access' for upgrade instructions");
 
     this.register_hook('connect', 'rdns_access');
-};
+}
 
 exports.rdns_access = function (next, connection) {
     const plugin = this;

--- a/plugins/data.headers.js
+++ b/plugins/data.headers.js
@@ -23,7 +23,7 @@ exports.register = function () {
         this.register_hook('data_post', 'delivered_to');
     }
     this.register_hook('data_post', 'mailing_list');
-};
+}
 
 exports.load_headers_ini = function () {
     const plugin = this;
@@ -48,7 +48,7 @@ exports.load_headers_ini = function () {
     }, function () {
         plugin.load_headers_ini();
     });
-};
+}
 
 exports.duplicate_singular = function (next, connection) {
     const plugin = this;
@@ -82,7 +82,7 @@ exports.duplicate_singular = function (next, connection) {
 
     connection.transaction.results.add(plugin, {pass: 'duplicate'});
     return next();
-};
+}
 
 exports.missing_required = function (next, connection) {
     const plugin = this;
@@ -111,7 +111,7 @@ exports.missing_required = function (next, connection) {
 
     connection.transaction.results.add(plugin, {pass: 'missing'});
     return next();
-};
+}
 
 exports.invalid_return_path = function (next, connection) {
     const plugin = this;
@@ -144,7 +144,7 @@ exports.invalid_return_path = function (next, connection) {
 
     connection.transaction.results.add(plugin, {pass: 'Return-Path'});
     return next();
-};
+}
 
 exports.invalid_date = function (next, connection) {
     const plugin = this;
@@ -195,7 +195,7 @@ exports.invalid_date = function (next, connection) {
 
     connection.transaction.results.add(plugin, {pass: 'invalid_date'});
     return next();
-};
+}
 
 exports.user_agent = function (next, connection) {
     const plugin = this;
@@ -229,7 +229,7 @@ exports.user_agent = function (next, connection) {
 
     connection.transaction.results.add(plugin, {fail: 'UA'});
     return next();
-};
+}
 
 exports.direct_to_mx = function (next, connection) {
     const plugin = this;
@@ -261,7 +261,7 @@ exports.direct_to_mx = function (next, connection) {
 
     connection.transaction.results.add(plugin, {pass: `direct-to-mx(${c})`});
     return next();
-};
+}
 
 exports.from_match = function (next, connection) {
     const plugin = this;
@@ -322,7 +322,7 @@ exports.from_match = function (next, connection) {
         fail: `from_match(${env_dom} / ${msg_dom})`
     });
     return next();
-};
+}
 
 exports.delivered_to = function (next, connection) {
     const plugin = this;
@@ -343,7 +343,7 @@ exports.delivered_to = function (next, connection) {
     }
 
     return next();
-};
+}
 
 exports.mailing_list = function (next, connection) {
     const plugin = this;
@@ -409,4 +409,4 @@ exports.mailing_list = function (next, connection) {
 
     connection.transaction.results.add(plugin, {msg: 'not MLM'});
     return next();
-};
+}

--- a/plugins/data.rfc5322_header_checks.js
+++ b/plugins/data.rfc5322_header_checks.js
@@ -10,7 +10,7 @@ const singular_headers =  [
 
 exports.register = function () {
     this.logwarn("NOTICE: plugin deprecated, use 'data.headers' instead!");
-};
+}
 
 exports.hook_data_post = function (next, connection) {
     const header = connection.transaction.header;
@@ -29,4 +29,4 @@ exports.hook_data_post = function (next, connection) {
     }
 
     return next();
-};
+}

--- a/plugins/data.uribl.js
+++ b/plugins/data.uribl.js
@@ -45,7 +45,7 @@ exports.register = function () {
     schemeless = new RegExp(re_schemeless, 'gi');
     const re_schemed = `(\\w{3,16}:\\/+(?:\\S+@)?([a-zA-Z0-9][a-zA-Z0-9\\-.]+\\.(?:${Object.keys(tlds.top_level_tlds).join('|')})))(?!\\w)`;
     schemed = new RegExp(re_schemed, 'gi');
-};
+}
 
 exports.load_uri_config = function (next) {
     lists = this.config.get('data.uribl.ini');
@@ -62,7 +62,7 @@ exports.load_uri_config = function (next) {
     if (lists.main && !lists.main.max_uris_per_list) {
         lists.main.max_uris_per_list = 20;
     }
-};
+}
 
 
 // IS: IPv6 compatible (maybe; if the BL is support IPv6 requests)
@@ -270,7 +270,7 @@ exports.do_lookups = function (connection, next, hosts, type) {
     });
 
     conclude_if_no_pending();
-};
+}
 
 exports.hook_lookup_rdns = function (next, connection) {
     this.load_uri_config(next);
@@ -286,7 +286,7 @@ exports.hook_lookup_rdns = function (next, connection) {
         }
         plugin.do_lookups(connection, next, rdns, 'rdns');
     });
-};
+}
 
 exports.hook_ehlo = function (next, connection, helo) {
     this.load_uri_config(next);
@@ -298,19 +298,19 @@ exports.hook_ehlo = function (next, connection, helo) {
     else {
         this.do_lookups(connection, next, helo, 'helo');
     }
-};
+}
 exports.hook_helo = exports.hook_ehlo;
 
 exports.hook_mail = function (next, connection, params) {
     this.load_uri_config(next);
     this.do_lookups(connection, next, params[0].host, 'envfrom');
-};
+}
 
 exports.hook_data = function (next, connection) {
     // enable mail body parsing
     connection.transaction.parse_body = 1;
     return next();
-};
+}
 
 exports.hook_data_post = function (next, connection) {
     this.load_uri_config(next);
@@ -367,7 +367,7 @@ exports.hook_data_post = function (next, connection) {
         next_in_chain(chain_caller);
     }
     chain_caller();
-};
+}
 
 function extract_urls (urls, body, connection, self) {
     // extract from body.bodytext

--- a/plugins/delay_deny.js
+++ b/plugins/delay_deny.js
@@ -94,7 +94,7 @@ exports.hook_deny = function (next, connection, params) {
             // No delays
             return next();
     }
-};
+}
 
 exports.hook_rcpt_ok = function (next, connection, rcpt) {
     const plugin = this;
@@ -129,7 +129,7 @@ exports.hook_rcpt_ok = function (next, connection, rcpt) {
         }
     }
     return next();
-};
+}
 
 exports.hook_data = function (next, connection) {
     const transaction = connection.transaction;

--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -137,7 +137,7 @@ exports.register = function () {
     const plugin = this;
     plugin.load_dkim_sign_ini();
     plugin.load_dkim_key();
-};
+}
 
 exports.load_dkim_sign_ini = function () {
     const plugin = this;
@@ -148,7 +148,7 @@ exports.load_dkim_sign_ini = function () {
     },
     function () { plugin.load_dkim_sign_ini(); }
     );
-};
+}
 
 exports.load_dkim_key = function () {
     const plugin = this;
@@ -157,11 +157,11 @@ exports.load_dkim_key = function () {
         'data',
         function () { plugin.load_dkim_key(); }
     ).join('\n');
-};
+}
 
 exports.load_key = function (file) {
     return this.config.get(file, 'data').join('\n');
-};
+}
 
 exports.hook_queue_outbound = exports.hook_pre_send_trans_email = function (next, connection) {
     const plugin = this;
@@ -213,7 +213,7 @@ exports.hook_queue_outbound = exports.hook_pre_send_trans_email = function (next
             selector, domain, private_key, headers_to_sign,
             txn.header, dkimCallback));
     });
-};
+}
 
 exports.get_key_dir = function (connection, done) {
     const plugin = this;
@@ -243,7 +243,7 @@ exports.get_key_dir = function (connection, done) {
         connection.logdebug(plugin, results);
         done(err, results);
     });
-};
+}
 
 exports.has_key_data = function (conn, domain, selector, private_key) {
     const plugin = this;
@@ -264,7 +264,7 @@ exports.has_key_data = function (conn, domain, selector, private_key) {
 
     conn.logprotocol(plugin, 'selector: '+selector);
     return true;
-};
+}
 
 exports.get_headers_to_sign = function () {
     const plugin = this;
@@ -283,7 +283,7 @@ exports.get_headers_to_sign = function () {
         headers.push('from');
     }
     return headers;
-};
+}
 
 exports.get_sender_domain = function (txn) {
     const plugin = this;
@@ -330,4 +330,4 @@ exports.get_sender_domain = function (txn) {
         }
     }
     return domain;
-};
+}

--- a/plugins/dkim_verify.js
+++ b/plugins/dkim_verify.js
@@ -7,11 +7,11 @@ const plugin = exports;
 
 dkim.DKIMObject.prototype.debug = function (str) {
     plugin.logdebug(str);
-};
+}
 
 DKIMVerifyStream.prototype.debug = function (str) {
     plugin.logdebug(str);
-};
+}
 
 exports.hook_data_post = function (next, connection) {
     const self = this;
@@ -46,4 +46,4 @@ exports.hook_data_post = function (next, connection) {
     }, ((plugin.timeout) ? plugin.timeout - 1 : 0));
 
     txn.message_stream.pipe(verifier, { line_endings: '\r\n' });
-};
+}

--- a/plugins/dns_list_base.js
+++ b/plugins/dns_list_base.js
@@ -60,7 +60,7 @@ exports.lookup = function (lookup, zone, cb) {
         }
         return cb(err, a);
     });
-};
+}
 
 exports.stats_incr_zone = function (err, zone, start) {
     const plugin = this;
@@ -77,7 +77,7 @@ exports.stats_incr_zone = function (err, zone, start) {
             : parseInt(elapsed);
         redis_client.hset(rkey, 'AVG_RT', avg);
     });
-};
+}
 
 exports.init_redis = function () {
     const plugin = this;
@@ -95,7 +95,7 @@ exports.init_redis = function () {
         redis_client = null; // should force a reconnect
         // not sure if that's the right thing but better than nothing...
     });
-};
+}
 
 exports.multi = function (lookup, zones, cb) {
     if (!lookup) return cb();
@@ -128,7 +128,7 @@ exports.multi = function (lookup, zones, cb) {
         cb(err, null, null, false);
     }
     async.each(zones, zoneIter, zonesDone);
-};
+}
 
 // Return first positive or last result.
 exports.first = function (lookup, zones, cb, cb_each) {
@@ -146,7 +146,7 @@ exports.first = function (lookup, zones, cb, cb_each) {
         ran_cb = true;
         return cb(err, zone, a);
     });
-};
+}
 
 exports.check_zones = function (interval) {
     const self = this;
@@ -191,14 +191,14 @@ exports.check_zones = function (interval) {
             self.check_zones();
         }, (interval * 60) * 1000);
     }
-};
+}
 
 exports.shutdown = function () {
     clearInterval(this._interval);
     if (redis_client) {
         redis_client.quit();
     }
-};
+}
 
 exports.disable_zone = function (zone, result) {
     if (!zone) return false;
@@ -219,4 +219,4 @@ exports.disable_zone = function (zone, result) {
     this.logwarn('disabling zone \'' + zone + '\'' + (result ? ': ' +
         result : ''));
     return true;
-};
+}

--- a/plugins/dnsbl.js
+++ b/plugins/dnsbl.js
@@ -16,7 +16,7 @@ exports.register = function () {
     else {
         plugin.register_hook('connect',  'connect_first');
     }
-};
+}
 
 exports.load_config = function () {
     const plugin = this;
@@ -43,7 +43,7 @@ exports.load_config = function () {
     }
 
     plugin.get_uniq_zones();
-};
+}
 
 exports.get_uniq_zones = function () {
     const plugin = this;
@@ -66,7 +66,7 @@ exports.get_uniq_zones = function () {
 
     for (const key in unique_zones) { plugin.zones.push(key); }
     return plugin.zones;
-};
+}
 
 exports.should_skip = function (connection) {
     const plugin = this;
@@ -84,7 +84,7 @@ exports.should_skip = function (connection) {
     }
 
     return false;
-};
+}
 
 exports.connect_first = function (next, connection) {
     const plugin = this;
@@ -109,7 +109,7 @@ exports.connect_first = function (next, connection) {
         const result = a ? {fail: zone} : {pass: zone};
         connection.results.add(plugin, result);
     });
-};
+}
 
 exports.connect_multi = function (next, connection) {
     const plugin = this;
@@ -148,4 +148,4 @@ exports.connect_multi = function (next, connection) {
         }
         return next();
     });
-};
+}

--- a/plugins/dnswl.js
+++ b/plugins/dnswl.js
@@ -11,7 +11,7 @@ exports.register = function () {
     ['ehlo','helo','mail'].forEach(function (hook) {
         plugin.register_hook(hook, 'check_dnswl');
     });
-};
+}
 
 exports.load_dnswl_ini = function () {
     const plugin = this;
@@ -42,11 +42,11 @@ exports.load_dnswl_ini = function () {
     if (plugin.cfg.main.periodic_checks) {
         plugin.check_zones(plugin.cfg.main.periodic_checks);
     }
-};
+}
 
 exports.check_dnswl = function (next, connection) {
     return connection.notes.dnswl ? next(OK) : next();
-};
+}
 
 exports.hook_connect = function (next, connection) {
     const plugin = this;
@@ -61,4 +61,4 @@ exports.hook_connect = function (next, connection) {
         connection.notes.dnswl = true;
         return next(OK);
     });
-};
+}

--- a/plugins/early_talker.js
+++ b/plugins/early_talker.js
@@ -8,7 +8,7 @@ exports.register = function () {
     plugin.load_config();
     plugin.register_hook('connect_init', 'early_talker');
     plugin.register_hook('data',         'early_talker');
-};
+}
 
 exports.load_config = function () {
     const plugin = this;
@@ -34,7 +34,7 @@ exports.load_config = function () {
     plugin.pause = plugin.config.get('early_talker.pause', function () {
         plugin.load_config();
     });
-};
+}
 
 exports.early_talker = function (next, connection) {
     const plugin = this;
@@ -75,7 +75,7 @@ exports.early_talker = function (next, connection) {
     }
 
     setTimeout(function () { check(); }, pause);
-};
+}
 
 
 /**
@@ -102,7 +102,7 @@ exports.ip_in_list = function (ip) {
         }
     }
     return false;
-};
+}
 
 
 /**
@@ -129,4 +129,4 @@ exports.load_ip_list = function (list) {
         }
     }
     return whitelist;
-};
+}

--- a/plugins/esets.js
+++ b/plugins/esets.js
@@ -72,4 +72,4 @@ exports.hook_data_post = function (next, connection) {
     });
 
     txn.message_stream.pipe(ws, { line_endings: '\r\n' });
-};
+}

--- a/plugins/greylist.js
+++ b/plugins/greylist.js
@@ -27,7 +27,7 @@ exports.register = function (next) {
 
     // redundant - using the special hook_ nomenclature
     // this.register_hook('rcpt_ok', 'hook_rcpt_ok');
-};
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 exports.load_config = function () {
@@ -44,7 +44,7 @@ exports.load_config = function () {
 
     plugin.merge_redis_ini();
     plugin.load_config_lists();
-};
+}
 
 // Load various configuration lists
 exports.load_config_lists = function () {
@@ -99,7 +99,7 @@ exports.load_config_lists = function () {
     load_ip_list('ip', 'ip_whitelist');
 
     load_config_list('dyndom', 'special_dynamic_domains');
-};
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 exports.shutdown = function () {
@@ -142,7 +142,7 @@ exports.hook_mail = function (next, connection, params) {
     }
 
     return next();
-};
+}
 
 //
 exports.hook_rcpt_ok = function (next, connection, rcpt) {
@@ -231,7 +231,7 @@ exports.hook_rcpt_ok = function (next, connection, rcpt) {
             });
         }
     });
-};
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -266,7 +266,7 @@ exports.process_tuple = function (connection, sender, rcpt, cb) {
             return cb(err3, null);
         });
     });
-};
+}
 
 // Checks if host is _white_. Updates stats if so.
 exports.check_and_update_white = function (connection, cb) {
@@ -290,7 +290,7 @@ exports.check_and_update_white = function (connection, cb) {
 
         return cb(null, false);
     });
-};
+}
 
 // invokes next() depending on outcome param
 exports.invoke_outcome_cb = function (next, is_whitelisted) {
@@ -304,7 +304,7 @@ exports.invoke_outcome_cb = function (next, is_whitelisted) {
 
         return next(DENYSOFT, DSN.sec_unauthorized(text, '451'));
     }
-};
+}
 
 // Should we skip greylisting invokation altogether?
 exports.should_skip_check = function (connection) {
@@ -339,12 +339,12 @@ exports.should_skip_check = function (connection) {
     }
 
     return false;
-};
+}
 
 // Was whitelisted previously in this session
 exports.was_whitelisted_in_session = function (connection) {
     return connection.transaction.results.has(this, 'pass', 'whitelisted');
-};
+}
 
 exports.process_skip_rules = function (connection) {
     const plugin = this;
@@ -362,7 +362,7 @@ exports.process_skip_rules = function (connection) {
     }
 
     return false;
-};
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -376,13 +376,13 @@ exports.craft_grey_key = function (connection, from, to) {
         key += `:${(to || '<>')}`;
     }
     return key;
-};
+}
 
 // Build white DB key off supplied params.
 exports.craft_white_key = function (connection) {
     const plugin = this;
     return 'white:' + plugin.craft_hostid(connection);
-};
+}
 
 // Return so-called +hostid+.
 exports.craft_hostid = function (connection) {
@@ -459,7 +459,7 @@ exports.craft_hostid = function (connection) {
     }
 
     return chsit(stripped_dom);
-};
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -480,7 +480,7 @@ exports.retrieve_grey = function (rcpt_key, sender_key, cb) {
         }
         return cb(err, result);
     });
-};
+}
 
 // Update or create _grey_ record
 exports.update_grey = function (key, create, cb) {
@@ -518,7 +518,7 @@ exports.update_grey = function (key, create, cb) {
         }
         return cb(null, ((create) ? new_record : false));
     });
-};
+}
 
 // Promote _grey_ record to _white_.
 exports.promote_to_white = function (connection, grey_rec, cb) {
@@ -552,7 +552,7 @@ exports.promote_to_white = function (connection, grey_rec, cb) {
             return cb(err2, result2);
         });
     });
-};
+}
 
 // Update _white_ record
 exports.update_white_record = function (key, record, cb) {
@@ -576,7 +576,7 @@ exports.update_white_record = function (key, record, cb) {
         }
         return cb(null, record2);
     });
-};
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -597,7 +597,7 @@ exports.db_lookup = function (key, cb) {
         }
         return cb(null, result);
     });
-};
+}
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 exports.addr_in_list = function (type, address) {
@@ -618,7 +618,7 @@ exports.addr_in_list = function (type, address) {
     } catch (err) {
         return false;
     }
-};
+}
 
 exports.ip_in_list = function (ip) {
     const plugin = this;
@@ -635,7 +635,7 @@ exports.ip_in_list = function (ip) {
     }
 
     return false;
-};
+}
 
 // Match patterns in the list against (end of) domain
 exports.domain_in_list = function (list_name, domain) {
@@ -653,7 +653,7 @@ exports.domain_in_list = function (list_name, domain) {
     }
 
     return false;
-};
+}
 
 // Check for special rDNS cases
 // @return {type: 'dynamic'} if rnds is dynamic (hostid should be IP)
@@ -668,4 +668,4 @@ exports.check_rdns_for_special_cases = function (domain, label) {
         };
 
     return false;
-};
+}

--- a/plugins/helo.checks.js
+++ b/plugins/helo.checks.js
@@ -51,7 +51,7 @@ exports.register = function () {
         };
         load_re_file();
     }
-};
+}
 
 exports.load_helo_checks_ini = function () {
     const plugin = this;
@@ -95,7 +95,7 @@ exports.load_helo_checks_ini = function () {
         plugin.logerror('deprecated setting mismatch renamed to host_mismatch');
         plugin.cfg.reject.host_mismatch = plugin.cfg.reject.mismatch;
     }
-};
+}
 
 exports.init = function (next, connection, helo) {
     const plugin = this;
@@ -110,7 +110,7 @@ exports.init = function (next, connection, helo) {
     connection.results.add(plugin, {multi: true});
 
     return next();
-};
+}
 
 exports.should_skip = function (connection, test_name) {
     const plugin = this;
@@ -131,7 +131,7 @@ exports.should_skip = function (connection, test_name) {
     }
 
     return false;
-};
+}
 
 exports.host_mismatch = function (next, connection, helo) {
     const plugin = this;
@@ -155,7 +155,7 @@ exports.host_mismatch = function (next, connection, helo) {
     if (!plugin.cfg.reject.host_mismatch) return next();
 
     return next(DENY, 'HELO host ' + msg);
-};
+}
 
 exports.valid_hostname = function (next, connection, helo) {
     const plugin = this;
@@ -193,7 +193,7 @@ exports.valid_hostname = function (next, connection, helo) {
 
     connection.results.add(plugin, {pass: 'valid_hostname'});
     return next();
-};
+}
 
 exports.match_re = function (next, connection, helo) {
     const plugin = this;
@@ -209,7 +209,7 @@ exports.match_re = function (next, connection, helo) {
     }
     connection.results.add(plugin, {pass: 'match_re'});
     return next();
-};
+}
 
 exports.rdns_match = function (next, connection, helo) {
     const plugin = this;
@@ -243,7 +243,7 @@ exports.rdns_match = function (next, connection, helo) {
         return next(DENY, 'HELO host does not match rDNS');
     }
     return next();
-};
+}
 
 exports.bare_ip = function (next, connection, helo) {
     const plugin = this;
@@ -262,7 +262,7 @@ exports.bare_ip = function (next, connection, helo) {
 
     connection.results.add(plugin, {pass: 'bare_ip'});
     return next();
-};
+}
 
 exports.dynamic = function (next, connection, helo) {
     const plugin = this;
@@ -290,7 +290,7 @@ exports.dynamic = function (next, connection, helo) {
 
     connection.results.add(plugin, {pass: 'dynamic'});
     return next();
-};
+}
 
 exports.big_company = function (next, connection, helo) {
     const plugin = this;
@@ -335,7 +335,7 @@ exports.big_company = function (next, connection, helo) {
         return next(DENY, "You are not who you say you are");
     }
     return next();
-};
+}
 
 exports.literal_mismatch = function (next, connection, helo) {
     const plugin = this;
@@ -378,7 +378,7 @@ exports.literal_mismatch = function (next, connection, helo) {
         return next(DENY, 'HELO IP literal does not match your IP address');
     }
     return next();
-};
+}
 
 exports.forward_dns = function (next, connection, helo) {
     const plugin = this;
@@ -449,7 +449,7 @@ exports.forward_dns = function (next, connection, helo) {
     };
 
     plugin.get_a_records(helo, cb);
-};
+}
 
 exports.proto_mismatch = function (next, connection, helo, proto) {
     const plugin = this;
@@ -469,15 +469,15 @@ exports.proto_mismatch = function (next, connection, helo, proto) {
     }
 
     return next();
-};
+}
 
 exports.proto_mismatch_smtp = function (next, connection, helo) {
     this.proto_mismatch(next, connection, helo, 'smtp');
-};
+}
 
 exports.proto_mismatch_esmtp = function (next, connection, helo) {
     this.proto_mismatch(next, connection, helo, 'esmtp');
-};
+}
 
 exports.emit_log = function (next, connection, helo) {
     const plugin = this;
@@ -499,7 +499,7 @@ exports.emit_log = function (next, connection, helo) {
     // [UUID] [helo.checks] fail:dynamic
     connection.loginfo(plugin, connection.results.collate(plugin));
     return next();
-};
+}
 
 exports.get_a_records = function (host, cb) {
     const plugin = this;
@@ -546,4 +546,4 @@ exports.get_a_records = function (host, cb) {
         // return the DNS results
         return cb(null, ips);
     });
-};
+}

--- a/plugins/log.syslog.js
+++ b/plugins/log.syslog.js
@@ -1,4 +1,4 @@
 
 exports.register = function () {
     this.logerror('deprecated! See https://github.com/haraka/haraka-plugin-syslog');
-};
+}

--- a/plugins/lookup_rdns.strict.js
+++ b/plugins/lookup_rdns.strict.js
@@ -164,4 +164,4 @@ exports.hook_lookup_rdns = function (next, connection) {
             });
         });
     });
-};
+}

--- a/plugins/mail_from.is_resolvable.js
+++ b/plugins/mail_from.is_resolvable.js
@@ -7,7 +7,7 @@ const net_utils = require('haraka-net-utils');
 
 exports.register = function () {
     this.load_ini();
-};
+}
 
 exports.load_ini = function () {
     const plugin = this;
@@ -22,7 +22,7 @@ exports.load_ini = function () {
 
     plugin.re_bogus_ip = new RegExp(plugin.cfg.main.re_bogus_ip ||
             '^(?:0\\.0\\.0\\.0|255\\.255\\.255\\.255|127\\.)' );
-};
+}
 
 exports.hook_mail = function (next, connection, params) {
     const plugin    = this;
@@ -130,7 +130,7 @@ exports.hook_mail = function (next, connection, params) {
         // In case we don't run any queries
         check_results();
     });
-};
+}
 
 exports.mxErr = function (connection, domain, type, err, mxDone) {
     const plugin = this;
@@ -149,7 +149,7 @@ exports.mxErr = function (connection, domain, type, err, mxDone) {
             return true;
     }
     return false;
-};
+}
 
 // IS: IPv6 compatible
 exports.implicit_mx = function (connection, domain, mxDone) {
@@ -193,4 +193,4 @@ exports.implicit_mx = function (connection, domain, mxDone) {
         txn.results.add(plugin, {fail: 'implicit_mx('+domain+')'});
         return mxDone();
     });
-};
+}

--- a/plugins/max_unrecognized_commands.js
+++ b/plugins/max_unrecognized_commands.js
@@ -8,7 +8,7 @@ exports.hook_connect = function (next, connection) {
         count: 0,
     });
     return next();
-};
+}
 
 exports.hook_unrecognized_command = function (next, connection, cmd) {
     const plugin = this;
@@ -22,4 +22,4 @@ exports.hook_unrecognized_command = function (next, connection, cmd) {
         return next(DENYDISCONNECT, "Too many bad commands");
     }
     return next();
-};
+}

--- a/plugins/messagesniffer.js
+++ b/plugins/messagesniffer.js
@@ -10,7 +10,7 @@ let port = 9001;
 exports.register = function () {
     const cfg = this.config.get('messagesniffer.ini');
     if (cfg.main.port) port = parseInt(cfg.main.port);
-};
+}
 
 exports.hook_connect = function (next, connection) {
     const self = this;
@@ -97,7 +97,7 @@ exports.hook_connect = function (next, connection) {
             return next();
         }
     });
-};
+}
 
 exports.hook_data_post = function (next, connection) {
     const self = this;
@@ -328,7 +328,7 @@ exports.hook_data_post = function (next, connection) {
 
     // TODO: we only need the first 64Kb of the message
     txn.message_stream.pipe(ws, { line_endings: '\r\n' });
-};
+}
 
 exports.hook_disconnect = function (next, connection) {
     const self = this;

--- a/plugins/prevent_credential_leaks.js
+++ b/plugins/prevent_credential_leaks.js
@@ -10,7 +10,7 @@ exports.hook_data = function (next, connection) {
         connection.transaction.parse_body = true;
     }
     next();
-};
+}
 
 exports.hook_data_post = function (next, connection) {
     if (!(connection.notes.auth_user && connection.notes.auth_passwd)) {
@@ -39,7 +39,7 @@ exports.hook_data_post = function (next, connection) {
     }
 
     next();
-};
+}
 
 function look_for_credentials (user_regexp, passwd_regexp, body) {
     if (user_regexp.test(body.bodytext) && passwd_regexp.test(body.bodytext)) {

--- a/plugins/process_title.js
+++ b/plugins/process_title.js
@@ -106,7 +106,7 @@ exports.hook_init_master = function (next, server) {
     }
     this._interval = setupInterval(title, server);
     return next();
-};
+}
 
 exports.hook_init_child = function (next, server) {
     server.notes.pt_connections = 0;
@@ -120,12 +120,12 @@ exports.hook_init_child = function (next, server) {
     process.title = title;
     this._interval = setupInterval(title, server);
     return next();
-};
+}
 
 exports.shutdown = function () {
     this.logdebug("Shutting down interval: " + this._interval);
     clearInterval(this._interval);
-};
+}
 
 exports.hook_connect_init = function (next, connection) {
     const server = connection.server;
@@ -137,7 +137,7 @@ exports.hook_connect_init = function (next, connection) {
     server.notes.pt_connections++;
     server.notes.pt_concurrent++;
     return next();
-};
+}
 
 exports.hook_disconnect = function (next, connection) {
     const server = connection.server;
@@ -160,7 +160,7 @@ exports.hook_disconnect = function (next, connection) {
     }
     server.notes.pt_concurrent--;
     return next();
-};
+}
 
 exports.hook_data = function (next, connection) {
     const server = connection.server;
@@ -170,4 +170,4 @@ exports.hook_data = function (next, connection) {
     }
     server.notes.pt_messages++;
     return next();
-};
+}

--- a/plugins/profile.js
+++ b/plugins/profile.js
@@ -3,9 +3,9 @@ const prof = require('v8-profiler');
 exports.hook_connect_init = function (next, conn) {
     prof.startProfiling(`Connection from: ${conn.remote.ip}`);
     next();
-};
+}
 
 exports.hook_disconnect = function (next, conn) {
     prof.stopProfiling(`Connection from: ${conn.remote.ip}`);
     next();
-};
+}

--- a/plugins/queue/qmail-queue.js
+++ b/plugins/queue/qmail-queue.js
@@ -16,7 +16,7 @@ exports.register = function () {
     if (plugin.cfg.main.enable_outbound) {
         plugin.register_hook('queue_outbound', 'hook_queue');
     }
-};
+}
 
 exports.load_qmail_queue_ini = function () {
     const plugin = this;
@@ -29,7 +29,7 @@ exports.load_qmail_queue_ini = function () {
     function () {
         plugin.load_qmail_queue_ini();
     });
-};
+}
 
 exports.hook_queue = function (next, connection) {
     const plugin = this;
@@ -85,4 +85,4 @@ exports.hook_queue = function (next, connection) {
         qmail_queue.stdout.on('error', function (err) {}); // stdout throws an error on close
         qmail_queue.stdout.end(buf);
     });
-};
+}

--- a/plugins/queue/quarantine.js
+++ b/plugins/queue/quarantine.js
@@ -11,7 +11,7 @@ exports.register = function () {
 
     plugin.register_hook('queue',          'quarantine');
     plugin.register_hook('queue_outbound', 'quarantine');
-};
+}
 
 exports.hook_init_master = function (next, server) {
     this.init_quarantine_dir(() => {
@@ -32,7 +32,7 @@ const zeroPad = exports.zeroPad = function (n, digits) {
         n = '0' + n;
     }
     return n;
-};
+}
 
 exports.clean_tmp_directory = function (next) {
     // At start-up; delete any files in the temporary directory
@@ -49,7 +49,7 @@ exports.clean_tmp_directory = function (next) {
         }
     }
     next();
-};
+}
 
 function wants_quarantine (connection) {
     if (connection.notes.quarantine)

--- a/plugins/queue/rabbitmq.js
+++ b/plugins/queue/rabbitmq.js
@@ -15,7 +15,7 @@ exports.register = function () {
     logger.logdebug("About to connect and initialize queue object");
     this.init_rabbitmq_server();
     logger.logdebug("Finished initiating : " + exports.exchangeMapping[exchangeName + queueName]);
-};
+}
 
 
 //Actual magic of publishing message to rabbit when email comes happen here.
@@ -47,7 +47,7 @@ exports.hook_queue = function (next, connection) {
             return next();
         }
     });
-};
+}
 
 //This initializes the connection to rabbitmq server, It reads values from rabbitmq.ini file in config directory.
 exports.init_rabbitmq_server = function () {
@@ -145,4 +145,4 @@ exports.init_rabbitmq_server = function () {
             });
         });
     });
-};
+}

--- a/plugins/queue/rabbitmq_amqplib.js
+++ b/plugins/queue/rabbitmq_amqplib.js
@@ -21,7 +21,7 @@ exports.rabbitmq_queue = function (next, connection) {
             return next();
         }
     });
-};
+}
 
 exports.init_amqp_connection = function () {
     const plugin = this;
@@ -71,4 +71,4 @@ exports.init_amqp_connection = function () {
             });
         });
     });
-};
+}

--- a/plugins/queue/smtp_bridge.js
+++ b/plugins/queue/smtp_bridge.js
@@ -3,14 +3,14 @@
 
 exports.register = function () {
     this.load_flat_ini();
-};
+}
 
 exports.load_flat_ini = function () {
     const plugin = this;
     plugin.cfg = plugin.config.get('smtp_bridge.ini', function () {
         plugin.load_flat_ini();
     });
-};
+}
 
 exports.hook_data_post = function (next, connection) {
     const txn = connection.transaction;

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -29,7 +29,7 @@ exports.register = function () {
     if (plugin.cfg.main.enable_outbound) {
         plugin.register_hook('queue_outbound', 'queue_forward');
     }
-};
+}
 
 exports.load_smtp_forward_ini = function () {
     const plugin = this;
@@ -47,7 +47,7 @@ exports.load_smtp_forward_ini = function () {
     function () {
         plugin.load_smtp_forward_ini();
     });
-};
+}
 
 exports.get_config = function (connection) {
     const plugin = this;
@@ -60,7 +60,7 @@ exports.get_config = function (connection) {
     if (!plugin.cfg[dom]) return plugin.cfg.main;  // no specific route
 
     return plugin.cfg[dom];
-};
+}
 
 exports.check_sender = function (next, connection, params) {
     const plugin = this;
@@ -86,7 +86,7 @@ exports.check_sender = function (next, connection, params) {
 
     txn.results.add(plugin, {pass: 'mail_from'});
     return next();
-};
+}
 
 exports.set_queue = function (connection, queue_wanted, domain) {
     const plugin = this;
@@ -152,7 +152,7 @@ exports.check_recipient = function (next, connection, params) {
     // Another RCPT plugin may vouch for this recipient.
     txn.results.add(plugin, {msg: 'rcpt!local'});
     return next();
-};
+}
 
 exports.auth = function (cfg, connection, smtp_client) {
     const plugin = this;
@@ -282,7 +282,7 @@ exports.queue_forward = function (next, connection) {
             smtp_client.release();
         });
     });
-};
+}
 
 exports.get_mx_next_hop = function (next_hop) {
     const dest = url.parse(next_hop);
@@ -332,4 +332,4 @@ exports.get_mx = function (next, hmail, domain) {
     })
 
     return next(OK, mx);
-};
+}

--- a/plugins/queue/smtp_proxy.js
+++ b/plugins/queue/smtp_proxy.js
@@ -14,7 +14,7 @@ exports.register = function () {
     if (plugin.cfg.main.enable_outbound) {
         plugin.register_hook('queue_outbound', 'hook_queue');
     }
-};
+}
 
 exports.load_smtp_proxy_ini = function () {
     const plugin = this;
@@ -28,7 +28,7 @@ exports.load_smtp_proxy_ini = function () {
     function () {
         plugin.load_smtp_proxy_ini();
     });
-};
+}
 
 exports.hook_mail = function (next, connection, params) {
     const plugin = this;
@@ -73,21 +73,21 @@ exports.hook_mail = function (next, connection, params) {
             }
         });
     });
-};
+}
 
 exports.hook_rcpt_ok = function (next, connection, recipient) {
     const smtp_client = connection.notes.smtp_client;
     if (!smtp_client) return next();
     smtp_client.next = next;
     smtp_client.send_command('RCPT', 'TO:' + recipient.format(!smtp_client.smtp_utf8));
-};
+}
 
 exports.hook_data = function (next, connection) {
     const smtp_client = connection.notes.smtp_client;
     if (!smtp_client) return next();
     smtp_client.next = next;
     smtp_client.send_command("DATA");
-};
+}
 
 exports.hook_queue = function (next, connection) {
     const plugin = this;
@@ -99,7 +99,7 @@ exports.hook_queue = function (next, connection) {
         return;
     }
     smtp_client.start_data(connection.transaction.message_stream);
-};
+}
 
 exports.hook_rset = function (next, connection) {
     const smtp_client = connection.notes.smtp_client;
@@ -107,7 +107,7 @@ exports.hook_rset = function (next, connection) {
     smtp_client.release();
     delete connection.notes.smtp_client;
     next();
-};
+}
 
 exports.hook_quit = exports.hook_rset;
 
@@ -118,4 +118,4 @@ exports.hook_disconnect = function (next, connection) {
     delete connection.notes.smtp_client;
     smtp_client.call_next();
     next();
-};
+}

--- a/plugins/queue/test.js
+++ b/plugins/queue/test.js
@@ -11,4 +11,4 @@ exports.hook_queue = function (next, connection) {
         return next(OK);
     });
     connection.transaction.message_stream.pipe(ws);
-};
+}

--- a/plugins/rate_limit.js
+++ b/plugins/rate_limit.js
@@ -2,4 +2,4 @@
 
 exports.register = function () {
     this.logerror('deprecated! See https://github.com/haraka/haraka-plugin-limit');
-};
+}

--- a/plugins/rcpt_to.access.js
+++ b/plugins/rcpt_to.access.js
@@ -22,7 +22,7 @@ exports.register = function () {
 
     this.logerror(this, "plugin deprecated. see 'haraka -h access' for upgrade instructions");
     this.register_hook('rcpt', 'rcpt_to_access');
-};
+}
 
 exports.rcpt_to_access = function (next, connection, params) {
     const plugin = this;
@@ -55,7 +55,7 @@ exports.rcpt_to_access = function (next, connection, params) {
 
     connection.transaction.results.add(plugin, {pass: 'unlisted', emit: true});
     return next();
-};
+}
 
 function _in_whitelist (connection, plugin, address) {
     let i;

--- a/plugins/rcpt_to.blocklist.js
+++ b/plugins/rcpt_to.blocklist.js
@@ -4,7 +4,7 @@ const utils = require('haraka-utils');
 
 exports.register = function () {
     this.logwarn("NOTICE: plugin deprecated, use 'rcpt_to.access' instead!");
-};
+}
 
 exports.hook_rcpt = function (next, connection, params) {
     const rcpt_to = params[0].address();
@@ -13,4 +13,4 @@ exports.hook_rcpt = function (next, connection, params) {
         return next(DENY, "Mail to " + rcpt_to + "is not allowed here");
     }
     return next();
-};
+}

--- a/plugins/rcpt_to.host_list_base.js
+++ b/plugins/rcpt_to.host_list_base.js
@@ -14,7 +14,7 @@ exports.load_host_list = function () {
     }
 
     plugin.host_list = lowered_list;
-};
+}
 
 exports.load_host_list_regex = function () {
     const plugin = this;
@@ -27,7 +27,7 @@ exports.load_host_list_regex = function () {
 
     plugin.hl_re = new RegExp ('^(?:' +
                 plugin.host_list_regex.join('|') + ')$', 'i');
-};
+}
 
 exports.hook_mail = function (next, connection, params) {
     const plugin = this;
@@ -57,7 +57,7 @@ exports.hook_mail = function (next, connection, params) {
 
     txn.results.add(plugin, {msg: 'mail_from!local'});
     return next();
-};
+}
 
 exports.in_host_list = function (domain) {
     const plugin = this;
@@ -66,7 +66,7 @@ exports.in_host_list = function (domain) {
         return true;
     }
     return false;
-};
+}
 
 exports.in_host_regex = function (domain) {
     const plugin = this;
@@ -77,4 +77,4 @@ exports.in_host_regex = function (domain) {
 
     if (plugin.hl_re.test(domain)) { return true; }
     return false;
-};
+}

--- a/plugins/rcpt_to.in_host_list.js
+++ b/plugins/rcpt_to.in_host_list.js
@@ -15,7 +15,7 @@ exports.register = function () {
 
     plugin.load_host_list();
     plugin.load_host_list_regex();
-};
+}
 
 exports.hook_rcpt = function (next, connection, params) {
     const plugin = this;
@@ -54,4 +54,4 @@ exports.hook_rcpt = function (next, connection, params) {
     // Another RCPT plugin may yet vouch for this recipient.
     txn.results.add(plugin, {msg: 'rcpt!local'});
     return next();
-};
+}

--- a/plugins/rcpt_to.max_count.js
+++ b/plugins/rcpt_to.max_count.js
@@ -19,4 +19,4 @@ exports.hook_rcpt = function (next, connection) {
         return next(DENYDISCONNECT, "Too many recipient attempts");
     }
     return next();
-};
+}

--- a/plugins/rcpt_to.qmail_deliverable.js
+++ b/plugins/rcpt_to.qmail_deliverable.js
@@ -1,5 +1,4 @@
 exports.register = function () {
     const plugin = this;
     plugin.logerror("ERROR: this plugin has been replaced by https://github.com/haraka/haraka-plugin-qmail-deliverable");
-};
-
+}

--- a/plugins/rdns.regexp.js
+++ b/plugins/rdns.regexp.js
@@ -6,7 +6,7 @@
 
 exports.register = function () {
     this.logwarn("NOTICE: deprecated, use 'connect.rdns_access' instead!");
-};
+}
 
 exports.hook_connect = function (next, connection) {
     const deny_list = this.config.get('rdns.deny_regexps', 'list');
@@ -30,4 +30,4 @@ exports.hook_connect = function (next, connection) {
     }
 
     return next();
-};
+}

--- a/plugins/record_envelope_addresses.js
+++ b/plugins/record_envelope_addresses.js
@@ -8,7 +8,7 @@ exports.hook_rcpt = function (next, connection, params) {
         txn.add_header('X-Envelope-To', params[0].address());
     }
     next();
-};
+}
 
 exports.hook_mail = function (next, connection, params) {
     const txn = connection.transaction;
@@ -16,4 +16,4 @@ exports.hook_mail = function (next, connection, params) {
         txn.add_header('X-Envelope-From', params[0].address());
     }
     next();
-};
+}

--- a/plugins/relay.js
+++ b/plugins/relay.js
@@ -30,7 +30,7 @@ exports.register = function () {
     if (plugin.cfg.relay.all) {
         plugin.register_hook('rcpt', 'all');
     }
-};
+}
 
 exports.load_relay_ini = function () {
     const plugin = this;
@@ -44,7 +44,7 @@ exports.load_relay_ini = function () {
     }, function () {
         plugin.load_relay_ini();
     });
-};
+}
 
 exports.load_dest_domains = function () {
     const plugin = this;
@@ -53,7 +53,7 @@ exports.load_dest_domains = function () {
         'ini',
         function () { plugin.load_dest_domains(); }
     );
-};
+}
 
 exports.load_acls = function () {
     const plugin = this;
@@ -74,7 +74,7 @@ exports.load_acls = function () {
             plugin.acl_allow[i] = cidr[0] + '/32';
         }
     }
-};
+}
 
 exports.acl = function (next, connection) {
     const plugin = this;
@@ -90,7 +90,7 @@ exports.acl = function (next, connection) {
     connection.results.add(plugin, {pass: 'acl'});
     connection.relaying = true;
     return next(OK);
-};
+}
 
 exports.is_acl_allowed = function (connection) {
     const plugin = this;
@@ -116,7 +116,7 @@ exports.is_acl_allowed = function (connection) {
         }
     }
     return false;
-};
+}
 
 exports.dest_domains = function (next, connection, params) {
     const plugin = this;
@@ -171,7 +171,7 @@ exports.dest_domains = function (next, connection, params) {
 
     transaction.results.add(plugin, {fail: 'relay_dest_domain'});
     return next(DENY, "Mail for that recipient is not accepted here.");
-};
+}
 
 exports.force_routing = function (next, hmail, domain) {
     const plugin = this;
@@ -193,7 +193,7 @@ exports.force_routing = function (next, hmail, domain) {
 
     plugin.logdebug(plugin, `using ${nexthop} for: ${domain}`);
     return next(OK, nexthop);
-};
+}
 
 exports.all = function (next, connection, params) {
 // relay everything - could be useful for a spamtrap
@@ -203,5 +203,4 @@ exports.all = function (next, connection, params) {
     connection.loginfo(plugin, `confirming recipient ${params[0]}`);
     connection.relaying = true;
     next(OK);
-};
-
+}

--- a/plugins/relay_acl.js
+++ b/plugins/relay_acl.js
@@ -10,13 +10,13 @@ exports.register = function () {
     this.register_hook('lookup_rdns', 'refresh_config');
     this.register_hook('connect',     'relay_acl');
     this.register_hook('rcpt',        'relay_dest_domains');
-};
+}
 
 exports.refresh_config = function (next, connection) {
     this.cfg = this.config.get('relay_dest_domains.ini', 'ini');
     this.acl_allow = this.config.get('relay_acl_allow', 'list');
     return next();
-};
+}
 
 exports.relay_acl = function (next, connection, params) {
     connection.logdebug(this, `checking ${connection.remote_ip} in relay_acl_allow`);
@@ -29,7 +29,7 @@ exports.relay_acl = function (next, connection, params) {
     connection.results.add(this, {pass: 'relay_acl'});
     connection.relaying = true;
     return next(OK);
-};
+}
 
 exports.relay_dest_domains = function (next, connection, params) {
     const plugin = this;
@@ -74,7 +74,7 @@ exports.relay_dest_domains = function (next, connection, params) {
 
     transaction.results.add(plugin, {fail: 'relay_dest_domain'});
     return next(DENY, "This is not an open relay");
-};
+}
 
 /**
  * @return bool}
@@ -102,4 +102,4 @@ exports.is_acl_allowed = function (connection) {
         }
     }
     return false;
-};
+}

--- a/plugins/relay_all.js
+++ b/plugins/relay_all.js
@@ -3,11 +3,11 @@
 exports.register = function () {
     this.logerror(this, "deprecated. see 'haraka -h relay'");
     this.register_hook('rcpt', 'confirm_all');
-};
+}
 
 exports.confirm_all = function (next, connection, params) {
     const recipient = params.shift();
     connection.loginfo(this, "confirming recipient " + recipient);
     connection.relaying = true;
     next(OK);
-};
+}

--- a/plugins/relay_force_routing.js
+++ b/plugins/relay_force_routing.js
@@ -4,7 +4,7 @@
 
 exports.register = function () {
     this.logerror(this, "deprecated. see 'haraka -h relay'");
-};
+}
 
 exports.hook_get_mx = function (next, hmail, domain) {
     const domain_ini = this.config.get('relay_dest_domains.ini', 'ini');

--- a/plugins/reseed_rng.js
+++ b/plugins/reseed_rng.js
@@ -5,4 +5,4 @@ exports.hook_init_child = function (next) {
     Math.seedrandom(crypto.randomBytes(256).toString('hex'));
     plugin.logdebug("reseeded rng");
     next();
-};
+}

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -7,7 +7,7 @@ const utils = require('haraka-utils');
 exports.register = function () {
     const plugin = this;
     plugin.load_spamassassin_ini();
-};
+}
 
 exports.load_spamassassin_ini = function () {
     const plugin = this;
@@ -38,7 +38,7 @@ exports.load_spamassassin_ini = function () {
         if (!plugin.cfg.main[item]) return;
         plugin.cfg.main[item] = Number(plugin.cfg.main[item]);
     });
-};
+}
 
 exports.hook_data_post = function (next, connection) {
     const plugin = this;
@@ -131,7 +131,7 @@ exports.hook_data_post = function (next, connection) {
 
         return next();
     });
-};
+}
 
 exports.fixup_old_headers = function (transaction) {
     const plugin = this;
@@ -162,7 +162,7 @@ exports.fixup_old_headers = function (transaction) {
             }
             break;
     }
-};
+}
 
 exports.munge_subject = function (connection, score) {
     const plugin = this;
@@ -176,7 +176,7 @@ exports.munge_subject = function (connection, score) {
 
     connection.transaction.remove_header('Subject');
     connection.transaction.add_header('Subject', `${plugin.cfg.main.subject_prefix} ${subj}`);
-};
+}
 
 exports.do_header_updates = function (connection, spamd_response) {
     const plugin = this;
@@ -202,7 +202,7 @@ exports.do_header_updates = function (connection, spamd_response) {
         if (val === '') continue;
         connection.transaction.add_header(`X-Spam-${key}`, val);
     }
-};
+}
 
 exports.score_too_high = function (connection, spamd_response) {
     const plugin = this;
@@ -220,7 +220,7 @@ exports.score_too_high = function (connection, spamd_response) {
     }
 
     return false;
-};
+}
 
 exports.get_spamd_username = function (connection) {
     const plugin = this;
@@ -243,7 +243,7 @@ exports.get_spamd_username = function (connection) {
         // from. If this is something you care about, this is the spot.
     }
     return user;
-};
+}
 
 exports.get_spamd_headers = function (connection, username) {
     // http://svn.apache.org/repos/asf/spamassassin/trunk/spamd/PROTOCOL
@@ -258,7 +258,7 @@ exports.get_spamd_headers = function (connection, username) {
         headers.push('X-Haraka-Relay: true');
     }
     return headers;
-};
+}
 
 exports.get_spamd_socket = function (next, connection, headers) {
     const plugin = this;
@@ -310,7 +310,7 @@ exports.get_spamd_socket = function (next, connection, headers) {
     }
 
     return socket;
-};
+}
 
 exports.msg_too_big = function (connection) {
     const plugin = this;
@@ -322,7 +322,7 @@ exports.msg_too_big = function (connection) {
     if (size <= max) { return false; }
     connection.loginfo(plugin, `skipping, size ${utils.prettySize(size)} exceeds max: ${utils.prettySize(max)}`);
     return true;
-};
+}
 
 exports.log_results = function (connection, spamd_response) {
     const plugin = this;
@@ -332,5 +332,4 @@ exports.log_results = function (connection, spamd_response) {
           `, required=${spamd_response.reqd}` +
           `, reject=${((connection.relaying) ? (cfg.relay_reject_threshold || cfg.reject_threshold) : cfg.reject_threshold)}` +
           `, tests="${spamd_response.tests}"`);
-};
-
+}

--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -12,7 +12,7 @@ exports.register = function () {
     };
 
     plugin.load_config();
-};
+}
 
 exports.load_config = function () {
     const plugin = this;
@@ -66,7 +66,7 @@ exports.load_config = function () {
     if (!plugin.cfg.relay) {
         plugin.cfg.relay = { context: 'sender' };  // default/legacy
     }
-};
+}
 
 exports.hook_helo = exports.hook_ehlo = function (next, connection, helo) {
     const plugin = this;
@@ -108,7 +108,7 @@ exports.hook_helo = exports.hook_ehlo = function (next, connection, helo) {
         });
         return next();
     });
-};
+}
 
 exports.hook_mail = function (next, connection, params) {
     const plugin = this;
@@ -217,12 +217,12 @@ exports.hook_mail = function (next, connection, params) {
             ch_cb(err, result, connection.remote.ip);
         });
     });
-};
+}
 
 exports.log_result = function (connection, scope, host, mfrom, result, ip) {
     const show_ip=ip ? ip : connection.remote.ip;
     connection.loginfo(this, `identity=${scope} ip=${show_ip} domain="${host}" mfrom=<${mfrom}> result=${result}`);
-};
+}
 
 exports.return_results = function (next, connection, spf, scope, result, sender) {
     const plugin = this;
@@ -260,7 +260,7 @@ exports.return_results = function (next, connection, spf, scope, result, sender)
             connection.logerror(plugin, `unknown result code=${result}`);
             return next();
     }
-};
+}
 
 exports.save_to_header = function (connection, spf, result, mfrom, host, id, ip) {
     const plugin = this;
@@ -270,4 +270,4 @@ exports.save_to_header = function (connection, spf, result, mfrom, host, id, ip)
     connection.transaction.add_leading_header('Received-SPF',
         `${spf.result(result)} (${plugin.config.get('me')}: domain of ${host}${result === spf.SPF_PASS ? ' designates ' : ' does not designate '}${connection.remote.ip} as permitted sender) receiver=${plugin.config.get('me')}; identity=${id}; client-ip=${ip ? ip : connection.remote.ip}; helo=${connection.hello.host}; envelope-from=<${mfrom}>`
     );
-};
+}

--- a/plugins/tarpit.js
+++ b/plugins/tarpit.js
@@ -19,7 +19,7 @@ exports.register = function () {
         const hook = hooks_to_delay[i];
         plugin.register_hook(hook, 'tarpit');
     }
-};
+}
 
 exports.tarpit = function (next, connection) {
     const plugin = this;
@@ -36,4 +36,4 @@ exports.tarpit = function (next, connection) {
     setTimeout(function () {
         return next();
     },  delay * 1000);
-};
+}

--- a/plugins/toobusy.js
+++ b/plugins/toobusy.js
@@ -18,7 +18,7 @@ exports.register = function () {
     plugin.loadConfig();
 
     plugin.register_hook('connect_pre', 'check_busy');
-};
+}
 
 exports.loadConfig = function () {
     const plugin = this;
@@ -31,7 +31,7 @@ exports.loadConfig = function () {
         // This will throw an exception on error
         toobusy.maxLag(maxLag);
     }
-};
+}
 
 exports.check_busy = function (next, connection) {
     if (!toobusy()) {
@@ -49,4 +49,4 @@ exports.check_busy = function (next, connection) {
     }
 
     return next(DENYSOFTDISCONNECT, 'Too busy; please try again later');
-};
+}

--- a/plugins/xclient.js
+++ b/plugins/xclient.js
@@ -34,7 +34,7 @@ exports.hook_capabilities = function (next, connection) {
         connection.capabilities.push('XCLIENT NAME ADDR PROTO HELO LOGIN');
     }
     next();
-};
+}
 
 exports.hook_unrecognized_command = function (next, connection, params) {
     if (params[0] !== 'XCLIENT') {
@@ -127,4 +127,4 @@ exports.hook_unrecognized_command = function (next, connection, params) {
     else {
         return next(NEXT_HOOK, 'connect');
     }
-};
+}

--- a/server.js
+++ b/server.js
@@ -50,14 +50,14 @@ Server.load_smtp_ini = function () {
         if (Server.cfg.main[key] !== undefined) continue;
         Server.cfg.main[key] = defaults[key];
     }
-};
+}
 
 Server.load_http_ini = function () {
     Server.http = {};
     Server.http.cfg = Server.config.get('http.ini', function () {
         Server.load_http_ini();
     }).main;
-};
+}
 
 Server.load_smtp_ini();
 Server.load_http_ini();
@@ -85,7 +85,7 @@ Server.daemonize = function () {
         logger.logerror(err.message);
         logger.dump_and_exit(1);
     }
-};
+}
 
 Server.flushQueue = function (domain) {
     if (!Server.cluster) {
@@ -96,7 +96,7 @@ Server.flushQueue = function (domain) {
     for (const id in cluster.workers) {
         cluster.workers[id].send({event: 'outbound.flush_queue', domain: domain});
     }
-};
+}
 
 let gracefull_in_progress = false;
 
@@ -218,7 +218,7 @@ Server.drainPools = function () {
     for (const id in cluster.workers) {
         cluster.workers[id].send({event: 'outbound.drain_pools'});
     }
-};
+}
 
 Server.sendToMaster = function (command, params) {
     // console.log("Send to master: ", command);
@@ -280,7 +280,7 @@ Server.get_listen_addrs = function (cfg, port) {
     listeners.push(`[::0]:${port}`);
 
     return listeners;
-};
+}
 
 Server.createServer = function (params) {
     const c = Server.cfg.main;
@@ -318,7 +318,7 @@ Server.createServer = function (params) {
     // We fork workers in init_master_respond so that plugins
     // can put handlers on cluster events before they are emitted.
     Server.plugins.run_hooks('init_master', Server);
-};
+}
 
 Server.load_default_tls_config = function (done) {
     // this fn exists solely for testing
@@ -369,7 +369,7 @@ Server.get_smtp_server = function (host, port, inactivity_timeout, done) {
         Server.listeners.push(server);
         done(server);
     }
-};
+}
 
 Server.setup_smtp_listeners = function (plugins2, type, inactivity_timeout) {
 
@@ -490,7 +490,7 @@ Server.setup_http_listeners = function () {
     };
 
     async.each(listeners, setupListener, registerRoutes);
-};
+}
 
 Server.init_master_respond = function (retval, msg) {
     if (!(retval === constants.ok || retval === constants.cont)) {
@@ -537,7 +537,7 @@ Server.init_master_respond = function (retval, msg) {
         });
         cluster.on('exit', cluster_exit_listener);
     });
-};
+}
 
 function cluster_exit_listener (worker, code, signal) {
     if (signal) {
@@ -577,7 +577,7 @@ Server.init_child_respond = function (retval, msg) {
         Server.logerror('Terminating child');
     }
     logger.dump_and_exit(1);
-};
+}
 
 Server.listening = function () {
     const c = Server.cfg.main;
@@ -595,7 +595,7 @@ Server.listening = function () {
     }
 
     Server.ready = 1;
-};
+}
 
 Server.init_http_respond = function () {
     logger.loginfo('init_http_respond');
@@ -617,12 +617,12 @@ Server.init_http_respond = function () {
     logger.loginfo('Server.http.wss loaded');
 
     Server.plugins.run_hooks('init_wss', Server);
-};
+}
 
 Server.init_wss_respond = function () {
     logger.loginfo('init_wss_respond');
     // logger.logdebug(arguments);
-};
+}
 
 Server.get_http_docroot = function () {
     if (Server.http.cfg.docroot) return Server.http.cfg.docroot;
@@ -633,7 +633,7 @@ Server.get_http_docroot = function () {
     );
     logger.loginfo(`using html docroot: ${Server.http.cfg.docroot}`);
     return Server.http.cfg.docroot;
-};
+}
 
 Server.handle404 = function (req, res){
     // abandon all hope, serve up a 404
@@ -652,4 +652,4 @@ Server.handle404 = function (req, res){
     }
 
     res.status(404).send('Not found!');
-};
+}

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -27,7 +27,7 @@ const STATE = {
     ACTIVE: 2,
     RELEASED: 3,
     DESTROYED: 4,
-};
+}
 
 class SMTPClient extends events.EventEmitter {
     constructor (port, host, connect_timeout, idle_timeout, socket) {
@@ -338,13 +338,13 @@ exports.get_pool = (server, port, host, cfg) => {
     };
     server.notes.pool[name] = pool;
     return pool;
-};
+}
 
 // Get a smtp_client for the given attributes.
 exports.get_client = function (server, callback, port, host, cfg) {
     const pool = exports.get_pool(server, port, host, cfg);
     pool.acquire(callback);
-};
+}
 
 
 exports.onCapabilitiesOutbound = function (smtp_client, secured, connection, config, on_secured) {
@@ -526,7 +526,7 @@ exports.get_client_plugin = function (plugin, connection, c, callback) {
 
         callback(err, smtp_client);
     });
-};
+}
 
 function get_hostport (connection, server, cfg) {
 

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -175,7 +175,7 @@ exports.connectionRaw = {
         test.done();
     }
     */
-};
+}
 
 exports.connectionPrivate = {
     setUp: function (done) {

--- a/tests/fixtures/vm_harness.js
+++ b/tests/fixtures/vm_harness.js
@@ -56,4 +56,4 @@ exports.add_tests = function (module_path, tests_path, test_exports, add_to_sand
     for (let x = 0; x < tests.length; x++) {
         test_exports[tests[x]] = make_test(module_path, tests_path + tests[x], additional_sandbox);
     }
-};
+}

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -17,7 +17,7 @@ exports.init = {
         test.ok(this.logger);
         test.done();
     },
-};
+}
 
 exports.log = {
     setUp : _set_up,
@@ -53,7 +53,7 @@ exports.log = {
         test.ok(this.logger.log('INFO', 'another test info'));
         test.done();
     },
-};
+}
 
 exports.level = {
     setUp : _set_up,
@@ -139,7 +139,7 @@ exports.set_loglevel = {
         test.equal(this.logger.loglevel, this.logger.levels.WARN);
         test.done();
     },
-};
+}
 
 exports.set_timestamps = {
     setUp : _set_up,
@@ -158,7 +158,7 @@ exports.set_timestamps = {
         test.equal(this.logger.timestamps, true);
         test.done();
     },
-};
+}
 
 exports.would_log = {
     setUp : _set_up,
@@ -180,7 +180,7 @@ exports.would_log = {
         test.equal(true, this.logger.would_log(1));
         test.done();
     },
-};
+}
 
 exports.log_respond = {
     setUp : _set_up,
@@ -196,7 +196,7 @@ exports.log_respond = {
         test.equal(true, this.logger.log_respond(900, 'test msg', data));
         test.done();
     },
-};
+}
 
 exports.dump_logs = {
     setUp : _set_up,
@@ -215,7 +215,7 @@ exports.dump_logs = {
         test.ok(this.logger.deferred_logs.length === 0);
         test.done();
     },
-};
+}
 
 exports.colors = {
     setUp : _set_up,
@@ -234,7 +234,7 @@ exports.colors = {
         test.equal(expected, this.logger.colorize('blue', 'good'));
         test.done();
     },
-};
+}
 
 exports.log_if_level = {
     setUp : _set_up,
@@ -280,7 +280,7 @@ exports.log_if_level = {
         test.equal(4, this.logger.deferred_logs.length);
         test.done();
     },
-};
+}
 
 exports.add_log_methods = {
     setUp : _set_up,
@@ -301,4 +301,4 @@ exports.add_log_methods = {
         }
         test.done();
     },
-};
+}

--- a/tests/mailbody.js
+++ b/tests/mailbody.js
@@ -76,7 +76,7 @@ exports.basic = {
         test.equal(body.children.length, 2);
         test.done();
     },
-};
+}
 
 exports.banners = {
     'banner': function (test) {
@@ -168,7 +168,7 @@ exports.banners = {
 
         test.done();
     },
-};
+}
 
 exports.filters = {
     'empty': function (test) {
@@ -242,7 +242,7 @@ exports.filters = {
         test.ok(!dupe, 'no duplicate lines found');
         test.done();
     },
-};
+}
 
 exports.rfc2231 = {
     'multi-value': function (test) {
@@ -275,7 +275,7 @@ exports.rfc2231 = {
         test.ok(body.children[1].header.get_decoded('content-type').indexOf('title="This is even more ***fun*** isn\'t it!";') > 0);
         test.done();
     }
-};
+}
 
 exports.boundaries = {
     'with-quotes': function (test) {

--- a/tests/outbound/index.js
+++ b/tests/outbound/index.js
@@ -52,7 +52,7 @@ exports.outbound = {
         });
         test.done();
     }
-};
+}
 
 exports.qfile = {
     setUp : function (done) {
@@ -129,7 +129,7 @@ exports.qfile = {
         test.equal(parts.host, overrides.host);
         test.done();
     }
-};
+}
 
 exports.get_tls_options = {
     setUp : function (done) {

--- a/tests/outbound_bounce_net_errors.js
+++ b/tests/outbound_bounce_net_errors.js
@@ -21,7 +21,7 @@ const outbound       = require('../outbound');
 const outbound_context = {
     TODOItem: TODOItem,
     exports: outbound
-};
+}
 
 const queue_dir = path.resolve(__dirname, 'test-queue');
 

--- a/tests/outbound_bounce_rfc3464.js
+++ b/tests/outbound_bounce_rfc3464.js
@@ -26,7 +26,7 @@ ob_cfg.pool_concurrency_max = 0;
 const outbound_context = {
     TODOItem: TODOItem,
     exports: outbound
-};
+}
 
 const queue_dir = path.resolve(__dirname, 'test-queue');
 

--- a/tests/plugins.js
+++ b/tests/plugins.js
@@ -44,14 +44,14 @@ exports.plugin = {
         test.ok(pi);
         test.done();
     }
-};
+}
 
 const toPath = path.join('config', piName + '.timeout');
 
 const toVals = [ '0', '3', '60', 'apple'];
-const getVal = function () {
+function getVal () {
     return toVals.shift();
-};
+}
 
 exports.get_timeout = {
     setUp : function (done) {
@@ -87,7 +87,7 @@ exports.get_timeout = {
         test.equal( this.plugin.timeout, 30 );
         test.done();
     },
-};
+}
 
 exports.plugin_paths = {
     setUp : function (done) {
@@ -201,8 +201,7 @@ exports.plugin_paths = {
         test.ok(p.base.base_plugin);
         test.done();
     },
-
-};
+}
 
 exports.plugin_config = {
     setUp : function (done) {
@@ -247,4 +246,3 @@ exports.plugin_config = {
         test.done();
     },
 }
-

--- a/tests/plugins/aliases.js
+++ b/tests/plugins/aliases.js
@@ -49,7 +49,7 @@ const _set_up = function (done) {
     this.plugin.register();
 
     done();
-};
+}
 
 exports.aliases = {
     setUp : _set_up,
@@ -373,4 +373,4 @@ exports.aliases = {
 
         this.plugin.aliases(next, this.connection, this.params);
     }
-};
+}

--- a/tests/plugins/auth/auth_base.js
+++ b/tests/plugins/auth/auth_base.js
@@ -58,7 +58,7 @@ exports.hook_capabilities = {
             test.done();
         }, this.connection);
     },
-};
+}
 
 exports.get_plain_passwd = {
     setUp : _set_up,
@@ -76,7 +76,7 @@ exports.get_plain_passwd = {
             test.done();
         });
     },
-};
+}
 
 exports.check_plain_passwd = {
     setUp : _set_up,
@@ -101,7 +101,7 @@ exports.check_plain_passwd = {
             test.done();
         });
     },
-};
+}
 
 exports.select_auth_method = {
     setUp : _set_up,
@@ -131,7 +131,7 @@ exports.select_auth_method = {
             test.done();
         }, this.connection, method);
     },
-};
+}
 
 exports.auth_plain = {
     setUp : _set_up,
@@ -172,7 +172,7 @@ exports.auth_plain = {
         }.bind(this);
         this.plugin.auth_plain(next, this.connection, '');
     },
-};
+}
 
 exports.check_user = {
     setUp : _set_up_2,
@@ -196,7 +196,7 @@ exports.check_user = {
             test.done();
         }, this.connection, credentials, 'PLAIN');
     },
-};
+}
 
 exports.hook_unrecognized_command = {
     setUp : _set_up,
@@ -231,7 +231,7 @@ exports.hook_unrecognized_command = {
             test.done();
         }, this.connection, [utils.base64('discard\0test\0testpass')]);
     }
-};
+}
 
 exports.auth_login = {
     setUp : _set_up,
@@ -343,7 +343,7 @@ exports.auth_login = {
         this.connection.notes.allowed_auth_methods = ['PLAIN','LOGIN'];
         this.plugin.hook_unrecognized_command(next, this.connection, params);
     }
-};
+}
 
 exports.hexi = {
     setUp : _set_up,
@@ -353,5 +353,4 @@ exports.hexi = {
         test.equal(this.plugin.hexi(8), 8);
         test.done();
     },
-};
-
+}

--- a/tests/plugins/auth/auth_vpopmaild.js
+++ b/tests/plugins/auth/auth_vpopmaild.js
@@ -4,7 +4,7 @@ const path         = require('path');
 
 const fixtures     = require('haraka-test-fixtures');
 
-const _set_up = function (done) {
+function _set_up (done) {
     this.backup = {};
 
     // needed for tests
@@ -18,7 +18,7 @@ const _set_up = function (done) {
     this.connection.capabilities=null;
 
     done();
-};
+}
 
 exports.hook_capabilities = {
     setUp : _set_up,
@@ -58,7 +58,7 @@ exports.hook_capabilities = {
         this.connection.capabilities=[];
         this.plugin.hook_capabilities(cb, this.connection);
     },
-};
+}
 
 exports.get_vpopmaild_socket = {
     setUp : _set_up,
@@ -70,7 +70,7 @@ exports.get_vpopmaild_socket = {
         socket.end();
         test.done();
     }
-};
+}
 
 exports.get_plain_passwd = {
     setUp : _set_up,
@@ -88,4 +88,4 @@ exports.get_plain_passwd = {
             test.done();
         }
     }
-};
+}

--- a/tests/plugins/bounce.js
+++ b/tests/plugins/bounce.js
@@ -8,7 +8,7 @@ const Connection   = fixtures.connection;
 const Body         = require('../../mailbody').Body;
 const Header       = require('../../mailheader').Header;
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('bounce');
     this.plugin.cfg = {
@@ -36,7 +36,7 @@ const _set_up = function (done) {
     };
 
     done();
-};
+}
 
 exports.load_configs = {
     setUp : _set_up,
@@ -56,7 +56,7 @@ exports.load_configs = {
         test.ok(this.plugin.cfg.reject);
         test.done();
     },
-};
+}
 
 exports.reject_all = {
     setUp : _set_up,
@@ -93,7 +93,7 @@ exports.reject_all = {
         this.plugin.reject_all(cb, this.connection, new Address.Address('<>'));
         test.done();
     },
-};
+}
 
 exports.empty_return_path = {
     setUp : _set_up,
@@ -118,7 +118,7 @@ exports.empty_return_path = {
         this.plugin.empty_return_path(cb, this.connection);
         test.done();
     },
-};
+}
 
 exports.non_local_msgid = {
     setUp: _set_up,
@@ -225,7 +225,7 @@ exports.single_recipient = {
         this.plugin.single_recipient(cb, this.connection);
         test.done();
     },
-};
+}
 
 exports.bad_rcpt = {
     setUp : _set_up,
@@ -278,7 +278,7 @@ exports.bad_rcpt = {
         this.plugin.bad_rcpt(cb, this.connection);
         test.done();
     },
-};
+}
 
 exports.has_null_sender = {
     setUp : _set_up,
@@ -306,4 +306,4 @@ exports.has_null_sender = {
         test.equal(false, this.plugin.has_null_sender(this.connection));
         test.done();
     },
-};
+}

--- a/tests/plugins/clamd.js
+++ b/tests/plugins/clamd.js
@@ -4,7 +4,7 @@ const fixtures     = require('haraka-test-fixtures');
 
 const Connection   = fixtures.connection;
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('clamd');
     this.plugin.register();
@@ -17,7 +17,7 @@ const _set_up = function (done) {
     };
 
     done();
-};
+}
 
 exports.load_clamd_ini = {
     setUp : _set_up,
@@ -61,7 +61,7 @@ exports.load_clamd_ini = {
         test.equal(false, this.plugin.rejectRE.test('MattWuzHere'));
         test.done();
     },
-};
+}
 
 exports.hook_data = {
     setUp : _set_up,
@@ -85,7 +85,7 @@ exports.hook_data = {
         }.bind(this);
         this.plugin.hook_data(next, this.connection);
     },
-};
+}
 
 exports.hook_data_post = {
     setUp : _set_up,
@@ -109,4 +109,4 @@ exports.hook_data_post = {
         }.bind(this);
         this.plugin.hook_data_post(next, this.connection);
     },
-};
+}

--- a/tests/plugins/data.headers.js
+++ b/tests/plugins/data.headers.js
@@ -5,7 +5,7 @@ const fixtures     = require('haraka-test-fixtures');
 
 const Header       = require('../../mailheader').Header;
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('data.headers');
 
@@ -25,7 +25,7 @@ const _set_up = function (done) {
     };
 
     done();
-};
+}
 
 exports.invalid_date = {
     setUp : _set_up,
@@ -33,18 +33,18 @@ exports.invalid_date = {
         test.expect(0);
         test.done();
     },
-};
+}
 
 exports.user_agent = {
     setUp : _set_up,
     'none': function (test) {
         test.expect(2);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /UA/.test(r.fail));
             test.equal(false, /UA/.test(r.pass));
-        };
+        }
         outer.plugin.cfg.check.user_agent=true;
         outer.plugin.user_agent(next_cb, outer.connection);
         test.done();
@@ -52,11 +52,11 @@ exports.user_agent = {
     'user-agent': function (test) {
         test.expect(2);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /UA/.test(r.pass));
             test.equal(false, /UA/.test(r.fail));
-        };
+        }
         outer.plugin.cfg.check.user_agent=true;
         outer.connection.transaction.header.add_end('User-Agent', 'Thunderbird');
         outer.plugin.user_agent(next_cb, outer.connection);
@@ -65,17 +65,17 @@ exports.user_agent = {
     'X-mailer': function (test) {
         test.expect(2);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /UA/.test(r.pass));
             test.equal(false, /UA/.test(r.fail));
-        };
+        }
         outer.plugin.cfg.check.user_agent=true;
         outer.connection.transaction.header.add_end('X-Mailer', 'Apple Mail');
         outer.plugin.user_agent(next_cb, outer.connection);
         test.done();
     },
-};
+}
 
 exports.direct_to_mx = {
     setUp : _set_up,
@@ -83,12 +83,12 @@ exports.direct_to_mx = {
         test.expect(3);
         this.connection.notes.auth_user = 'test@example.com';
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /^direct-to-mx/.test(r.skip));
             test.equal(false, /^direct-to-mx/.test(r.pass));
             test.equal(false, /^direct-to-mx/.test(r.fail));
-        };
+        }
         this.plugin.cfg.check.direct_to_mx=true;
         this.plugin.direct_to_mx(next_cb, this.connection);
         test.done();
@@ -96,12 +96,12 @@ exports.direct_to_mx = {
     'received 0': function (test) {
         test.expect(3);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /^direct-to-mx/.test(r.fail));
             test.equal(false, /^direct-to-mx/.test(r.pass));
             test.equal(false, /^direct-to-mx/.test(r.skip));
-        };
+        }
         this.plugin.cfg.check.direct_to_mx=true;
         this.plugin.direct_to_mx(next_cb, this.connection);
         test.done();
@@ -109,10 +109,10 @@ exports.direct_to_mx = {
     'received 1': function (test) {
         test.expect(1);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /^direct-to-mx/.test(r.fail));
-        };
+        }
         this.plugin.cfg.check.direct_to_mx=true;
         this.connection.transaction.header.add_end('Received', 'blah');
         this.plugin.direct_to_mx(next_cb, this.connection);
@@ -121,29 +121,29 @@ exports.direct_to_mx = {
     'received 2': function (test) {
         test.expect(3);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /^direct-to-mx/.test(r.pass));
             test.equal(false, /^direct-to-mx/.test(r.fail));
             test.equal(false, /^direct-to-mx/.test(r.skip));
-        };
+        }
         this.plugin.cfg.check.direct_to_mx=true;
         this.connection.transaction.header.add_end('Received', 'blah1');
         this.connection.transaction.header.add_end('Received', 'blah2');
         this.plugin.direct_to_mx(next_cb, this.connection);
         test.done();
     },
-};
+}
 
 exports.from_match = {
     setUp : _set_up,
     'match bare': function (test) {
         test.expect(1);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.notEqual(-1, r.pass.indexOf('from_match'));
-        };
+        }
         this.plugin.cfg.check.from_match=true;
         this.connection.transaction.mail_from = new Address.Address('<test@example.com>');
         this.connection.transaction.header.add_end('From', 'test@example.com');
@@ -153,10 +153,10 @@ exports.from_match = {
     'match typical': function (test) {
         test.expect(1);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.notEqual(-1, r.pass.indexOf('from_match'));
-        };
+        }
         this.plugin.cfg.check.from_match=true;
         this.connection.transaction.mail_from = new Address.Address('<test@example.com>');
         this.connection.transaction.header.add_end('From', '"Test User" <test@example.com>');
@@ -166,10 +166,10 @@ exports.from_match = {
     'match unquoted': function (test) {
         test.expect(1);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.notEqual(-1, r.pass.indexOf('from_match'));
-        };
+        }
         this.plugin.cfg.check.from_match=true;
         this.connection.transaction.mail_from = new Address.Address('<test@example.com>');
         this.connection.transaction.header.add_end('From', 'Test User <test@example.com>');
@@ -179,28 +179,28 @@ exports.from_match = {
     'mismatch': function (test) {
         test.expect(1);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /^from_match/.test(r.fail));
-        };
+        }
         this.plugin.cfg.check.from_match=true;
         this.connection.transaction.mail_from = new Address.Address('<test@example.com>');
         this.connection.transaction.header.add_end('From', "test@example.net");
         this.plugin.from_match(next_cb, this.connection);
         test.done();
     },
-};
+}
 
 exports.mailing_list = {
     setUp : _set_up,
     'ezmlm true': function (test) {
         test.expect(2);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /ezmlm/.test(r.pass));
             test.equal(0, r.fail.length);
-        };
+        }
         this.plugin.cfg.check.mailing_list=true;
         this.connection.transaction.header.add_end('Mailing-List', "blah blah: run by ezmlm");
         this.plugin.mailing_list(next_cb, this.connection);
@@ -209,11 +209,11 @@ exports.mailing_list = {
     'ezmlm false': function (test) {
         test.expect(2);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(r.pass.length, 0);
             test.equal(true, /not/.test(r.msg));
-        };
+        }
         this.plugin.cfg.check.mailing_list=true;
         this.connection.transaction.header.add_end('Mailing-List', "blah blah random header tokens");
         this.plugin.mailing_list(next_cb, this.connection);
@@ -222,10 +222,10 @@ exports.mailing_list = {
     'yahoogroups': function (test) {
         test.expect(1);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /yahoogroups/.test(r.pass));
-        };
+        }
         this.plugin.cfg.check.mailing_list=true;
         outer.connection.transaction.header.add_end('Mailing-List', "blah blah such-and-such@yahoogroups.com email list");
         this.plugin.mailing_list(next_cb, this.connection);
@@ -234,10 +234,10 @@ exports.mailing_list = {
     'majordomo': function (test) {
         test.expect(1);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /majordomo/.test(r.pass));
-        };
+        }
         this.plugin.cfg.check.mailing_list=true;
         outer.connection.transaction.header.add_end('Sender', "owner-blah-blah whatcha");
         outer.plugin.mailing_list(next_cb, outer.connection);
@@ -247,10 +247,10 @@ exports.mailing_list = {
         test.expect(1);
         const outer = this;
         outer.connection.transaction.header.add_end('X-Mailman-Version', "owner-blah-blah whatcha");
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /mailman/.test(r.pass));
-        };
+        }
         this.plugin.cfg.check.mailing_list=true;
         this.plugin.mailing_list(next_cb, this.connection);
         test.done();
@@ -258,10 +258,10 @@ exports.mailing_list = {
     'majordomo v': function (test) {
         test.expect(1);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /majordomo/.test(r.pass));
-        };
+        }
         this.plugin.cfg.check.mailing_list=true;
         this.connection.transaction.header.add_end('X-Majordomo-Version', "owner-blah-blah whatcha");
         this.plugin.mailing_list(next_cb, this.connection);
@@ -270,16 +270,16 @@ exports.mailing_list = {
     'google groups': function (test) {
         test.expect(1);
         const outer = this;
-        const next_cb = function () {
+        function next_cb () {
             const r = outer.connection.transaction.results.get('data.headers');
             test.equal(true, /googlegroups/.test(r.pass));
-        };
+        }
         this.plugin.cfg.check.mailing_list=true;
         this.connection.transaction.header.add_end('X-Google-Loop', "blah-blah whatcha");
         this.plugin.mailing_list(next_cb, this.connection);
         test.done();
     },
-};
+}
 
 exports.delivered_to = {
     setUp : _set_up,
@@ -342,4 +342,4 @@ exports.delivered_to = {
         this.connection.transaction.rcpt_to.push(new Address.Address('user@example.com'));
         this.plugin.delivered_to(next_cb, this.connection);
     },
-};
+}

--- a/tests/plugins/deprecated/relay_acl.js
+++ b/tests/plugins/deprecated/relay_acl.js
@@ -2,7 +2,7 @@
 
 const fixtures     = require('haraka-test-fixtures');
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('relay_acl');
     this.plugin.cfg = {};
@@ -13,7 +13,7 @@ const _set_up = function (done) {
     };
 
     done();
-};
+}
 
 exports.is_acl_allowed = {
     setUp : _set_up,
@@ -54,87 +54,87 @@ exports.is_acl_allowed = {
 
         test.done();
     },
-};
+}
 
 exports.relay_dest_domains = {
     setUp : _set_up,
     'relaying' : function (test) {
         test.expect(2);
         const outer = this;
-        const next = function () {
+        function next () {
             // console.log(outer.connection.results.get('relay_acl'));
             // console.log(outer.connection.transaction.results.get('relay_acl'));
             test.equal(undefined, arguments[0]);
             test.equal(1, outer.connection.transaction.results.get('relay_acl').skip.length);
             test.done();
-        };
+        }
         this.connection.relaying=true;
         this.plugin.relay_dest_domains(next, this.connection, [{host:'foo'}]);
     },
     'no config' : function (test) {
         test.expect(2);
         const outer = this;
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.equal(1, outer.connection.transaction.results.get('relay_acl').skip.length);
             test.done();
-        };
+        }
         this.plugin.relay_dest_domains(next, this.connection, [{host:'foo'}]);
     },
     'action=undef' : function (test) {
         test.expect(2);
         const outer = this;
-        const next = function () {
+        function next () {
             test.equal(DENY, arguments[0]);
             test.equal(1, outer.connection.transaction.results.get('relay_acl').fail.length);
             test.done();
-        };
+        }
         this.plugin.cfg.domains = { foo: '{"action":"dunno"}' };
         this.plugin.relay_dest_domains(next, this.connection, [{host:'foo'}]);
     },
     'action=deny' : function (test) {
         test.expect(2);
         const outer = this;
-        const next = function () {
+        function next () {
             test.equal(DENY, arguments[0]);
             test.equal(1, outer.connection.transaction.results.get('relay_acl').fail.length);
             test.done();
-        };
+        }
         this.plugin.cfg.domains = { foo: '{"action":"deny"}' };
         this.plugin.relay_dest_domains(next, this.connection, [{host:'foo'}]);
     },
     'action=continue' : function (test) {
         test.expect(2);
         const outer = this;
-        const next = function () {
+        function next () {
             test.equal(CONT, arguments[0]);
             test.equal(1, outer.connection.transaction.results.get('relay_acl').pass.length);
             test.done();
-        };
+        }
         this.plugin.cfg.domains = { foo: '{"action":"continue"}' };
         this.plugin.relay_dest_domains(next, this.connection, [{host:'foo'}]);
     },
     'action=accept' : function (test) {
         test.expect(2);
         const outer = this;
-        const next = function () {
+        function next () {
             test.equal(CONT, arguments[0]);
             test.equal(1, outer.connection.transaction.results.get('relay_acl').pass.length);
             test.done();
-        };
+        }
         this.plugin.cfg.domains = { foo: '{"action":"continue"}' };
         this.plugin.relay_dest_domains(next, this.connection, [{host:'foo'}]);
     },
-};
+}
 
 exports.refresh_config = {
     setUp : _set_up,
     'callback' : function (test) {
         test.expect(1);
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         this.plugin.refresh_config(next, this.connection);
     },
-};
+}

--- a/tests/plugins/deprecated/relay_all.js
+++ b/tests/plugins/deprecated/relay_all.js
@@ -2,7 +2,7 @@
 
 const fixtures     = require('haraka-test-fixtures');
 
-const _set_up = function (callback) {
+function _set_up (callback) {
 
     this.plugin = new fixtures.plugin('relay_all');
     this.connection = fixtures.connection.createConnection();
@@ -11,7 +11,7 @@ const _set_up = function (callback) {
     this.plugin.register();
 
     callback();
-};
+}
 
 exports.relay_all = {
     setUp : _set_up,
@@ -56,4 +56,4 @@ exports.relay_all = {
 
         this.plugin.confirm_all(next, this.connection, this.params);
     }
-};
+}

--- a/tests/plugins/dkim_sign.js
+++ b/tests/plugins/dkim_sign.js
@@ -18,7 +18,7 @@ const _set_up = function (done) {
     this.connection.transaction = fixtures.transaction.createTransaction();
 
     done();
-};
+}
 
 exports.get_sender_domain = {
     setUp : _set_up,
@@ -108,7 +108,7 @@ exports.get_sender_domain = {
         test.equal('example.net', r);
         test.done();
     },
-};
+}
 
 exports.get_key_dir = {
     setUp : function (done) {
@@ -155,7 +155,7 @@ exports.get_key_dir = {
             test.done();
         });
     },
-};
+}
 
 exports.get_headers_to_sign = {
     setUp : _set_up,
@@ -185,4 +185,4 @@ exports.get_headers_to_sign = {
         );
         test.done();
     },
-};
+}

--- a/tests/plugins/dns_list_base.js
+++ b/tests/plugins/dns_list_base.js
@@ -7,7 +7,7 @@ const _set_up = function (done) {
     this.plugin = new fixtures.plugin('dns_list_base');
 
     done();
-};
+}
 
 exports.disable_zone = {
     setUp : _set_up,
@@ -41,7 +41,7 @@ exports.disable_zone = {
         test.equal(0, this.plugin.zones.length);
         test.done();
     },
-};
+}
 
 exports.lookup = {
     setUp : _set_up,
@@ -63,7 +63,7 @@ exports.lookup = {
         }.bind(this);
         this.plugin.lookup('127.0.0.1', 'bl.spamcop.net', cb);
     },
-};
+}
 
 exports.multi = {
     setUp : _set_up,
@@ -151,7 +151,7 @@ exports.multi = {
         const dnsbls = ['bl.spamcop.net','cbl.abuseat.org'];
         this.plugin.multi('::1', dnsbls, cb);
     }
-};
+}
 
 exports.first = {
     setUp : _set_up,
@@ -193,4 +193,4 @@ exports.first = {
         };
         this.plugin.first('127.0.0.2', dnsbls, cb, cb_each);
     }
-};
+}

--- a/tests/plugins/dnsbl.js
+++ b/tests/plugins/dnsbl.js
@@ -5,7 +5,7 @@ const fixtures     = require('haraka-test-fixtures');
 
 const Connection   = fixtures.connection;
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('dnsbl');
     this.plugin.config.root_path = path.resolve(__dirname, '../../config');
@@ -13,7 +13,7 @@ const _set_up = function (done) {
     this.connection = Connection.createConnection();
 
     done();
-};
+}
 
 exports.load_config = {
     setUp : _set_up,
@@ -30,7 +30,7 @@ exports.load_config = {
         test.equal('first', this.plugin.cfg.main.search);
         test.done();
     },
-};
+}
 
 exports.get_uniq_zones = {
     setUp : _set_up,
@@ -49,7 +49,7 @@ exports.get_uniq_zones = {
 
         test.done();
     },
-};
+}
 
 exports.should_skip = {
     setUp : _set_up,
@@ -98,4 +98,4 @@ exports.should_skip = {
         test.equal(true, this.plugin.should_skip(this.connection));
         test.done();
     },
-};
+}

--- a/tests/plugins/early_talker.js
+++ b/tests/plugins/early_talker.js
@@ -2,14 +2,14 @@
 
 const fixtures     = require('haraka-test-fixtures');
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('early_talker');
     this.plugin.cfg = { main: { reject: true } };
 
     this.connection = fixtures.connection.createConnection();
     done();
-};
+}
 
 function _tear_down (done) { done(); }
 
@@ -99,4 +99,4 @@ exports.early_talker = {
         test.equal(whitelist[1][1], 16);
         test.done();
     },
-};
+}

--- a/tests/plugins/greylist.js
+++ b/tests/plugins/greylist.js
@@ -28,7 +28,7 @@ const _set_up = function (done) {
     };
 
     done();
-};
+}
 
 exports.in_list = {
     setUp : _set_up,
@@ -55,4 +55,4 @@ exports.in_list = {
         test.ok(this.plugin.ip_in_list('2a02:8204:d600:8060:7920:eeee::ff00'));
         test.done();
     }
-};
+}

--- a/tests/plugins/helo.checks.js
+++ b/tests/plugins/helo.checks.js
@@ -16,7 +16,7 @@ const _set_up = function (done) {
     this.plugin.register();
 
     done();
-};
+}
 
 exports.init = {
     setUp: _set_up,
@@ -59,7 +59,7 @@ exports.host_mismatch = {
         this.plugin.host_mismatch(cb, this.connection, 'anything');
         test.done();
     },
-};
+}
 
 exports.proto_mismatch = {
     setUp : _set_up,
@@ -108,7 +108,7 @@ exports.proto_mismatch = {
         this.plugin.proto_mismatch(cb, this.connection, 'anything', 'esmtp');
         test.done();
     },
-};
+}
 
 exports.rdns_match = {
     setUp : _set_up,
@@ -171,7 +171,7 @@ exports.rdns_match = {
         this.plugin.rdns_match(cb, this.connection, 'helo.example.com');
         test.done();
     },
-};
+}
 
 exports.bare_ip = {
     setUp : _set_up,
@@ -215,7 +215,7 @@ exports.bare_ip = {
         this.plugin.bare_ip(cb, this.connection, '192.168.1.1');
         test.done();
     },
-};
+}
 
 exports.dynamic = {
     setUp : _set_up,
@@ -266,7 +266,7 @@ exports.dynamic = {
         this.plugin.dynamic(cb, this.connection, test_helo);
         test.done();
     },
-};
+}
 
 exports.big_company = {
     setUp : _set_up,
@@ -316,7 +316,7 @@ exports.big_company = {
         this.plugin.cfg.reject.big_company=true;
         this.plugin.big_company(cb, this.connection, test_helo);
     },
-};
+}
 
 exports.literal_mismatch = {
     setUp : _set_up,
@@ -386,7 +386,7 @@ exports.literal_mismatch = {
         this.plugin.cfg.reject.literal_mismatch=true;
         this.plugin.literal_mismatch(cb, this.connection, test_helo);
     },
-};
+}
 
 exports.valid_hostname = {
     setUp : _set_up,
@@ -435,7 +435,7 @@ exports.valid_hostname = {
         this.plugin.cfg.reject.valid_hostname=true;
         this.plugin.valid_hostname(cb, this.connection, test_helo);
     },
-};
+}
 
 exports.forward_dns = {
     setUp : _set_up,
@@ -490,7 +490,7 @@ exports.forward_dns = {
         this.plugin.cfg.reject.forward_dns=true;
         this.plugin.forward_dns(cb, this.connection, test_helo);
     },
-};
+}
 
 exports.match_re = {
     setUp : _set_up,
@@ -549,4 +549,4 @@ exports.match_re = {
         this.plugin.cfg.list_re = new RegExp(`^(${['ylm.*'].join('|')})$`, 'i');
         this.plugin.match_re(cb, this.connection, test_helo);
     },
-};
+}

--- a/tests/plugins/mail_from.is_resolvable.js
+++ b/tests/plugins/mail_from.is_resolvable.js
@@ -16,7 +16,7 @@ const _set_up = function (done) {
     };
 
     done();
-};
+}
 
 exports.mxErr = {
     setUp : _set_up,
@@ -50,7 +50,7 @@ exports.mxErr = {
         test.equal(mf.msg[0], 'any.com:MX:oops');
         test.done();
     }
-};
+}
 
 exports.implicit_mx = {
     setUp : _set_up,
@@ -157,5 +157,4 @@ exports.implicit_mx = {
             test.done();
         });
     },
-};
-
+}

--- a/tests/plugins/queue/smtp_forward.js
+++ b/tests/plugins/queue/smtp_forward.js
@@ -33,7 +33,7 @@ exports.loadingTLSConfig = {
 
         test.done();
     },
-};
+}
 
 exports.register = {
     setUp : _setup,
@@ -43,7 +43,7 @@ exports.register = {
         test.ok(this.plugin.cfg.main);
         test.done();
     },
-};
+}
 
 exports.get_config = {
     setUp : _setup,
@@ -110,23 +110,23 @@ exports.get_config = {
         test.deepEqual(cfg.host, '1.2.3.4' );
         test.done();
     },
-};
+}
 
 const hmail = { todo: { notes: {} } };
 exports.get_mx = {
     setUp : _setup,
     'returns no outbound route for undefined domains' : function (test) {
         test.expect(2);
-        const cb = function (code, mx) {
+        function cb (code, mx) {
             test.equal(code, undefined);
             test.deepEqual(mx, undefined);
             test.done();
-        };
+        }
         this.plugin.get_mx(cb, hmail, 'undefined.com');
     },
     'returns an outbound route for defined domains' : function (test) {
         test.expect(2);
-        const cb = function (code, mx) {
+        function cb (code, mx) {
             test.equal(code, OK);
             test.deepEqual(mx, {
                 priority: 0, exchange: '1.2.3.4', port: 2555,
@@ -134,7 +134,8 @@ exports.get_mx = {
                 auth_pass: 'superDuperSecret'
             });
             test.done();
-        };
+        }
         this.plugin.get_mx(cb, hmail, 'test.com');
     },
 }
+

--- a/tests/plugins/rcpt_to.host_list_base.js
+++ b/tests/plugins/rcpt_to.host_list_base.js
@@ -3,7 +3,7 @@
 const Address      = require('address-rfc2821').Address;
 const fixtures     = require('haraka-test-fixtures');
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('rcpt_to.host_list_base');
     this.plugin.cfg = {};
@@ -16,7 +16,7 @@ const _set_up = function (done) {
     };
 
     done();
-};
+}
 
 exports.in_host_list = {
     setUp : _set_up,
@@ -31,7 +31,7 @@ exports.in_host_list = {
         test.equal(true, this.plugin.in_host_list('test.com'));
         test.done();
     },
-};
+}
 
 exports.in_host_regex = {
     setUp : _set_up,
@@ -65,7 +65,7 @@ exports.in_host_regex = {
         test.equal(true, r);
         test.done();
     },
-};
+}
 
 exports.hook_mail = {
     setUp : _set_up,
@@ -129,4 +129,4 @@ exports.hook_mail = {
         this.plugin.hl_re = new RegExp (`^(?:${this.plugin.host_list_regex.join('|')})$`, 'i');
         this.plugin.hook_mail(next, this.connection, [new Address('<user@example.com>')]);
     },
-};
+}

--- a/tests/plugins/rcpt_to.in_host_list.js
+++ b/tests/plugins/rcpt_to.in_host_list.js
@@ -3,7 +3,7 @@
 const Address      = require('address-rfc2821').Address;
 const fixtures     = require('haraka-test-fixtures');
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('rcpt_to.in_host_list');
     this.plugin.inherits('rcpt_to.host_list_base');
@@ -17,7 +17,7 @@ const _set_up = function (done) {
     };
 
     done();
-};
+}
 
 exports.in_host_list = {
     setUp : _set_up,
@@ -34,7 +34,7 @@ exports.in_host_list = {
         test.equal(true, r);
         test.done();
     },
-};
+}
 
 exports.in_host_regex = {
     setUp : _set_up,
@@ -68,7 +68,7 @@ exports.in_host_regex = {
         test.equal(true, r);
         test.done();
     },
-};
+}
 
 exports.hook_mail = {
     setUp : _set_up,
@@ -135,17 +135,17 @@ exports.hook_mail = {
         this.plugin.hl_re = new RegExp (`^(?:${this.plugin.host_list_regex.join('|')})$`, 'i');
         this.plugin.hook_mail(next, this.connection, [new Address('<user@example.com>')]);
     },
-};
+}
 
 exports.hook_rcpt = {
     setUp : _set_up,
     'missing txn' : function (test) {
         test.expect(1);
         // sometimes txn goes away, make sure it's handled
-        const next = function (rc, msg) {
+        function next (rc, msg) {
             test.equal(undefined, rc);
             test.equal(undefined, msg);
-        };
+        }
         delete this.connection.transaction;
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
         test.ok(true);
@@ -153,66 +153,66 @@ exports.hook_rcpt = {
     },
     'hit list' : function (test) {
         test.expect(2);
-        const next = function (rc, msg) {
+        function next (rc, msg) {
             test.equal(OK, rc);
             test.equal(undefined, msg);
             test.done();
-        };
+        }
         this.plugin.host_list = { 'test.com': true };
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
     },
     'miss list' : function (test) {
         test.expect(2);
-        const next = function (rc, msg) {
+        function next (rc, msg) {
             test.equal(undefined, rc);
             test.equal(undefined, msg);
             test.done();
-        };
+        }
         this.plugin.host_list = { 'miss.com': true };
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
     },
     'hit regex, exact' : function (test) {
         test.expect(2);
-        const next = function (rc, msg) {
+        function next (rc, msg) {
             test.equal(OK, rc);
             test.equal(undefined, msg);
             test.done();
-        };
+        }
         this.plugin.host_list_regex=['test.com'];
         this.plugin.hl_re = new RegExp (`^(?:${this.plugin.host_list_regex.join('|')})$`, 'i');
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
     },
     'hit regex, pattern' : function (test) {
         test.expect(2);
-        const next = function (rc, msg) {
+        function next (rc, msg) {
             test.equal(OK, rc);
             test.equal(undefined, msg);
             test.done();
-        };
+        }
         this.plugin.host_list_regex=['.est.com'];
         this.plugin.hl_re = new RegExp (`^(?:${this.plugin.host_list_regex.join('|')})$`, 'i');
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
     },
     'miss regex, pattern' : function (test) {
         test.expect(2);
-        const next = function (rc, msg) {
+        function next (rc, msg) {
             test.equal(undefined, rc);
             test.equal(undefined, msg);
             test.done();
-        };
+        }
         this.plugin.host_list_regex=['a.est.com'];
         this.plugin.hl_re = new RegExp (`^(?:${this.plugin.host_list_regex.join('|')})$`, 'i');
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
     },
     'rcpt miss, relaying to local sender' : function (test) {
         test.expect(2);
-        const next = function (rc, msg) {
+        function next (rc, msg) {
             test.equal(OK, rc);
             test.equal(undefined, msg);
             test.done();
-        };
+        }
         this.connection.relaying=true;
         this.connection.transaction.notes = { local_sender: true };
         this.plugin.hook_rcpt(next, this.connection, [new Address('test@test.com')]);
     },
-};
+}

--- a/tests/plugins/relay.js
+++ b/tests/plugins/relay.js
@@ -2,14 +2,14 @@
 
 const fixtures     = require('haraka-test-fixtures');
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('relay');
     this.plugin.cfg = {};
     this.connection = fixtures.connection.createConnection();
 
     done();
-};
+}
 
 exports.plugin = {
     setUp : _set_up,
@@ -27,7 +27,7 @@ exports.plugin = {
         // console.log(this.plugin);
         test.done();
     },
-};
+}
 
 exports.load_config_files = {
     setUp : _set_up,
@@ -45,7 +45,7 @@ exports.load_config_files = {
         test.ok(typeof this.plugin.dest === 'object');
         test.done();
     },
-};
+}
 
 exports.is_acl_allowed = {
     setUp : _set_up,
@@ -86,7 +86,7 @@ exports.is_acl_allowed = {
 
         test.done();
     },
-};
+}
 
 exports.acl = {
     setUp : function (callback) {
@@ -150,7 +150,7 @@ exports.acl = {
         this.plugin.acl_allow=['1.1.1.1/24'];
         this.plugin.acl(next, this.connection);
     },
-};
+}
 
 exports.dest_domains = {
     setUp : function (callback) {
@@ -232,7 +232,7 @@ exports.dest_domains = {
         this.plugin.dest = { domains: { foo: '{"action":"continue"}' } };
         this.plugin.dest_domains(next, this.connection, [{host:'foo'}]);
     },
-};
+}
 
 exports.force_routing = {
     setUp : function (callback) {
@@ -285,7 +285,7 @@ exports.force_routing = {
         this.plugin.dest = { domains: { foo: '{"action":"blah blah","nexthop":"other-server"}' } };
         this.plugin.force_routing(next, this.connection, 'foo');
     },
-};
+}
 
 exports.all = {
     setUp : _set_up,
@@ -319,4 +319,4 @@ exports.all = {
         this.plugin.cfg.relay = { all: true };
         this.plugin.all(next, this.connection, ['foo@bar.com']);
     }
-};
+}

--- a/tests/plugins/spamassassin.js
+++ b/tests/plugins/spamassassin.js
@@ -6,7 +6,7 @@ const fixtures     = require('haraka-test-fixtures');
 const Connection   = fixtures.connection;
 const stub         = fixtures.stub.stub;
 
-const _set_up = function (done) {
+function _set_up (done) {
 
     this.plugin = new fixtures.plugin('spamassassin');
     this.plugin.cfg = { main: { } };
@@ -16,7 +16,7 @@ const _set_up = function (done) {
     this.connection.transaction.notes = {};
 
     done();
-};
+}
 
 exports.register = {
     setUp : _set_up,
@@ -32,7 +32,7 @@ exports.register = {
         test.ok(this.plugin.cfg.main.spamd_socket);
         test.done();
     },
-};
+}
 
 exports.load_spamassassin_ini = {
     setUp : _set_up,
@@ -43,7 +43,7 @@ exports.load_spamassassin_ini = {
         test.ok(this.plugin.cfg.main.spamd_socket);
         test.done();
     },
-};
+}
 
 exports.msg_too_big = {
     setUp : _set_up,
@@ -66,7 +66,7 @@ exports.msg_too_big = {
         test.equal(true, this.plugin.msg_too_big(this.connection));
         test.done();
     },
-};
+}
 
 // console.log(this.plugin.cfg);
 
@@ -87,7 +87,7 @@ exports.get_spamd_headers = {
         test.deepEqual(headers, expected_headers);
         test.done();
     },
-};
+}
 
 exports.get_spamd_username = {
     setUp : _set_up,
@@ -115,7 +115,7 @@ exports.get_spamd_username = {
 
         test.done();
     },
-};
+}
 
 exports.score_too_high = {
     setUp : _set_up,
@@ -144,4 +144,4 @@ exports.score_too_high = {
         test.equal('spam score exceeded relay threshold', this.plugin.score_too_high(this.connection, {score: 8}));
         test.done();
     },
-};
+}

--- a/tests/plugins/spf.js
+++ b/tests/plugins/spf.js
@@ -20,173 +20,161 @@ const _set_up = function (done) {
     this.connection.transaction.results = new fixtures.results(this.connection);
 
     done();
-};
+}
 
 exports.return_results = {
     setUp : _set_up,
     'result, none': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
-        this.plugin.return_results(next, this.connection,
-            spf, 'mfrom', spf.NONE, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.NONE, 'test@example.com');
     },
     'result, neutral': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
-        this.plugin.return_results(next, this.connection,
-            spf, 'mfrom', spf.NEUTRAL, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.NEUTRAL, 'test@example.com');
     },
     'result, pass': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
-        this.plugin.return_results(next, this.connection,
-            spf, 'mfrom', spf.SPF_PASS, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_PASS, 'test@example.com');
     },
     'result, softfail, reject=false': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.deny.mfrom_softfail=false;
-        this.plugin.return_results(next, this.connection,
-            spf, 'mfrom', spf.SPF_SOFTFAIL, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_SOFTFAIL, 'test@example.com');
     },
     'result, softfail, reject=true': function (test) {
-        const next = function () {
+        function next () {
             test.equal(DENY, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.deny.mfrom_softfail=true;
-        this.plugin.return_results(next, this.connection, spf,
-            'mfrom', spf.SPF_SOFTFAIL, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_SOFTFAIL, 'test@example.com');
     },
     'result, fail, reject=false': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.deny.mfrom_fail=false;
-        this.plugin.return_results(next, this.connection, spf,
-            'mfrom', spf.SPF_FAIL, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_FAIL, 'test@example.com');
     },
     'result, fail, reject=true': function (test) {
-        const next = function () {
+        function next () {
             test.equal(DENY, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.deny.mfrom_fail=true;
-        this.plugin.return_results(next, this.connection, spf,
-            'mfrom', spf.SPF_FAIL, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_FAIL, 'test@example.com');
     },
     'result, temperror, reject=false': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.defer.mfrom_temperror=false;
-        this.plugin.return_results(next, this.connection, spf,
-            'mfrom', spf.SPF_TEMPERROR, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_TEMPERROR, 'test@example.com');
     },
     'result, temperror, reject=true': function (test) {
-        const next = function () {
+        function next () {
             test.equal(DENYSOFT, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.defer.mfrom_temperror=true;
-        this.plugin.return_results(next, this.connection, spf,
-            'mfrom', spf.SPF_TEMPERROR, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_TEMPERROR, 'test@example.com');
     },
     'result, permerror, reject=false': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.deny.mfrom_permerror=false;
-        this.plugin.return_results(next, this.connection, spf,
-            'mfrom', spf.SPF_PERMERROR, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_PERMERROR, 'test@example.com');
     },
     'result, permerror, reject=true': function (test) {
-        const next = function () {
+        function next () {
             test.equal(DENY, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.deny.mfrom_permerror=true;
-        this.plugin.return_results(next, this.connection, spf,
-            'mfrom', spf.SPF_PERMERROR, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_PERMERROR, 'test@example.com');
     },
     'result, unknown': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
-        this.plugin.return_results(next, this.connection, spf,
-            'mfrom', 'unknown', 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', 'unknown', 'test@example.com');
     },
-};
+}
 
 exports.hook_helo = {
     setUp : _set_up,
     'rfc1918': function (test) {
         let completed = 0;
-        const next = function (rc) {
+        function next (rc) {
             completed++;
             test.equal(undefined, rc);
             if (completed >= 2) test.done();
-        };
+        }
         test.expect(2);
         this.connection.remote.is_private=true;
         this.plugin.hook_helo(next, this.connection);
         this.plugin.hook_helo(next, this.connection, 'helo.sender.com');
     },
     'IPv4 literal': function (test) {
-        const next = function (rc) {
+        function next (rc) {
             test.equal(undefined, rc);
             test.done();
-        };
+        }
         test.expect(1);
         this.connection.remote.ip='190.168.1.1';
         this.plugin.hook_helo(next, this.connection, '[190.168.1.1]' );
     },
 
-};
+}
 
 const test_addr = new Address('<test@example.com>');
 
 exports.hook_mail = {
     setUp : _set_up,
     'rfc1918': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.connection.remote.is_private=true;
         this.connection.remote.ip='192.168.1.1';
         this.plugin.hook_mail(next, this.connection, [test_addr]);
     },
     'rfc1918 relaying': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.connection.remote.is_private=true;
         this.connection.remote.ip='192.168.1.1';
@@ -194,40 +182,40 @@ exports.hook_mail = {
         this.plugin.hook_mail(next, this.connection, [test_addr]);
     },
     'no txn': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.connection.remote.ip='207.85.1.1';
         delete this.connection.transaction;
         this.plugin.hook_mail(next, this.connection);
     },
     'txn, no helo': function (test) {
-        const next = function () {
+        function next () {
             test.equal(undefined, arguments[0]);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.deny.mfrom_fail = false;
         this.connection.remote.ip='207.85.1.1';
         this.plugin.hook_mail(next, this.connection, [test_addr]);
     },
     'txn': function (test) {
-        const next = function (rc) {
+        function next (rc) {
             test.equal(undefined, rc);
             test.done();
-        };
+        }
         test.expect(1);
         this.connection.set('remote', 'ip', '207.85.1.1');
         this.connection.set('hello', 'host', 'mail.example.com');
         this.plugin.hook_mail(next, this.connection, [test_addr]);
     },
     'txn, relaying': function (test) {
-        const next = function (rc) {
+        function next (rc) {
             test.equal(undefined, rc);
             test.done();
-        };
+        }
         test.expect(1);
         this.connection.set('remote', 'ip', '207.85.1.1');
         this.connection.relaying=true;
@@ -235,10 +223,10 @@ exports.hook_mail = {
         this.plugin.hook_mail(next, this.connection, [test_addr]);
     },
     'txn, relaying, is_private': function (test) {
-        const next = function (rc) {
+        function next (rc) {
             test.equal(undefined, rc);
             test.done();
-        };
+        }
         test.expect(1);
         this.plugin.cfg.relay.context='myself';
         this.plugin.cfg.deny_relay.mfrom_fail = true;
@@ -249,5 +237,4 @@ exports.hook_mail = {
         this.plugin.nu.public_ip = '66.128.51.165';
         this.plugin.hook_mail(next, this.connection, [new Address('<nonexist@tnpi.net>')]);
     },
-};
-
+}

--- a/tests/rfc1869.js
+++ b/tests/rfc1869.js
@@ -55,4 +55,4 @@ exports.basic = {
         _check(test, 'RCPT TO:<user=name@domain.com> foo=bar',
             ['<user=name@domain.com>', 'foo=bar']);
     },
-};
+}

--- a/tests/server.js
+++ b/tests/server.js
@@ -72,7 +72,7 @@ exports.get_listen_addrs = {
         test.deepEqual(['127.0.0.1:250','[::1]:250'], listeners);
         test.done();
     },
-};
+}
 
 exports.load_smtp_ini = {
     setUp : _set_up,
@@ -86,7 +86,7 @@ exports.load_smtp_ini = {
         test.notEqual(c.daemon_pid_file, undefined);
         test.done();
     }
-};
+}
 
 exports.get_smtp_server = {
     setUp : function (done) {
@@ -138,7 +138,7 @@ exports.get_smtp_server = {
             });
         });
     }
-};
+}
 
 exports.get_http_docroot = {
     setUp : _set_up,
@@ -148,7 +148,7 @@ exports.get_http_docroot = {
         test.ok(docroot);
         test.done();
     },
-};
+}
 
 function _setupServer (done) {
     process.env.YES_REALLY_DO_DISCARD=1;   // for queue/discard plugin
@@ -194,7 +194,7 @@ exports.smtp_client = {
             connect_timeout: 2,
             pool_timeout: 5,
             max_connections: 3,
-        };
+        }
 
         const smtp_client   = require('../smtp_client');
         const MessageStream = require('../messagestream');
@@ -241,7 +241,7 @@ exports.smtp_client = {
 
         }, 2500, 'localhost', cfg);
     },
-};
+}
 
 exports.nodemailer = {
     setUp : _setupServer,

--- a/tests/spf.js
+++ b/tests/spf.js
@@ -27,18 +27,18 @@ exports.SPF = {
     },
     'mod_redirect, true': function (test) {
         test.expect(2);
-        const cb = function (err, rc) {
+        function cb (err, rc) {
             test.equal(null, err);
             test.equal(1, rc);
             test.done();
-        };
+        }
         this.SPF.been_there['example.com'] = true;
         this.SPF.mod_redirect('example.com', cb);
     },
     'mod_redirect, false': function (test) {
         test.expect(2);
         // var outer = this;
-        const cb = function (err, rc) {
+        function cb (err, rc) {
             test.equal(null, err);
             if (rc === 7) {
                 // from time to time (this is the third time we've seen it,
@@ -52,10 +52,10 @@ exports.SPF = {
             }
             test.done();
             // console.log(arguments);
-        };
+        }
         this.SPF.count=0;
         this.SPF.ip='212.70.129.94';
         this.SPF.mail_from='fraud@aexp.com';
         this.SPF.mod_redirect('aexp.com', cb);
     },
-};
+}

--- a/tests/transaction.js
+++ b/tests/transaction.js
@@ -101,7 +101,7 @@ exports.transaction = {
             });
         });
     }
-};
+}
 
 function write_file_data_to_transaction (test_transaction, filename) {
     const specimen = fs.readFileSync(filename, 'utf8');

--- a/transaction.js
+++ b/transaction.js
@@ -37,16 +37,14 @@ class Transaction {
             accept: 0,
             tempfail: 0,
             reject: 0,
-        };
+        }
         this.data_post_start = null;
         this.data_post_delay = 0;
         this.encoding = 'utf8';
     }
 
     ensure_body () {
-        if (this.body) {
-            return;
-        }
+        if (this.body) return;
 
         this.body = new body.Body(this.header);
         this.attachment_start_hooks.forEach(h => {
@@ -202,4 +200,4 @@ exports.createTransaction = uuid => {
     t.message_stream = new MessageStream(
         config.get('smtp.ini'), t.uuid, t.header.header_list);
     return t;
-};
+}


### PR DESCRIPTION
For quite some time, trailing semicolons ending function statements have been verboten. Eslint's [no-extra-semi](https://eslint.org/docs/rules/no-extra-semi) rule has been part of `eslint-recommended` for quite some time as well and our code base is consistent with this.

However, this rule only applies to function declarations that look like this:

```js
function foo () {
}
```

We also have a great many function statements that look like this:

```js
exports.foo = function () {
}
```

In the latter case, we have been quite inconsistent in our use of trailing semicolons. We have not been consistent by author, nor even within a single file. If anything, the general pattern appears to be older code, and code within `./tests/` prefers trailing semicolons.

````
~/git/haraka $ grep '^};' `gfind` | wc -l
     470
~/git/haraka $ grep '^}' `gfind` | wc -l
     819
````

For consistency, this PR drops the trailing semicolon from "assign a function to an exported variable" declarations.

I've also replaced a handful of `const foo = function () {` declarations with `function foo () {` within the `tests/*`. It's a low priority but in keeping with the "code that acts different should **look** different" principle, that change should be done across the code base, except in the rare cases where the non-hoisted declarations are desired.