### PR TITLE
mods to transaction.js & connection.js

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -1665,28 +1665,28 @@ class Connection {
             case constants.deny:
                 this.respond(550, msg || "Message denied", () => {
                     self.msg_count.reject++;
-                    self.transaction.msg_status.rejected = true;
+                    self.transaction.msg_status = 'rejected';
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denydisconnect:
                 this.respond(550, msg || "Message denied",() => {
                     self.msg_count.reject++;
-                    self.transaction.msg_status.rejected = true;
+                    self.transaction.msg_status = 'rejected';
                     self.disconnect();
                 });
                 break;
             case constants.denysoft:
                 this.respond(450, msg || "Message denied temporarily", () =>  {
                     self.msg_count.tempfail++;
-                    self.transaction.msg_status.tempfailed = true;
+                    self.transaction.msg_status = 'deferred';
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denysoftdisconnect:
                 this.respond(450, msg || "Message denied temporarily",() => {
                     self.msg_count.tempfail++;
-                    self.transaction.msg_status.tempfailed = true;
+                    self.transaction.msg_status = 'deferred';
                     self.disconnect();
                 });
                 break;
@@ -1762,28 +1762,28 @@ class Connection {
             case constants.deny:
                 this.respond(550, msg, () => {
                     self.msg_count.reject++;
-                    self.transaction.msg_status.rejected = true;
+                    self.transaction.msg_status = 'rejected';
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denydisconnect:
                 this.respond(550, msg, () => {
                     self.msg_count.reject++;
-                    self.transaction.msg_status.rejected = true;
+                    self.transaction.msg_status = 'rejected';
                     self.disconnect();
                 });
                 break;
             case constants.denysoft:
                 this.respond(450, msg, () => {
                     self.msg_count.tempfail++;
-                    self.transaction.msg_status.tempfailed = true;
+                    self.transaction.msg_status = 'deferred';
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denysoftdisconnect:
                 this.respond(450, msg, () => {
                     self.msg_count.tempfail++;
-                    self.transaction.msg_status.tempfailed = true;
+                    self.transaction.msg_status = 'deferred';
                     self.disconnect();
                 });
                 break;
@@ -1799,7 +1799,7 @@ class Connection {
                             if (!msg2) msg2 = self.queue_msg(retval2, msg2);
                             self.respond(550, msg2, () => {
                                 self.msg_count.reject++;
-                                self.transaction.msg_status.rejected = true;
+                                self.transaction.msg_status = 'rejected';
                                 self.reset_transaction(() => {
                                     self.resume();
                                 });
@@ -1809,7 +1809,7 @@ class Connection {
                             self.logerror(`Unrecognized response from outbound layer: ${retval2} : ${msg2}`);
                             self.respond(550, msg2 || "Internal Server Error", () => {
                                 self.msg_count.reject++;
-                                self.transaction.msg_status.rejected = true;
+                                self.transaction.msg_status = 'rejected';
                                 self.reset_transaction(() => {
                                     self.resume();
                                 });
@@ -1840,28 +1840,28 @@ class Connection {
             case constants.deny:
                 this.respond(550, msg, () => {
                     self.msg_count.reject++;
-                    self.transaction.msg_status.rejected = true;
+                    self.transaction.msg_status = 'rejected';
                     self.reset_transaction(() =>  self.resume());
                 });
                 break;
             case constants.denydisconnect:
                 this.respond(550, msg, () => {
                     self.msg_count.reject++;
-                    self.transaction.msg_status.rejected = true;
+                    self.transaction.msg_status = 'rejected';
                     self.disconnect();
                 });
                 break;
             case constants.denysoft:
                 this.respond(450, msg, () => {
                     self.msg_count.tempfail++;
-                    self.transaction.msg_status.tempfailed = true;
+                    self.transaction.msg_status = 'deferred';
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denysoftdisconnect:
                 this.respond(450, msg, () => {
                     self.msg_count.tempfail++;
-                    self.transaction.msg_status.tempfailed = true;
+                    self.transaction.msg_status = 'deferred';
                     self.disconnect();
                 });
                 break;
@@ -1869,7 +1869,7 @@ class Connection {
                 if (!msg) msg = 'Queuing declined or disabled, try later';
                 this.respond(451, msg, () => {
                     self.msg_count.tempfail++;
-                    self.transaction.msg_status.tempfailed = true;
+                    self.transaction.msg_status = 'deferred';
                     self.reset_transaction(() => self.resume());
                 });
                 break;
@@ -1889,7 +1889,7 @@ class Connection {
 
         this.respond(250, params, () => {
             self.msg_count.accept++;
-            if (self.transaction) self.transaction.msg_status.accepted = true;
+            if (self.transaction) self.transaction.msg_status = 'accepted';
             self.reset_transaction(() => self.resume());
         });
     }

--- a/connection.js
+++ b/connection.js
@@ -771,7 +771,8 @@ class Connection {
             case constants.deny:
                 this.respond(500, msg || "Unrecognized command");
                 break;
-            case constants.denydisconnect,constants.denysoftdisconnect:
+            case constants.denydisconnect:
+            case constants.denysoftdisconnect:
                 this.respond(521, msg || "Unrecognized command", () => {
                     self.disconnect();
                 });

--- a/connection.js
+++ b/connection.js
@@ -771,7 +771,7 @@ class Connection {
             case constants.deny:
                 this.respond(500, msg || "Unrecognized command");
                 break;
-            case constants.denydisconnect:
+            case constants.denydisconnect,constants.denysoftdisconnect:
                 this.respond(521, msg || "Unrecognized command", () => {
                     self.disconnect();
                 });
@@ -1219,6 +1219,11 @@ class Connection {
             }
         );
 
+        this.notes.proxy = {
+            type: 'haproxy', proto: proto,
+            src_ip: src_ip, src_port: src_port, dst_ip: dst_ip, dst_port: dst_port, proxy_ip: this.remote.ip
+        };
+
         this.reset_transaction(function () {
             self.set('proxy.ip', self.remote.ip);
             self.set('proxy.type', 'haproxy');
@@ -1659,24 +1664,28 @@ class Connection {
             case constants.deny:
                 this.respond(550, msg || "Message denied", () => {
                     self.msg_count.reject++;
+                    self.transaction.msg_status.rejected = true;
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denydisconnect:
                 this.respond(550, msg || "Message denied",() => {
                     self.msg_count.reject++;
+                    self.transaction.msg_status.rejected = true;
                     self.disconnect();
                 });
                 break;
             case constants.denysoft:
                 this.respond(450, msg || "Message denied temporarily", () =>  {
                     self.msg_count.tempfail++;
+                    self.transaction.msg_status.tempfailed = true;
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denysoftdisconnect:
                 this.respond(450, msg || "Message denied temporarily",() => {
                     self.msg_count.tempfail++;
+                    self.transaction.msg_status.tempfailed = true;
                     self.disconnect();
                 });
                 break;
@@ -1724,6 +1733,8 @@ class Connection {
             case constants.denysoftdisconnect:
                 this.transaction.results.add(res_as, { fail: msg });
                 break;
+            case constants.cont:
+                break;
             default:
                 this.transaction.results.add(res_as, { msg: msg });
                 break;
@@ -1731,7 +1742,7 @@ class Connection {
     }
     queue_outbound_respond (retval, msg) {
         const self = this;
-        if (!msg) msg = this.queue_msg(retval, msg);
+        if (!msg) msg = this.queue_msg(retval, msg) || 'Message Queued';
         this.store_queue_result(retval, msg);
         msg = `${msg} (${this.transaction.uuid})`;
         if (retval !== constants.ok) {
@@ -1750,30 +1761,34 @@ class Connection {
             case constants.deny:
                 this.respond(550, msg, () => {
                     self.msg_count.reject++;
+                    self.transaction.msg_status.rejected = true;
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denydisconnect:
                 this.respond(550, msg, () => {
                     self.msg_count.reject++;
+                    self.transaction.msg_status.rejected = true;
                     self.disconnect();
                 });
                 break;
             case constants.denysoft:
                 this.respond(450, msg, () => {
                     self.msg_count.tempfail++;
+                    self.transaction.msg_status.tempfailed = true;
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denysoftdisconnect:
                 this.respond(450, msg, () => {
                     self.msg_count.tempfail++;
+                    self.transaction.msg_status.tempfailed = true;
                     self.disconnect();
                 });
                 break;
             default:
                 outbound.send_email(this.transaction, (retval2, msg2) => {
-                    if (!msg2) msg2 = self.queue_msg(retval2, msg2);
+                    if (!msg2) msg2 = self.queue_msg(retval2, msg);
                     switch (retval2) {
                         case constants.ok:
                             if (!msg2) msg2 = self.queue_msg(retval2, msg2);
@@ -1783,6 +1798,7 @@ class Connection {
                             if (!msg2) msg2 = self.queue_msg(retval2, msg2);
                             self.respond(550, msg2, () => {
                                 self.msg_count.reject++;
+                                self.transaction.msg_status.rejected = true;
                                 self.reset_transaction(() => {
                                     self.resume();
                                 });
@@ -1792,6 +1808,7 @@ class Connection {
                             self.logerror(`Unrecognized response from outbound layer: ${retval2} : ${msg2}`);
                             self.respond(550, msg2 || "Internal Server Error", () => {
                                 self.msg_count.reject++;
+                                self.transaction.msg_status.rejected = true;
                                 self.reset_transaction(() => {
                                     self.resume();
                                 });
@@ -1822,24 +1839,28 @@ class Connection {
             case constants.deny:
                 this.respond(550, msg, () => {
                     self.msg_count.reject++;
+                    self.transaction.msg_status.rejected = true;
                     self.reset_transaction(() =>  self.resume());
                 });
                 break;
             case constants.denydisconnect:
                 this.respond(550, msg, () => {
                     self.msg_count.reject++;
+                    self.transaction.msg_status.rejected = true;
                     self.disconnect();
                 });
                 break;
             case constants.denysoft:
                 this.respond(450, msg, () => {
                     self.msg_count.tempfail++;
+                    self.transaction.msg_status.tempfailed = true;
                     self.reset_transaction(() => self.resume());
                 });
                 break;
             case constants.denysoftdisconnect:
                 this.respond(450, msg, () => {
                     self.msg_count.tempfail++;
+                    self.transaction.msg_status.tempfailed = true;
                     self.disconnect();
                 });
                 break;
@@ -1847,6 +1868,7 @@ class Connection {
                 if (!msg) msg = 'Queuing declined or disabled, try later';
                 this.respond(451, msg, () => {
                     self.msg_count.tempfail++;
+                    self.transaction.msg_status.tempfailed = true;
                     self.reset_transaction(() => self.resume());
                 });
                 break;
@@ -1866,6 +1888,7 @@ class Connection {
 
         this.respond(250, params, () => {
             self.msg_count.accept++;
+            if (self.transaction) self.transaction.msg_status.accepted = true;
             self.reset_transaction(() => self.resume());
         });
     }

--- a/transaction.js
+++ b/transaction.js
@@ -37,12 +37,8 @@ class Transaction {
             accept: 0,
             tempfail: 0,
             reject: 0,
-        };
-        this.msg_status = {
-            accepted:   false,
-            tempfailed: false,
-            rejected:   false
-        };
+        }
+        this.msg_status = 'undefined';
         this.data_post_start = null;
         this.data_post_delay = 0;
         this.encoding = 'utf8';

--- a/transaction.js
+++ b/transaction.js
@@ -38,7 +38,7 @@ class Transaction {
             tempfail: 0,
             reject: 0,
         }
-        this.msg_status = 'undefined';
+        this.msg_status = undefined;
         this.data_post_start = null;
         this.data_post_delay = 0;
         this.encoding = 'utf8';

--- a/transaction.js
+++ b/transaction.js
@@ -37,7 +37,12 @@ class Transaction {
             accept: 0,
             tempfail: 0,
             reject: 0,
-        }
+        };
+        this.msg_status = {
+            accepted:   false,
+            tempfailed: false,
+            rejected:   false
+        };
         this.data_post_start = null;
         this.data_post_delay = 0;
         this.encoding = 'utf8';


### PR DESCRIPTION
Changes proposed in this pull request:
* Basically, this patch adds more info to notes object, like:
  * `connection.notes.proxy` , for remotes that use PROXY proto
  * `transaction.msg_status.(rejected|tempfailed|accepted) = true`, for ex., for consequent logging into ES 
* Don't add anything to queue results if queue hook returned CONT (that probably means we want next queue hook to fire, which will populate the results with delivery info)
* Fix "queued" messages, so that we don't get ($uuid)($uuid) duplicates and such
* fixes #2403 , where we don't just ignore denysoftdisconnect on unrecognized_command

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
