### PR TITLE
CritFix: ensure ClamAV recognises input as a MIME message

### DIFF
--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -232,7 +232,15 @@ exports.hook_data_post = function (next, connection) {
             const addressInfo = hp === null ? '' : ` ${hp.address}:${hp.port}`;
             connection.logdebug(plugin, `connected to host${addressInfo}`);
             socket.write("zINSTREAM\0", function () {
-                txn.message_stream.pipe(socket, { clamd_style: true });
+                // We *MUST* ensure that the first line is a Received: header
+                // otherwise ClamAV will not interpret the input as MIME...
+                var fake_rcvd = "Received: from fake\r\n";
+                var buf = new Buffer(fake_rcvd.length+4);
+                buf.writeUInt32BE(fake_rcvd.length, 0);
+                buf.write(fake_rcvd, 4);
+                socket.write(buf, function () {
+                    txn.message_stream.pipe(socket, { clamd_style: true });
+                });
             });
         });
 


### PR DESCRIPTION
I've just discovered this morning that if the input message does not start with 'Received: ', then ClamAV will not correctly handle the input message as a MIME message and will therefore fail to detect attachments accordingly.

This is particularly bad if you have plugins that add Received-SPF, Auth-Results headers or any plugin that runs c.t.add_leading_header().

I considered a workaround by using `send_pristine: true` in the MessageStream options, but again, this would fail if the message was sent direct-to-MX by an MUA, so I decided to always add a fake Received header for maximum safety.

IMO - this is probably serious enough to warrant an immediate release.