### PR TITLE
outbound: support received_header=disabled

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,13 +1,16 @@
 ## x.y.z - unreleased
 
+* New features
+    * outbound: received_header=disabled supresses outbound Received header addition. #2409
 * Fixes
-  * queue/qmail-queue: fix a 2nd crash bug when client disconnects unexpectedly #2360
-  * remove desconstruction of SMTP commands to prevent exception #2398
+    * when installing, creates config/me if missing #2413
+    * queue/qmail-queue: fix a 2nd crash bug when client disconnects unexpectedly #2360
+    * remove desconstruction of SMTP commands to prevent exception #2398
 * Changes
-  * process\_title: add total recipients, avg rcpts/msg, recipients/sec cur/avg/max and messages/conn #2389
-  * when relaying is set in a transaction, don't persist beyond the transaction #2393
-  * connection.set supports dot delimited path syntax #2390
-  * remove deprecated (since 2.8.16) ./dsn.js
+    * process\_title: add total recipients, avg rcpts/msg, recipients/sec cur/avg/max and messages/conn #2389
+    * when relaying is set in a transaction, don't persist beyond the transaction #2393
+    * connection.set supports dot delimited path syntax #2390
+    * remove deprecated (since 2.8.16) ./dsn.js
 
 ## 2.8.18 - Mar 8, 2018
 

--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -68,8 +68,8 @@ enables more flexibility in mail delivery and bounce handling.
 
 * `received_header`
 
-Default: "Haraka outbound". This text is attached as a `Received` header to
-all outbound mail just before it is queued.
+Default: "Haraka outbound". If this text is any string except *disabled*, the
+string is attached as a `Received` header to all outbound mail just before it is queued.
 
 * `connect_timeout`
 

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -238,7 +238,9 @@ exports.send_trans_email = function (transaction, next) {
         transaction.add_header('Date', utils.date_to_str(new Date()));
     }
 
-    transaction.add_leading_header('Received', `(${cfg.received_header}); ${utils.date_to_str(new Date())}`);
+    if (cfg.received_header !== 'disabled') {
+        transaction.add_leading_header('Received', `(${cfg.received_header}); ${utils.date_to_str(new Date())}`);
+    }
 
     const connection = {
         transaction: transaction,


### PR DESCRIPTION
closes #2409
fixes #2406

Changes proposed in this pull request:
- outbound: support received_header=disabled

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated