### PR TITLE
create config/me if not present

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 ## x.y.z - unreleased
 
 * Fixes
+  * when installing, creates config/me if missing #2413
   * queue/qmail-queue: fix a 2nd crash bug when client disconnects unexpectedly #2360
   * remove desconstruction of SMTP commands to prevent exception #2398
 * Changes

--- a/bin/haraka
+++ b/bin/haraka
@@ -157,12 +157,10 @@ function copyDir (srcPath, dstPath) {
     mkDir(dstPath);
     const files = fs.readdirSync(srcPath);
 
-    for (let i = 0; i < files.length; i++) {
+    for (let i=0; i < files.length; i++) {
 
         // Ignore ".*"
-        if (/^\./.test(files[i])) {
-            continue;
-        }
+        if (/^\./.test(files[i])) continue;
 
         const srcFile = path.join(srcPath, files[i]);
         const dstFile = path.join(dstPath, files[i]);
@@ -185,12 +183,10 @@ function copyFile (srcFile, dstFile) {
 
     try {
         if (fs.statSync(dstFile).isFile()) {
-            // File exists
-            warning("EEXIST, File exists '" + dstFile + "'");
+            warning(`EEXIST, File exists '${dstFile}'`);
             return;
         }
-        // Something other than a file exists
-        throw "EEXIST but not a file: '" + dstFile + "'";
+        throw `EEXIST but not a file: '${dstFile}'`;
     }
     catch (e) {
         // File NOT exists
@@ -200,7 +196,7 @@ function copyFile (srcFile, dstFile) {
             create(dstFile)
         }
         else {
-            console.log('copy ' + srcFile + ' to ' + dstFile);
+            console.log(`copy ${srcFile} to ${dstFile}`);
             throw e;
         }
     }

--- a/bin/haraka
+++ b/bin/haraka
@@ -208,20 +208,19 @@ function copyFile (srcFile, dstFile) {
 
 function setupHostname (confPath) {
     mkDir(confPath);
-    const hlPath = path.join(confPath, 'host_list');
-    try {
-        if (fs.statSync(hlPath).isFile()) return;
-    }
-    catch (ignore) {}
 
-    const hostname = os.hostname() + "\n";
-    try {
-        const fd = fs.openSync(hlPath, 'w');
-        fs.writeSync(fd, hostname, null);
-    }
-    catch (e) {
-        warning("Unable to write config/host_list file: " + e);
-    }
+    const hostname = `${os.hostname()}\n`;
+
+    ['me','host_list'].forEach(f => {
+        const cfPath = path.join(confPath, f);
+        try {
+            if (fs.statSync(cfPath).isFile()) return;
+            fs.writeFileSync(cfPath, hostname);
+        }
+        catch (e) {
+            warning(`Unable to write to config/${f}: ${e.message}`);
+        }
+    })
 }
 
 function setupBaseConfig (confPath) {

--- a/bin/haraka
+++ b/bin/haraka
@@ -213,13 +213,12 @@ function setupHostname (confPath) {
 
     ['me','host_list'].forEach(f => {
         const cfPath = path.join(confPath, f);
-        try {
-            if (fs.statSync(cfPath).isFile()) return;
-            fs.writeFileSync(cfPath, hostname);
-        }
-        catch (e) {
-            warning(`Unable to write to config/${f}: ${e.message}`);
-        }
+
+        try { if (fs.statSync(cfPath).isFile()) return; }
+        catch (ignore) { }
+
+        try { fs.writeFileSync(cfPath, hostname); }
+        catch (err) { warning(`Unable to write to config/${f}: ${err.message}`); }
     })
 }
 

--- a/bin/haraka
+++ b/bin/haraka
@@ -209,7 +209,7 @@ function copyFile (srcFile, dstFile) {
 function setupHostname (confPath) {
     mkDir(confPath);
 
-    const hostname = `${os.hostname()}\n`;
+    const hostname = `${os.hostname()}${os.EOL}`;
 
     ['me','host_list'].forEach(f => {
         const cfPath = path.join(confPath, f);

--- a/docs/CoreConfig.md
+++ b/docs/CoreConfig.md
@@ -1,7 +1,7 @@
 Core Configuration Files
 ========================
 
-See [Logging](Logging).
+See [Logging](Logging.md).
 
 The Haraka core reads some configuration files to determine a few actions:
 
@@ -26,8 +26,7 @@ The list of plugins to load
   * listen\_host, port - the host and port to listen on (default: ::0 and 25)
   * listen - (default: [::0]:25) Comma separated IP:Port addresses to listen on
   * inactivity\_time - how long to let clients idle in seconds (default: 300)
-  * nodes - if [cluster][1] (or node version >= 0.8) is available, specifies how
-    many processes to fork off. Can be the string "cpus" to fork off as many
+  * nodes - specifies how many processes to fork. The string "cpus" will fork as many
     children as there are CPUs (default: 0, which disables cluster mode)
   * user - optionally a user to drop privileges to. Can be a string or UID.
   * group - optionally a group to drop privileges to. Can be a string or GID.
@@ -42,8 +41,6 @@ The list of plugins to load
     specify -1 to disable spooling completely or 0 to force all messages to be spooled to disk.
   * graceful\_shutdown - (default: false) enable this to wait for sockets on shutdown instead of closing them quickly
   * force_shutdown_timeout - (default: 30) number of seconds to wait for a graceful shutdown
-
-[1]: http://learnboost.github.com/cluster/
 
 * me
 
@@ -116,19 +113,18 @@ The list of plugins to load
 
 * outbound.disabled
 
-  Put a `1` in this file to temporarily disable outbound delivery. Useful to
-  do while you're figuring out network issues, or just testing things.
+  Put a `1` in this file to temporarily disable outbound delivery. Useful 
+  while figuring out network issues or testing.
 
 * outbound.bounce\_message
 
-  The bounce message should delivery of the mail fail. See the source of. The
-  default is normally fine. Bounce messages contain a number of template
+  The bounce message if delivery of the message fails. The default is normally fine. Bounce messages contain a number of template
   replacement values which are best discovered by looking at the source code.
 
 * haproxy\_hosts
 
   A list of HAProxy hosts that Haraka should enable the PROXY protocol from.
-  See HAProxy.md
+  See [HAProxy.md](HAProxy.md)
 
 * strict\_rfc1869
 

--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -248,7 +248,7 @@ exports.auth_cram_md5 = function (next, connection, params) {
             AUTH_METHOD_CRAM_MD5);
     }
 
-    const ticket = `<${plugin.hexi(Math.floor(Math.random() * 1000000))}. ${plugin.hexi(Date.now())}@${plugin.config.get('me')}>`;
+    const ticket = `<${plugin.hexi(Math.floor(Math.random() * 1000000))}. ${plugin.hexi(Date.now())}@${connection.local.host}>`;
 
     connection.loginfo(plugin, `ticket: ${ticket}`);
     connection.respond(334, utils.base64(ticket), function () {

--- a/plugins/auth/auth_proxy.js
+++ b/plugins/auth/auth_proxy.js
@@ -133,7 +133,7 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
                     if (key && cert) {
                         this.on('secure', function () {
                             secure = true;
-                            socket.send_command('EHLO', self.config.get('me'));
+                            socket.send_command('EHLO', connection.local.host);
                         });
                         socket.send_command('STARTTLS');
                         return;
@@ -205,7 +205,7 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
                 this.upgrade({ key: key, cert: cert });
                 break;
             case 'connect':
-                socket.send_command('EHLO', self.config.get('me'));
+                socket.send_command('EHLO', connection.local.host);
                 break;
             case 'auth':
                 // AUTH was successful

--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -268,6 +268,6 @@ exports.save_to_header = function (connection, spf, result, mfrom, host, id, ip)
     if (!connection) return;
     if (!connection.transaction) return;
     connection.transaction.add_leading_header('Received-SPF',
-        `${spf.result(result)} (${plugin.config.get('me')}: domain of ${host}${result === spf.SPF_PASS ? ' designates ' : ' does not designate '}${connection.remote.ip} as permitted sender) receiver=${plugin.config.get('me')}; identity=${id}; client-ip=${ip ? ip : connection.remote.ip}; helo=${connection.hello.host}; envelope-from=<${mfrom}>`
+        `${spf.result(result)} (${connection.local.host}: domain of ${host}${result === spf.SPF_PASS ? ' designates ' : ' does not designate '}${connection.remote.ip} as permitted sender) receiver=${connection.local.host}; identity=${id}; client-ip=${ip ? ip : connection.remote.ip}; helo=${connection.hello.host}; envelope-from=<${mfrom}>`
     );
 }

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -439,7 +439,7 @@ exports.get_client_plugin = function (plugin, connection, c, callback) {
                 smtp_client.send_command(command, connection.hello.host);
             }
             else {
-                smtp_client.send_command(command, plugin.config.get('me'));
+                smtp_client.send_command(command, connection.local.host);
             }
         }
         smtp_client.on('greeting', helo);


### PR DESCRIPTION
closes #2380 

Changes proposed in this pull request:
- create config/me if not present
- use platform dependent os.EOL instead of \n (in config/me and config/host_list)
- grammar fixes in docs/CoreConfig.md
- use config.local.host when connection in scope

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated