### PR TITLE
Divide relay.acl() between two hooks 

### DIFF
--- a/plugins/relay.js
+++ b/plugins/relay.js
@@ -12,7 +12,8 @@ exports.register = function () {
 
     if (plugin.cfg.relay.acl) {
         plugin.load_acls();             // plugin.acl_allow = [..]
-        plugin.register_hook('connect', 'acl');
+        plugin.register_hook('connect_init', 'acl');
+        plugin.register_hook('connect', 'pass_relaying');
     }
 
     if (plugin.cfg.relay.force_routing || plugin.cfg.relay.dest_domains) {
@@ -90,6 +91,14 @@ exports.acl = function (next, connection) {
     connection.results.add(plugin, {pass: 'acl'});
     connection.relaying = true;
     return next(OK);
+}
+
+exports.pass_relaying = function (next, connection) {
+    if (connection.relaying) {
+        return next(OK);
+    }
+
+    return next();
 }
 
 exports.is_acl_allowed = function (connection) {

--- a/tests/plugins/relay.js
+++ b/tests/plugins/relay.js
@@ -102,7 +102,8 @@ exports.acl = {
             test.done();
         };
         this.plugin.cfg.relay.acl=false;
-        this.plugin.acl(next, this.connection);
+        this.plugin.acl(() => {}, this.connection);
+        this.plugin.pass_relaying(next, this.connection);
     },
     'relay.acl=true, miss' : function (test) {
         test.expect(2);
@@ -112,7 +113,8 @@ exports.acl = {
             test.done();
         }.bind(this);
         this.plugin.cfg.relay.acl=true;
-        this.plugin.acl(next, this.connection);
+        this.plugin.acl(() => {}, this.connection);
+        this.plugin.pass_relaying(next, this.connection);
     },
     'relay.acl=true, hit' : function (test) {
         test.expect(2);
@@ -124,7 +126,8 @@ exports.acl = {
         this.plugin.cfg.relay.acl=true;
         this.connection.remote.ip='1.1.1.1';
         this.plugin.acl_allow=['1.1.1.1/32'];
-        this.plugin.acl(next, this.connection);
+        this.plugin.acl(() => {}, this.connection);
+        this.plugin.pass_relaying(next, this.connection);
     },
     'relay.acl=true, hit, missing mask' : function (test) {
         test.expect(2);
@@ -136,7 +139,8 @@ exports.acl = {
         this.plugin.cfg.relay.acl=true;
         this.connection.remote.ip='1.1.1.1';
         this.plugin.acl_allow=['1.1.1.1'];
-        this.plugin.acl(next, this.connection);
+        this.plugin.acl(() => {}, this.connection);
+        this.plugin.pass_relaying(next, this.connection);
     },
     'relay.acl=true, hit, net': function (test) {
         test.expect(2);
@@ -148,7 +152,8 @@ exports.acl = {
         this.plugin.cfg.relay.acl=true;
         this.connection.remote.ip='1.1.1.1';
         this.plugin.acl_allow=['1.1.1.1/24'];
-        this.plugin.acl(next, this.connection);
+        this.plugin.acl(() => {}, this.connection);
+        this.plugin.pass_relaying(next, this.connection);
     },
 }
 
@@ -297,7 +302,8 @@ exports.all = {
         this.plugin.cfg.relay.all = true;
         this.plugin.register_hook('rcpt', 'all');  // register() doesn't b/c config is disabled
         // console.log(this.plugin.register_hook.args);
-        test.equals(this.plugin.register_hook.args[2][1], 'all');
+        console.log(this.plugin.register_hook.args);
+        test.equals(this.plugin.register_hook.args[3][1], 'all');
         test.done();
     },
     'all hook always returns OK' : function (test) {


### PR DESCRIPTION
Since relay plugin uses `connect` hook and is last due `next(OK)` if relaying there is no easy way to know that IP is relayed before communication begins.

I have moved `acl` method to connect_init hook to just make relaying flag accessible earlier and created `pass_relaying` hooked to `connect` so it will work same as before. 

Checklist:
- [ ] docs updated
- [x] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
