### PR TITLE
mods to dns_list_base plugin

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+
+* introduce global plugin.lookback_is_rejected flag #2422
+
 ## 2.8.20 - Mmm DD, 2018
 
 * New Features

--- a/plugins/dns_list_base.js
+++ b/plugins/dns_list_base.js
@@ -45,7 +45,9 @@ exports.lookup = function (lookup, zone, cb) {
 
         // Check for a result of 127.0.0.1 or outside 127/8
         // This should *never* happen on a proper DNS list
-        if (a && (a[0] === '127.0.0.1' || (a[0].split('.'))[0] !== '127')) {
+        if (a && ((!self.lookback_is_rejected && a.indexOf('127.0.0.1') !== -1) ||
+                a.find((rec)=> { return rec.split('.')[0] !== '127' }))
+        ) {
             self.disable_zone(zone, a);
             return cb(err, null);  // Return a null A record
         }
@@ -165,7 +167,7 @@ exports.check_zones = function (interval) {
         this.multi('127.0.0.1', zones, function (err, zone, a, pending) {
             if (!zone) return;
 
-            if (a || (err && err.code === 'ETIMEOUT')) {
+            if ((!self.lookback_is_rejected && a) || (err && err.code === 'ETIMEOUT')) {
                 return self.disable_zone(zone, ((a) ? a : err.code));
             }
 


### PR DESCRIPTION
- introduce global plugin.lookback_is_rejected flag that allows dnsbls that answer on silence testpoint to function.

Some dnsbl (hostkarma.junkemailfilter.com) return so-called blocked status on queries to 127.0.0.1. This change allows such zones to continue functioning.

In your dnsbl plugin:
```js
    plugin.inherits('dns_list_base');

    plugin.load_config();
    plugin.lookback_is_rejected = plugin.cfg.main.lookback_is_rejected;
```

This will need a proper per-zone solution some day.

Checklist:
- [ ] docs updated
- [x] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
