### PR TITLE
Attempt to mitigate mime part explosion attack

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -600,6 +600,7 @@ class Connection {
         if (this.state >= states.DISCONNECTING) return;
         const self = this;
         self.state = states.DISCONNECTING;
+        self.current_data = null; // don't process any more data we have already received
         this.reset_transaction(() => {
             plugins.run_hooks('disconnect', self);
         });

--- a/connection.js
+++ b/connection.js
@@ -1595,6 +1595,14 @@ class Connection {
             return;
         }
 
+        if (this.transaction.mime_part_count >= 1000) {
+            this.logcrit("Possible DoS attempt - too many MIME parts");
+            this.respond(554, "Transaction failed due to too many MIME parts", function () {
+                self.reset_transaction();
+            });
+            return;
+        }
+
         this.transaction.add_data(line);
     }
     data_done () {

--- a/connection.js
+++ b/connection.js
@@ -1598,7 +1598,7 @@ class Connection {
         if (this.transaction.mime_part_count >= 1000) {
             this.logcrit("Possible DoS attempt - too many MIME parts");
             this.respond(554, "Transaction failed due to too many MIME parts", function () {
-                self.reset_transaction();
+                self.disconnect();
             });
             return;
         }

--- a/connection.js
+++ b/connection.js
@@ -1595,7 +1595,8 @@ class Connection {
             return;
         }
 
-        if (this.transaction.mime_part_count >= 1000) {
+        const max_mime_parts = config.get('max_mime_parts') || 1000;
+        if (this.transaction.mime_part_count >= max_mime_parts) {
             this.logcrit("Possible DoS attempt - too many MIME parts");
             this.respond(554, "Transaction failed due to too many MIME parts", function () {
                 self.disconnect();

--- a/docs/CoreConfig.md
+++ b/docs/CoreConfig.md
@@ -135,3 +135,8 @@ The list of plugins to load
   to enable:   `echo 1 > /path/to/haraka/config/strict_rfc1869`
   to disable:  `echo 0 > /path/to/haraka/config/strict_rfc1869`
 
+* max_mime_parts
+
+  Defaults to 1000. There's a potential denial of service in large numbers of
+  MIME parts in carefully crafted emails. If this limit is too low for some
+  reason you can increase it by setting a value in this file.

--- a/mailbody.js
+++ b/mailbody.js
@@ -60,10 +60,12 @@ class Body extends events.EventEmitter {
                 this.state = 'end';
             }
             else {
+                this.emit('mime_boundary', line);
                 const bod = new Body(new Header(), this.options);
                 this.listeners('attachment_start').forEach(function (cb) { bod.on('attachment_start', cb) });
                 this.listeners('attachment_data' ).forEach(function (cb) { bod.on('attachment_data', cb) });
                 this.listeners('attachment_end'  ).forEach(function (cb) { bod.on('attachment_end', cb) });
+                this.listeners('mime_boundary').forEach(cb => bod.on('mime_boundary', cb));
                 this.filters.forEach(function (f) { bod.add_filter(f); });
                 this.children.push(bod);
                 bod.state = 'headers';
@@ -268,8 +270,10 @@ class Body extends events.EventEmitter {
             }
             else {
                 // next section
+                this.emit('mime_boundary', line);
                 const bod = new Body(new Header(), this.options);
                 this.listeners('attachment_start').forEach(function (cb) { bod.on('attachment_start', cb) });
+                this.listeners('mime_boundary').forEach(cb => bod.on('mime_boundary', cb));
                 this.filters.forEach(function (f) { bod.add_filter(f); });
                 this.children.push(bod);
                 bod.state = 'headers';

--- a/transaction.js
+++ b/transaction.js
@@ -194,9 +194,6 @@ class Transaction {
 
     incr_mime_count (line) {
         this.mime_part_count++;
-        if (this.mime_part_count >= 1000) {
-            throw "Too many MIME parts. Possible DoS";
-        }
     }
 }
 


### PR DESCRIPTION
Fixes a privately disclosed security vulnerability

Changes proposed in this pull request:
- Limit mime parts to 1000 max.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
