### PR TITLE
mods to auth_base plugin

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,11 +2,13 @@
 
 * New features
     * outbound: received_header=disabled supresses outbound Received header addition. #2409
+    * auth_base.js: `check_plain_passwd` and `check_cram_md5_passwd` can now pass `message` and `code` to callback routine
 * Fixes
     * when installing, creates config/me if missing #2413
     * queue/qmail-queue: fix a 2nd crash bug when client disconnects unexpectedly #2360
     * remove desconstruction of SMTP commands to prevent exception #2398
 * Changes
+    * Breaking: auth_base.js: don't set `connection.notes.auth_passwd` 
     * process\_title: add total recipients, avg rcpts/msg, recipients/sec cur/avg/max and messages/conn #2389
     * when relaying is set in a transaction, don't persist beyond the transaction #2393
     * connection.set supports dot delimited path syntax #2390

--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,6 @@
     * queue/qmail-queue: fix a 2nd crash bug when client disconnects unexpectedly #2360
     * remove desconstruction of SMTP commands to prevent exception #2398
 * Changes
-    * Breaking: auth_base.js: don't set `connection.notes.auth_passwd` 
     * process\_title: add total recipients, avg rcpts/msg, recipients/sec cur/avg/max and messages/conn #2389
     * when relaying is set in a transaction, don't persist beyond the transaction #2393
     * connection.set supports dot delimited path syntax #2390

--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -103,9 +103,9 @@ exports.check_user = function (next, connection, credentials, method) {
 
     // valid: (true|false)
     // opts: ({ message, code }|String)
-    var passwd_ok = function (valid, opts) {
-        var status_code = (typeof(opts) == 'object' && opts['code']) || (valid ? 235 : 535);
-        var status_message = (typeof(opts) == 'object' ? opts['message'] : opts) ||
+    function passwd_ok (valid, opts) {
+        const status_code = (typeof(opts) === 'object' && opts.code) || (valid ? 235 : 535);
+        const status_message = (typeof(opts) === 'object' ? opts.message : opts) ||
                 (valid  ? '2.7.0 Authentication successful' : '5.7.8 Authentication failed');
 
         if (valid) {
@@ -116,7 +116,7 @@ exports.check_user = function (next, connection, credentials, method) {
             connection.results.add({name:'auth'}, {
                 pass: plugin.name,
                 method: method,
-                user: credentials[0]
+                user: credentials[0],
             });
 
             connection.respond(status_code, status_message, function () {
@@ -150,7 +150,7 @@ exports.check_user = function (next, connection, credentials, method) {
                 });
             });
         }, delay * 1000);
-    };
+    }
 
     if (method === AUTH_METHOD_PLAIN || method === AUTH_METHOD_LOGIN) {
         plugin.check_plain_passwd(connection, credentials[0], credentials[1],

--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -2,6 +2,8 @@
 // This cannot be used on its own. You need to inherit from it.
 // See plugins/auth/flat_file.js for an example.
 
+// Note: You can disable setting `connection.notes.auth_passwd` by `plugin.blankout_password = true`
+
 const crypto = require('crypto');
 const utils = require('haraka-utils');
 const AUTH_COMMAND = 'AUTH';
@@ -123,6 +125,7 @@ exports.check_user = function (next, connection, credentials, method) {
                 connection.authheader = "(authenticated bits=0)\n";
                 connection.auth_results(`auth=pass (${method.toLowerCase()})`);
                 connection.notes.auth_user = credentials[0];
+                if (!plugin.blankout_password) connection.notes.auth_passwd = credentials[1];
                 return next(OK);
             });
             return;

--- a/tests/plugins/auth/auth_base.js
+++ b/tests/plugins/auth/auth_base.js
@@ -276,6 +276,35 @@ exports.check_user_custom_opts = {
     },
 }
 
+exports.auth_notes_are_set = {
+    setUp : _set_up_2,
+    'bad auth: no notes should be set': function (test) {
+        const credentials = ['matt','ttam'];
+        this.plugin.check_user((code) => {
+            test.equal(this.connection.notes.auth_user, undefined);
+            test.equal(this.connection.notes.auth_passwd, undefined);
+            test.done();
+        }, this.connection, credentials, 'PLAIN');
+    },
+    'good auth: dont store password': function (test) {
+        const creds = ['test','testpass'];
+        this.plugin.blankout_password = true;
+        this.plugin.check_user((code) => {
+            test.equal(this.connection.notes.auth_user, creds[0]);
+            test.equal(this.connection.notes.auth_passwd, undefined);
+            test.done();
+        }, this.connection, creds, 'PLAIN');
+    },
+    'good auth: store password (default)': function (test) {
+        const creds = ['test','testpass'];
+        this.plugin.check_user((code) => {
+            test.equal(this.connection.notes.auth_user, creds[0]);
+            test.equal(this.connection.notes.auth_passwd, creds[1]);
+            test.done();
+        }, this.connection, creds, 'PLAIN');
+    },
+}
+
 exports.hook_unrecognized_command = {
     setUp : _set_up,
     'AUTH type FOO': function (test) {

--- a/tests/plugins/auth/auth_base.js
+++ b/tests/plugins/auth/auth_base.js
@@ -34,6 +34,32 @@ function _set_up_2 (done) {
     done();
 }
 
+function _set_up_custom_pwcb_opts (done) {
+    this.plugin = new fixtures.plugin('auth/auth_base');
+
+    this.plugin.check_plain_passwd = function (connection, user, passwd, pwok_cb) {
+        switch (user) {
+            case 'legacyok_nomessage':      return pwok_cb(true);
+            case 'legacyfail_nomessage':    return pwok_cb(false);
+            case 'legacyok_message':        return pwok_cb(true, 'GREAT SUCCESS');
+            case 'legacyfail_message':      return pwok_cb(false, 'FAIL 123');
+            case 'newok':                   return pwok_cb(true, {message: 'KOKOKO', code: 215});
+            case 'newfail':                 return pwok_cb(false, {message: 'OHOHOH', code: 555});
+            default: throw 'what?!';
+        }
+    };
+
+    this.connection = fixtures.connection.createConnection();
+    this.connection.capabilities=null;
+    this.connection.notes.resp_strings = [];
+    this.connection.respond = (code, msg, cb) => {
+        this.connection.notes.resp_strings.push([code, msg]);
+        return cb();
+    }
+
+    done();
+}
+
 exports.hook_capabilities = {
     setUp : _set_up,
     'no TLS, no auth': function (test) {
@@ -195,6 +221,58 @@ exports.check_user = {
             test.equal(this.connection.notes.auth_custom_note, 'custom_note');
             test.done();
         }, this.connection, credentials, 'PLAIN');
+    },
+}
+
+exports.check_user_custom_opts = {
+    setUp: _set_up_custom_pwcb_opts,
+    'legacyok_nomessage': function (test) {
+        this.plugin.check_user((code, msg) => {
+            test.equal(code, OK);
+            test.equal(this.connection.relaying, true);
+            test.deepEqual(this.connection.notes.resp_strings, [[ 235, '2.7.0 Authentication successful' ]]);
+            test.done();
+        }, this.connection, ['legacyok_nomessage', 'any'], 'PLAIN');
+    },
+    'legacyfail_nomessage': function (test) {
+        this.plugin.check_user((code, msg) => {
+            test.equal(code, OK);
+            test.equal(this.connection.relaying, false);
+            test.deepEqual(this.connection.notes.resp_strings, [ [ 535, '5.7.8 Authentication failed' ] ]);
+            test.done();
+        }, this.connection, ['legacyfail_nomessage', 'any'], 'PLAIN');
+    },
+    'legacyok_message': function (test) {
+        this.plugin.check_user((code, msg) => {
+            test.equal(code, OK);
+            test.equal(this.connection.relaying, true);
+            test.deepEqual(this.connection.notes.resp_strings, [[ 235, 'GREAT SUCCESS' ]]);
+            test.done();
+        }, this.connection, ['legacyok_message', 'any'], 'PLAIN');
+    },
+    'legacyfail_message': function (test) {
+        this.plugin.check_user((code, msg) => {
+            test.equal(code, OK);
+            test.equal(this.connection.relaying, false);
+            test.deepEqual(this.connection.notes.resp_strings, [[ 535, 'FAIL 123' ]]);
+            test.done();
+        }, this.connection, ['legacyfail_message', 'any'], 'PLAIN');
+    },
+    'newok': function (test) {
+        this.plugin.check_user((code, msg) => {
+            test.equal(code, OK);
+            test.equal(this.connection.relaying, true);
+            test.deepEqual(this.connection.notes.resp_strings, [[ 215, 'KOKOKO' ]]);
+            test.done();
+        }, this.connection, ['newok', 'any'], 'PLAIN');
+    },
+    'newfail': function (test) {
+        this.plugin.check_user((code, msg) => {
+            test.equal(code, OK);
+            test.equal(this.connection.relaying, false);
+            test.deepEqual(this.connection.notes.resp_strings, [[ 555, 'OHOHOH' ]]);
+            test.done();
+        }, this.connection, ['newfail', 'any'], 'PLAIN');
     },
 }
 


### PR DESCRIPTION
Allow supplying custom message and status codes to passcheck callback routine. We "hijack" `message` param for that, maintaining backwards compatibility in case it's a plain string message.

Checklist:
- [ ] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
