### PR TITLE
mods to outbound

### DIFF
--- a/outbound/index.js
+++ b/outbound/index.js
@@ -96,6 +96,7 @@ exports.send_email = function () {
     // set MAIL FROM address, and parse if it's not an Address object
     if (from instanceof Address) {
         transaction.mail_from = from;
+        if (from.hack) transaction.notes = from.hack;
     }
     else {
         try {
@@ -239,7 +240,7 @@ exports.send_trans_email = function (transaction, next) {
     }
 
     if (cfg.received_header !== 'disabled') {
-        transaction.add_leading_header('Received', `(${cfg.received_header}); ${utils.date_to_str(new Date())}`);
+        transaction.add_leading_header('Received', `(${cfg.received_header}) with LOCAL id ${transaction.uuid}; ${utils.date_to_str(new Date())}`);
     }
 
     const connection = {
@@ -248,7 +249,7 @@ exports.send_trans_email = function (transaction, next) {
 
     logger.add_log_methods(connection);
     if (!transaction.results) {
-        logger.logerror('adding missing results store');
+        logger.loginfo('adding missing results store');
         transaction.results = new ResultStore(connection);
     }
 


### PR DESCRIPTION
This is a collection of small "improvements" over `outbound` framework.
* rework send_email_respond switch so that it would accept `DENY` and send bounce with passed `params`
* add hack to allow passing params into bounce creation routine
* add trans uuid to Received header
* include mx.bind IP address in log message
* note outbound client UUID in `hmail`.todo
* pass `extra` param to `deferred` hook

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
