### PR TITLE
line_socket: remove superfluous function

### DIFF
--- a/line_socket.js
+++ b/line_socket.js
@@ -16,7 +16,7 @@ class Socket extends net.Socket {
 function setup_line_processor (socket) {
     let current_data = '';
 
-    socket.on('data', function process_data (data) {
+    socket.on('data', function on_socket_data (data) {
         current_data += data;
         let results;
         while ((results = utils.line_regexp.exec(current_data))) {
@@ -26,7 +26,7 @@ function setup_line_processor (socket) {
         }
     })
 
-    socket.on('end', function process_end () {
+    socket.on('end', function on_socket_end () {
         if (current_data.length) {
             socket.emit('line', current_data);
         }

--- a/line_socket.js
+++ b/line_socket.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 // A subclass of Socket which reads data by line
 
 const net   = require('net');
@@ -15,7 +15,8 @@ class Socket extends net.Socket {
 
 function setup_line_processor (socket) {
     let current_data = '';
-    socket.process_data = function (data) {
+
+    socket.on('data', function process_data (data) {
         current_data += data;
         let results;
         while ((results = utils.line_regexp.exec(current_data))) {
@@ -23,17 +24,14 @@ function setup_line_processor (socket) {
             current_data = current_data.slice(this_line.length);
             socket.emit('line', this_line);
         }
-    };
+    })
 
-    socket.process_end = function () {
+    socket.on('end', function process_end () {
         if (current_data.length) {
             socket.emit('line', current_data);
         }
         current_data = '';
-    };
-
-    socket.on('data', function (data) { socket.process_data(data);});
-    socket.on('end',  function ()     { socket.process_end();     });
+    })
 }
 
 exports.Socket = Socket;


### PR DESCRIPTION
should be reviewed by @baudehlo

- Near as I can tell, despite this function being attached to the socket object, it is never called from outside `setup_line_processor()`. If my cursory check is representative, exporting those functions has served only one purpose over the years: unnecessary function calls on the stack.
- Note: there are functions with exactly the same names in connection.js and outbound/index.js. However, those are independently defined and accessed. A secondary use of these intermediate functions has been an additional namespace collision. I have therefore renamed them.