### PR TITLE
mods to logger.js

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -286,6 +286,9 @@ logger.log_if_level = function (level, key, plugin) {
             ) {
                 logobj = Object.assign(logobj, data);
             }
+            else if (typeof data === 'object' && data.hasOwnProperty('uuid')) {
+                logobj.uuid = data.uuid;
+            }
             else if (data.constructor === Object) {
                 if (!logobj.message.endsWith(' ')) {
                     logobj.message += ' ';

--- a/logger.js
+++ b/logger.js
@@ -271,8 +271,13 @@ logger.log_if_level = function (level, key, plugin) {
             }
             else if (data instanceof outbound.HMailItem) {
                 logobj.origin = 'outbound';
-                if (data.todo && data.todo.uuid) {
-                    logobj.uuid = data.todo.uuid;
+                if (data.todo) {
+                    if (data.todo.uuid)
+                        logobj.uuid = data.todo.uuid;
+                    if (data.todo.client_uuid) {
+                        // dirty hack
+                        logobj.origin = `outbound] [${data.todo.client_uuid}`;
+                    }
                 }
             }
             else if (

--- a/logger.js
+++ b/logger.js
@@ -130,14 +130,14 @@ logger.dump_and_exit = function (code) {
     });
 }
 
-logger.log = function (level, data) {
+logger.log = function (level, data, logobj) {
     if (level === 'PROTOCOL') {
         data = data.replace(/\n/g, '\\n');
     }
     data = data.replace(/\r/g, '\\r')
         .replace(/\n$/, '');
 
-    const item = { 'level' : level, 'data'  : data };
+    const item = { 'level' : level, 'data'  : data, obj: logobj};
 
     // buffer until plugins are loaded
     if (!plugins || (Array.isArray(plugins.plugin_list) &&
@@ -153,7 +153,7 @@ logger.log = function (level, data) {
         plugins.run_hooks('log', logger, log_item);
     }
 
-    plugins.run_hooks('log', logger, item );
+    plugins.run_hooks('log', logger, item);
     return true;
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:
-  Add a special "obj" log param to `log` func so that arbitrary params to log hook could be passed
- somewhat hacky: include outbound client ID in logging: but you'll have to set `hmail.todo.client_uuid` in order for this to work (in upcoming pull requests).
- allow specifying uuid in params when logging: `plugin.loginfo({name: 'hehe'}, {uuid: '123-123', 'meh'})`

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
