### PR TITLE
qmail-queue: fix undefined err variable

### DIFF
--- a/plugins/queue/qmail-queue.js
+++ b/plugins/queue/qmail-queue.js
@@ -63,7 +63,7 @@ exports.hook_queue = function (next, connection) {
 
             try {
                 qmail_queue.stdout.end();
-            } catch (error) {
+            } catch (err) {
                 if (err.code !== 'ENOTCONN') {
                     // Ignore ENOTCONN and re throw anything else
                     throw err


### PR DESCRIPTION
I noticed eslint barking about `err` being undefined, and that's because it was. This fixes it.