### PR TITLE
Ensure unrecognized_command hooks are invoked with params as an array

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -315,7 +315,7 @@ class Connection {
             const [ , methodMatch, , remainingMatch] = /^([^ ]*)( +(.*))?$/.exec(this.current_line);
             if (!methodMatch) {
                 return plugins.run_hooks('unrecognized_command',
-                    this, this.current_line);
+                    this, [this.current_line]);
             }
             const method = `cmd_${methodMatch.toLowerCase()}`;
             const remaining = remainingMatch || '';

--- a/plugins/max_unrecognized_commands.js
+++ b/plugins/max_unrecognized_commands.js
@@ -10,10 +10,10 @@ exports.hook_connect = function (next, connection) {
     return next();
 }
 
-exports.hook_unrecognized_command = function (next, connection, cmd) {
+exports.hook_unrecognized_command = function (next, connection, params) {
     const plugin = this;
 
-    connection.results.add(plugin, {fail: `Unrecognized command: ${cmd}`, emit: true});
+    connection.results.add(plugin, {fail: `Unrecognized command: ${params}`, emit: true});
     connection.results.incr(plugin, {count: 1});
 
     const uc = connection.results.get('max_unrecognized_commands');


### PR DESCRIPTION
Plugins expect the last parameter cmd/params to be an array and not a string.
If an empty command is passed, tls plugin fails because it expects the argument
to be an array:

[CRIT] [3DD21EB3-057C-445B-9345-CDA7552D6BE0] [core] Plugin tls failed: TypeError: Cannot read property 'toUpperCase' of undefined
    at Plugin.exports.upgrade_connection (/app/haraka/plugins/tls.js:93:18)
    at Object.plugins.run_next_hook (/app/haraka/plugins.js:506:28)
    at callback (/app/haraka/plugins.js:464:32)
    at Plugin.exports.hook_unrecognized_command (/app/haraka/plugins/max_unrecognized_commands.js:27:12)
