### PR TITLE
connection: assure hostname is set

### DIFF
--- a/config/me
+++ b/config/me
@@ -1,1 +1,0 @@
-haraka.test

--- a/connection.js
+++ b/connection.js
@@ -59,7 +59,7 @@ class Connection {
         this.local = {           // legacy property locations
             ip: null,            // c.local_ip
             port: null,          // c.local_port
-            host: config.get('me'),
+            host: config.get('me') || os.hostname(),
             info: 'Haraka',
         };
         this.remote = {


### PR DESCRIPTION
- default to os.hostname() when config/me does not exist
