### PR TITLE
connection: make setting relaying in a transaction safe

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
   * queue/qmail-queue: fix a 2nd crash bug when client disconnects unexpectedly #2360
 * Changes
   * process\_title: add total recipients, avg rcpts/msg, recipients/sec cur/avg/max and messages/conn
+  * when relaying is set in a transaction, don't persist beyond the transaction
 
 ## 2.8.18 - Mar 8, 2018
 

--- a/connection.js
+++ b/connection.js
@@ -104,7 +104,7 @@ class Connection {
         this.deny_includes_uuid = config.get('deny_includes_uuid') || null;
         this.early_talker = false;
         this.pipelining = false;
-        this.relaying = false;
+        this._relaying = false;
         this.esmtp = false;
         this.last_response = null;
         this.hooks_to_run = [];
@@ -266,6 +266,18 @@ class Connection {
         return prop_str.split('.').reduce((prev, curr) => {
             return prev ? prev[curr] : undefined
         }, this)
+    }
+    set relaying (val) {
+        if (this.transaction) {
+            this.transaction._relaying = val;
+        }
+        else {
+            this._relaying = val;
+        }
+    }
+    get relaying () {
+        if (this.transaction && this.transaction._relaying) return this.transaction._relaying;
+        return this._relaying;
     }
     process_line (line) {
         const self = this;

--- a/connection.js
+++ b/connection.js
@@ -276,7 +276,7 @@ class Connection {
         }
     }
     get relaying () {
-        if (this.transaction && this.transaction._relaying !== undefined) return this.transaction._relaying;
+        if (this.transaction && '_relaying' in this.transaction) return this.transaction._relaying;
         return this._relaying;
     }
     process_line (line) {

--- a/connection.js
+++ b/connection.js
@@ -276,7 +276,7 @@ class Connection {
         }
     }
     get relaying () {
-        if (this.transaction && this.transaction._relaying) return this.transaction._relaying;
+        if (this.transaction && this.transaction._relaying !== undefined) return this.transaction._relaying;
         return this._relaying;
     }
     process_line (line) {

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -244,3 +244,24 @@ exports.local_info = {
         test.done();
     }
 }
+
+exports.relaying = {
+    setUp : _set_up,
+    tearDown : _tear_down,
+    'sets and gets': function (test) {
+        test.expect(3);
+        test.equal(this.connection.relaying, false);
+        test.ok(this.connection.relaying = 'alligators');
+        test.equal(this.connection.relaying, 'alligators');
+        test.done();
+    },
+    'sets and gets in a transaction': function (test) {
+        test.expect(4);
+        test.equal(this.connection.relaying, false);
+        this.connection.transaction = {};
+        test.ok(this.connection.relaying = 'crocodiles');
+        test.equal(this.connection.transaction._relaying, 'crocodiles');
+        test.equal(this.connection.relaying, 'crocodiles');
+        test.done();
+    }
+}


### PR DESCRIPTION
This is an alternative implementation of Steve's excellent idea in #2387, which is making sure that when relaying is set in a transaction, that it's automatically unset when the transaction ends.

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
