### PR TITLE
add outbound TLS NO-GO feature

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,11 @@
+## 2.8.21 - Mmm DD, 2018
+
+* New Features
+    * outbound: skip STARTTLS after remote host fails TLS upgrade
+* Fixes
+* Changes
+
+
 ## 2.8.20 - Jun 29, 2018
 
 * New Features
@@ -16,7 +24,6 @@
 ## 2.8.19 - Jun 26, 2018
 
 * New features
-    * outbound: TLS NO-GO feature that "downgrades" to unsecure when remote host is misbehaving during TLS session
     * outbound: received_header=disabled supresses outbound Received header addition. #2409
     * auth_base.js: `check_plain_passwd` and `check_cram_md5_passwd` can now pass `message` and `code` to callback routine
     * spf: allow bypass for relay and AUTH clients #2417

--- a/Changes.md
+++ b/Changes.md
@@ -16,6 +16,7 @@
 ## 2.8.19 - Jun 26, 2018
 
 * New features
+    * outbound: TLS NO-GO feature that "downgrades" to unsecure when remote host is misbehaving during TLS session
     * outbound: received_header=disabled supresses outbound Received header addition. #2409
     * auth_base.js: `check_plain_passwd` and `check_cram_md5_passwd` can now pass `message` and `code` to callback routine
     * spf: allow bypass for relay and AUTH clients #2417

--- a/config/tls.ini
+++ b/config/tls.ini
@@ -19,30 +19,30 @@
 [redis]
 ; options in this block require redis to be enabled in config/plugins.
 
-; remember when a remote fails STARTTLS. The next time they connect,
-;     don't offer STARTTLS option (so message gets delivered).
+; Remember when a remote fails STARTTLS, the next time they/we connect,
+;     don't offer/use STARTTLS option (so message gets delivered).
 ;     pro: increases mail reliability
 ;     con: reduces security
+; outbound only warning: **you must restart haraka** after changing this option
 ; default: false
 ; disable_for_failed_hosts=true
 
+; The following section applies to outbound only:
 ; host = 127.0.0.1
 ; "TLS NO-GO" db
 ; db = 3
-
-; Remember when a remote fails STARTTLS. The next time we connect,
-;   don't use STARTTLS option (so message gets delivered).
-; default: false
-; **you must restart haraka** after changing this option
-; disable_for_failed_hosts = true
 ; Expiry time in seconds
 ; disable_expiry = 604800
 
-
-; no_tls_hosts - disable TLS for servers with broken TLS.
+; no_tls_hosts - disable TLS for servers with broken TLS. (applies to inbound only)
 [no_tls_hosts]
 ; 127.0.0.1
 ; 192.168.1.1
 ; 172.16.0.0/16
 
 [outbound]
+; key=tls_key.pem
+; cert=tls_cert.pem
+; dhparam=dhparams.pem
+
+; and other options from [main] section above

--- a/config/tls.ini
+++ b/config/tls.ini
@@ -26,9 +26,23 @@
 ; default: false
 ; disable_for_failed_hosts=true
 
+; host = 127.0.0.1
+; "TLS NO-GO" db
+; db = 3
+
+; Remember when a remote fails STARTTLS. The next time we connect,
+;   don't use STARTTLS option (so message gets delivered).
+; default: false
+; **you must restart haraka** after changing this option
+; disable_for_failed_hosts = true
+; Expiry time in seconds
+; disable_expiry = 604800
+
 
 ; no_tls_hosts - disable TLS for servers with broken TLS.
 [no_tls_hosts]
 ; 127.0.0.1
 ; 192.168.1.1
 ; 172.16.0.0/16
+
+[outbound]

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -389,6 +389,8 @@ class HMailItem extends events.EventEmitter {
                 self.logerror(`Ongoing connection failed to ${host}:${port} : ${err}`);
                 processing_mail = false;
                 client_pool.release_client(socket, port, host, mx.bind, true);
+                if (err.source === 'tls') // exception thrown from tls_socket during tls upgrade
+                    return obtls.mark_tls_nogo(host, () => { return self.try_deliver_host(mx); });
                 // try the next MX
                 return self.try_deliver_host(mx);
             }
@@ -463,8 +465,8 @@ class HMailItem extends events.EventEmitter {
             response = [];
         };
 
-        const process_ehlo_data = function () {
-            for (let i=0,l=response.length; i < l; i++) {
+        const set_ehlo_props = function () {
+            for (let i = 0, l = response.length; i < l; i++) {
                 const r = response[i];
                 if (r.toUpperCase() === '8BITMIME') {
                     smtp_properties.eightbitmime = true;
@@ -491,23 +493,9 @@ class HMailItem extends events.EventEmitter {
                     }
                 }
             }
+        };
 
-            // TLS
-            if (!secured && smtp_properties.tls && cfg.enable_tls) {
-                const tls_cfg = obtls.tls_socket.load_tls_ini({role: 'client'});
-                if (!net_utils.ip_in_list(tls_cfg.no_tls_hosts, host) &&
-                    !net_utils.ip_in_list(tls_cfg.no_tls_hosts, self.todo.domain)) {
-                    socket.on('secure', function () {
-                        // Set this flag so we don't try STARTTLS again if it
-                        // is incorrectly offered at EHLO once we are secured.
-                        secured = true;
-                        send_command(mx.using_lmtp ? 'LHLO' : 'EHLO', mx.bind_helo);
-                    });
-                    return send_command('STARTTLS');
-                }
-            }
-
-            // IMPORTANT: do STARTTLS before AUTH for security
+        const auth_and_mail_phase = function () {
             if (!authenticated && (mx.auth_user && mx.auth_pass)) {
                 // We have AUTH credentials to send for this domain
                 if (!(Array.isArray(smtp_properties.auth) && smtp_properties.auth.length)) {
@@ -558,7 +546,41 @@ class HMailItem extends events.EventEmitter {
             }
 
             return send_command('MAIL', `FROM:${self.todo.mail_from.format(!smtp_properties.smtp_utf8)}`);
-        };
+        }; // auth_and_mail_phase()
+
+        const process_ehlo_data = function () {
+            set_ehlo_props();
+
+            // TLS
+            if (!secured && smtp_properties.tls && cfg.enable_tls) {
+                const tls_cfg = obtls.tls_socket.load_tls_ini({role: 'client'});
+                if (!net_utils.ip_in_list(tls_cfg.no_tls_hosts, host) &&
+                    !net_utils.ip_in_list(tls_cfg.no_tls_hosts, self.todo.domain)) {
+
+                    self.logdebug(`Trying TLS for domain: ${self.todo.domain}, host: ${host}`);
+
+                    return obtls.check_tls_nogo(host,
+                        () => { // Clear to GO
+                            socket.on('secure', function () {
+                                // Set this flag so we don't try STARTTLS again if it
+                                // is incorrectly offered at EHLO once we are secured.
+                                secured = true;
+                                send_command(mx.using_lmtp ? 'LHLO' : 'EHLO', mx.bind_helo);
+                            });
+                            return send_command('STARTTLS');
+                        },
+                        (when) => { // No GO
+                            self.loginfo(`TLS disabled for ${host} because it was marked as non-TLS on ${when}`);
+                            return auth_and_mail_phase();
+                        }
+                    );
+                }
+            }
+
+            // IMPORTANT: we do STARTTLS before we attempt AUTH for extra security
+            return auth_and_mail_phase();
+
+        }; // process_ehlo_data()
 
         let fp_called = false;
 
@@ -1401,6 +1423,7 @@ class HMailItem extends events.EventEmitter {
 }
 
 module.exports = HMailItem;
+module.exports.obtls = obtls;
 
 // copy logger methods into HMailItem:
 for (const key in logger) {

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -300,7 +300,7 @@ class HMailItem extends events.EventEmitter {
             return this.temp_fail("Tried all MXs");
         }
 
-        const mx   = this.mxlist.shift();
+        const mx = this.mxlist.shift();
         let host = mx.exchange;
 
         // IP or IP:port
@@ -465,7 +465,7 @@ class HMailItem extends events.EventEmitter {
             response = [];
         };
 
-        const set_ehlo_props = function () {
+        function set_ehlo_props () {
             for (let i = 0, l = response.length; i < l; i++) {
                 const r = response[i];
                 if (r.toUpperCase() === '8BITMIME') {
@@ -493,9 +493,9 @@ class HMailItem extends events.EventEmitter {
                     }
                 }
             }
-        };
+        }
 
-        const auth_and_mail_phase = function () {
+        function auth_and_mail_phase () {
             if (!authenticated && (mx.auth_user && mx.auth_pass)) {
                 // We have AUTH credentials to send for this domain
                 if (!(Array.isArray(smtp_properties.auth) && smtp_properties.auth.length)) {
@@ -546,9 +546,9 @@ class HMailItem extends events.EventEmitter {
             }
 
             return send_command('MAIL', `FROM:${self.todo.mail_from.format(!smtp_properties.smtp_utf8)}`);
-        }; // auth_and_mail_phase()
+        } // auth_and_mail_phase()
 
-        const process_ehlo_data = function () {
+        function process_ehlo_data () {
             set_ehlo_props();
 
             // TLS
@@ -580,7 +580,7 @@ class HMailItem extends events.EventEmitter {
             // IMPORTANT: we do STARTTLS before we attempt AUTH for extra security
             return auth_and_mail_phase();
 
-        }; // process_ehlo_data()
+        } // process_ehlo_data()
 
         let fp_called = false;
 
@@ -1034,7 +1034,6 @@ class HMailItem extends events.EventEmitter {
         bounce_msg_image_.forEach(function (line) {
             bounce_image_lines.push(line)
         });
-
 
         const boundary = `boundary_${utils.uuid()}`;
         const bounce_body = [];

--- a/outbound/queue.js
+++ b/outbound/queue.js
@@ -70,9 +70,11 @@ exports.stat_queue = function (cb) {
 exports.load_queue = function (pid) {
     // Initialise and load queue
     // This function is called first when not running under cluster,
-    // so we create the queue directory if it doesn't already exist.
-    exports.ensure_queue_dir();
-    exports._load_cur_queue(pid, "_add_file");
+    HMailItem.obtls.get_plugin_ready(function () {
+        // so we create the queue directory if it doesn't already exist.
+        exports.ensure_queue_dir();
+        exports._load_cur_queue(pid, "_add_file");
+    });
 }
 
 exports._load_cur_queue = function (pid, cb_name, cb) {

--- a/outbound/tls.js
+++ b/outbound/tls.js
@@ -1,48 +1,107 @@
 'use strict';
 
+exports.name = 'outbound-tls';
+
 exports.config     = require('haraka-config');
 
 exports.tls_socket = require('../tls_socket');
+const logger       = require('../logger');
+const hkredis      = require('haraka-plugin-redis');
 
-exports.get_tls_options = function (mx) {
+// initialization routine, please call it early
+exports.get_plugin_ready = function (cb) {
+    const plugin = this;
 
+    plugin.cfg = exports.load_config();
+    // logger.logdebug(plugin, plugin.cfg.redis);
+
+    if (plugin.cfg.redis.disable_for_failed_hosts) { // which means changing this var in-flight won't work
+        logger.logdebug(plugin, 'Will disable outbound TLS for failing TLS hosts');
+        Object.assign(plugin, hkredis);
+        plugin.merge_redis_ini();
+        return plugin.init_redis_plugin(cb);
+    }
+    return cb();
+};
+
+exports.load_config = function () {
     const tls_cfg = exports.tls_socket.load_tls_ini();
-    const tls_options = JSON.parse(JSON.stringify(tls_cfg.outbound || {}));
+    const cfg = JSON.parse(JSON.stringify(tls_cfg.outbound || {}));
+    cfg.redis = tls_cfg.redis;
 
     const inheritable_opts = [
         'key', 'cert', 'ciphers', 'dhparam',
         'requestCert', 'honorCipherOrder', 'rejectUnauthorized'
     ];
 
-    tls_options.servername = mx.exchange;
-
     for (const opt of inheritable_opts) {
-        if (tls_options[opt] === undefined) {
+        if (cfg[opt] === undefined) {
             // not declared in tls.ini[section]
             if (tls_cfg.main[opt] !== undefined) {
                 // use value from [main] section
-                tls_options[opt] = tls_cfg.main[opt];
+                cfg[opt] = tls_cfg.main[opt];
             }
         }
     }
 
-    if (tls_options.key) {
-        if (Array.isArray(tls_options.key)) {
-            tls_options.key = tls_options.key[0];
+    if (cfg.key) {
+        if (Array.isArray(cfg.key)) {
+            cfg.key = cfg.key[0];
         }
-        tls_options.key = exports.config.get(tls_options.key, 'binary');
+        cfg.key = exports.config.get(cfg.key, 'binary');
     }
 
-    if (tls_options.dhparam) {
-        tls_options.dhparam = exports.config.get(tls_options.dhparam, 'binary');
+    if (cfg.dhparam) {
+        cfg.dhparam = exports.config.get(cfg.dhparam, 'binary');
     }
 
-    if (tls_options.cert) {
-        if (Array.isArray(tls_options.cert)) {
-            tls_options.cert = tls_options.cert[0];
+    if (cfg.cert) {
+        if (Array.isArray(cfg.cert)) {
+            cfg.cert = cfg.cert[0];
         }
-        tls_options.cert = exports.config.get(tls_options.cert, 'binary');
+        cfg.cert = exports.config.get(cfg.cert, 'binary');
     }
 
-    return tls_options;
-}
+    return cfg;
+};
+
+exports.get_tls_options = function (mx) {
+    return Object.assign(this.cfg, {servername: mx.exchange});
+};
+
+// Check for if host is prohibited from TLS negotiation
+exports.check_tls_nogo = function (host, cb_ok, cb_nogo){
+    const plugin = this;
+    const dbkey = `no_tls|${host}`;
+
+    if (!plugin.cfg.redis.disable_for_failed_hosts)
+        return cb_ok();
+
+    plugin.db.get(dbkey, (err, dbr) => {
+        if (err) {
+            logger.logdebug(plugin, `Redis returned error: ${err}`);
+            return cb_ok();
+        }
+
+        return dbr ? cb_nogo(dbr) : cb_ok();
+    });
+};
+
+exports.mark_tls_nogo = function (host, cb){
+    const plugin = this;
+    const dbkey = `no_tls|${host}`;
+    const expiry = plugin.cfg.redis.disable_expiry || 604800;
+
+    if (!plugin.cfg.redis.disable_for_failed_hosts)
+        return cb();
+
+    logger.lognotice(plugin, `TLS connection failed. Marking ${host} as non-TLS for ${expiry} seconds`);
+
+    plugin.db.setex(dbkey, expiry, new Date(), (err, dbr) => {
+        if (err) logger.logerror(plugin, `Redis returned error: ${err}`);
+
+        cb();
+    });
+};
+
+logger.add_log_methods(this);

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -67,7 +67,6 @@ exports.advertise_starttls = function (next, connection) {
 }
 
 exports.set_notls = function (ip) {
-    const plugin = this;
 
     if (!tls_socket.cfg.redis) return;
     if (!tls_socket.cfg.redis.disable_for_failed_hosts) return;

--- a/tests/outbound/index.js
+++ b/tests/outbound/index.js
@@ -136,14 +136,6 @@ exports.get_tls_options = {
         process.env.HARAKA_TEST_DIR=path.resolve('tests');
         this.outbound = require('../../outbound');
         this.obtls = require('../../outbound/tls');
-        done();
-    },
-    tearDown: function (done) {
-        delete process.env.HARAKA_TEST_DIR;
-        done();
-    },
-    'gets TLS properties from tls.ini.outbound': function (test) {
-        test.expect(1);
 
         // reset config to load from tests directory
         const testDir = path.resolve('tests');
@@ -151,6 +143,14 @@ exports.get_tls_options = {
         this.outbound.config = this.outbound.config.module_config(testDir);
         this.obtls.config = this.outbound.config.module_config(testDir);
 
+        this.obtls.get_plugin_ready(()=> done());
+    },
+    tearDown: function (done) {
+        delete process.env.HARAKA_TEST_DIR;
+        done();
+    },
+    'gets TLS properties from tls.ini.outbound': function (test) {
+        test.expect(1);
         const tls_config = this.obtls.get_tls_options(
             { exchange: 'mail.example.com'}
         );
@@ -163,7 +163,8 @@ exports.get_tls_options = {
             ciphers: 'ECDHE-RSA-AES256-GCM-SHA384',
             rejectUnauthorized: false,
             requestCert: false,
-            honorCipherOrder: false
+            honorCipherOrder: false,
+            redis: { disable_for_failed_hosts: false },
         });
         test.done();
     },

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -82,6 +82,7 @@ class pluggableStream extends stream.Stream {
         });
         self.targetsocket.once('error', function (exception) {
             self.writable = self.targetsocket.writable;
+            exception.source = 'tls';
             self.emit('error', exception);
         });
         self.targetsocket.on('timeout', function () {
@@ -618,6 +619,7 @@ function createServer (cb) {
 
             cleartext
                 .on('error', exception => {
+                    exception.source = 'tls';
                     socket.emit('error', exception);
                 })
                 .on('secure', () => {


### PR DESCRIPTION
* outbound: TLS NO-GO feature that "downgrades" to unsecure when remote host is misbehaving during TLS session

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
