### PR TITLE
smtp_forward: add domain_selector

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,7 @@
+## 2.8.18
+
+* New features
+    * smtp_forward: domain configuration is now chosen based on domain_selector #2346
 
 ## 2.8.17 - Feb 16, 2017
 

--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -86,9 +86,15 @@ Configuration
 
 # Per-Domain Configuration
 
-More specific forward routes for domains can be defined. More specific routes
-are only honored for SMTP connections with a single recipient or SMTP
+More specific forward routes for domains can be defined. The domain is
+chosen based on the value of the `domain_selector` config variable.
+
+When `domain_selector` is set to `rcpt_to` (the default), more specific
+routes are only honored for SMTP connections with a single recipient or SMTP
 connections where every recipient host is identical.
+
+When `domain_selector` is set to `mail_from`, the domain of the MAIL FROM
+address is used.
 
 enable\_outbound can be set or unset on a per-domain level to enable or disable
 forwarding for specific domains.

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -52,8 +52,16 @@ exports.get_config = function (connection) {
     const plugin = this;
 
     if (!connection.transaction) return plugin.cfg.main;
-    if (!connection.transaction.rcpt_to[0]) return plugin.cfg.main;
-    const dom = connection.transaction.rcpt_to[0].host;
+
+    let dom;
+    if (plugin.cfg.main.domain_selector === 'mail_from') {
+        if (!connection.transaction.mail_from) return plugin.cfg.main;
+        dom = connection.transaction.mail_from.host;
+    }
+    else {
+        if (!connection.transaction.rcpt_to[0]) return plugin.cfg.main;
+        dom = connection.transaction.rcpt_to[0].host;
+    }
 
     if (!dom)             return plugin.cfg.main;
     if (!plugin.cfg[dom]) return plugin.cfg.main;  // no specific route

--- a/tests/plugins/queue/smtp_forward.js
+++ b/tests/plugins/queue/smtp_forward.js
@@ -110,6 +110,25 @@ exports.get_config = {
         test.deepEqual(cfg.host, '1.2.3.4' );
         test.done();
     },
+    'null sender': function (test) {
+        test.expect(3);
+        this.plugin.cfg.main.domain_selector = 'mail_from';
+        this.connection.transaction.mail_from = new Address('<>');
+        const cfg = this.plugin.get_config(this.connection);
+        test.equal(cfg.host, 'localhost');
+        test.equal(cfg.enable_tls, true);
+        test.equal(cfg.one_message_per_rcpt, true);
+        test.done();
+    },
+    'return mail_from domain configuration': function (test) {
+        test.expect(1);
+        this.connection.transaction.mail_from = new Address('<matt@test2.com>');
+        this.plugin.cfg.main.domain_selector = 'mail_from';
+        const cfg = this.plugin.get_config(this.connection);
+        test.deepEqual(cfg.host, '2.3.4.5');
+        delete this.plugin.cfg.main.domain_selector; // clear this for future tests
+        test.done();
+    }
 }
 
 const hmail = { todo: { notes: {} } };


### PR DESCRIPTION
this config variable can be set to rcpt_to or mail_from to decide how the domain configuration is chosen

Fixes #2346

Changes proposed in this pull request:
- add domain_selector config variable that chooses domain configuration based on mail_from or rcpt_to domain

Checklist:
- [ X ] docs updated
- [ X ] tests updated
- [ X ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
