### PR TITLE
add `received_header_disabled` outbound option 

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@
   * process\_title: add total recipients, avg rcpts/msg, recipients/sec cur/avg/max and messages/conn
   * when relaying is set in a transaction, don't persist beyond the transaction
   * remove deprecated (since 2.8.16) ./dsn.js
+  * add `received_header_disabled` outbound option to disable injecting new Received header
 
 ## 2.8.18 - Mar 8, 2018
 

--- a/config/outbound.ini
+++ b/config/outbound.ini
@@ -19,6 +19,9 @@
 ; always_split: default: false
 ; always_split=true
 
+; received_header_disabled (default: false
+; received_header_disabled=true
+
 ; received_header (default: "Haraka outbound")
 ; received_header=Haraka outbound
 

--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -66,6 +66,10 @@ session. When `always_split` is enabled, each recipient gets a queue entry and
 delivery in its own SMTP session. This carries a performance penalty but
 enables more flexibility in mail delivery and bounce handling.
 
+* `received_header_disabled`
+
+Default: false. Disable injecting new `Received` header to all outbound mails.
+
 * `received_header`
 
 Default: "Haraka outbound". This text is attached as a `Received` header to

--- a/outbound/config.js
+++ b/outbound/config.js
@@ -11,6 +11,7 @@ function load_config () {
             '-always_split',
             '+enable_tls',
             '-ipv6_enabled',
+            '-received_header_disabled'
         ],
     }, function () {
         load_config();
@@ -40,6 +41,9 @@ function load_config () {
     }
     if (!cfg.ipv6_enabled && config.get('outbound.ipv6_enabled')) {
         cfg.ipv6_enabled = true;
+    }
+    if (!cfg.received_header_disabled && config.get('outbound.received_header_disabled')) {
+        cfg.received_header_disabled = true;
     }
     if (!cfg.received_header) {
         cfg.received_header = config.get('outbound.received_header') || 'Haraka outbound';

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -238,7 +238,9 @@ exports.send_trans_email = function (transaction, next) {
         transaction.add_header('Date', utils.date_to_str(new Date()));
     }
 
-    transaction.add_leading_header('Received', `(${cfg.received_header}); ${utils.date_to_str(new Date())}`);
+    if (!cfg.received_header_disabled) {
+        transaction.add_leading_header('Received', `(${cfg.received_header}); ${utils.date_to_str(new Date())}`);
+    }
 
     const connection = {
         transaction: transaction,


### PR DESCRIPTION
Add `received_header_disabled` outbound option to disable injecting new Received header. 

Fixes #2406

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
