### PR TITLE
document force_shutdown_timeout and graceful_shutdown

### DIFF
--- a/docs/CoreConfig.md
+++ b/docs/CoreConfig.md
@@ -40,6 +40,8 @@ The list of plugins to load
   * spool\_dir - (default: none) directory to create temporary spool files in
   * spool\_after - (default: -1) if message exceeds this size in bytes, then spool the message to disk
     specify -1 to disable spooling completely or 0 to force all messages to be spooled to disk.
+  * graceful\_shutdown - (default: false) enable this to wait for sockets on shutdown instead of closing them quickly
+  * force_shutdown_timeout - (default: 30) number of seconds to wait for a graceful shutdown
 
 [1]: http://learnboost.github.com/cluster/ or node version >= 0.8
 


### PR DESCRIPTION
This adds documentation for [`force_shutdown_timeout`](https://github.com/haraka/Haraka/blob/master/server.js#L45) as well as [`graceful_shutdown`](https://github.com/haraka/Haraka/blob/master/server.js#L116) found in the code, but not in the config. Please let me know if I got the meaning of those settings wrong.