### PR TITLE
plugins/data.headers.js: don't explode on failed header parse

### DIFF
--- a/plugins/data.headers.js
+++ b/plugins/data.headers.js
@@ -293,7 +293,9 @@ exports.from_match = function (next, connection) {
             return next();
         }
     } catch (e) {
-        plugin.logwarn(`address-rfc2822 plugin returning: ${e.message}`);
+        plugin.logwarn(`address-rfc2822 plugin for "${hdr_from.trim()}" returning: ${e.message}`);
+        connection.transaction.results.add(plugin, {fail: 'from_match(rfc_violation)'});
+        return next();
     }
 
     if (env_addr.address().toLowerCase() === hdr_addr.address.toLowerCase()) {


### PR DESCRIPTION
Fixes #2373

Happens when there's a special char that is allowed unquoted/unprocessed in rfc2821 but not allowed in rfc2822. Don't remember what that char is.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
