### PR TITLE
lower log level on invalid CTE, outbound client ID

### DIFF
--- a/mailbody.js
+++ b/mailbody.js
@@ -98,7 +98,7 @@ class Body extends events.EventEmitter {
 
         enc = enc.toLowerCase().split("\n").pop().trim();
         if (!enc.match(/^base64|quoted-printable|[78]bit$/i)) {
-            logger.logerror(`Invalid CTE on email: ${enc}, using 8bit`);
+            logger.logwarn(`Invalid CTE on email: ${enc}, using 8bit`);
             enc = '8bit';
         }
         enc = enc.replace(/^quoted-printable$/i, 'qp');

--- a/outbound/client_pool.js
+++ b/outbound/client_pool.js
@@ -72,7 +72,7 @@ function get_pool (port, host, local_addr, is_unix_socket, max) {
                     socket.destroy();
                 })
                 if (socket.writable) {
-                    logger.logprotocol("[outbound] C: QUIT");
+                    logger.logprotocol(`[outbound] [${socket.__uuid}] C: QUIT`);
                     socket.write("QUIT\r\n");
                 }
                 socket.end(); // half close


### PR DESCRIPTION
- lower log level on invalid CTE (seems like foreign spam likes it)
- outbound/client_pool.js: include outbound client ID into quit logstring, otherwise you can't know what client from the pool sent the QUIT.