### PR TITLE
Clear timeout on cancel

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -433,7 +433,10 @@ plugins.run_next_hook = function (hook, object, params) {
     let cancelled = false;
     let item;
 
-    function cancel () { cancelled = true; }
+    function cancel () {
+        if (timeout_id) clearTimeout(timeout_id);
+        cancelled = true;
+    }
     function callback (retval, msg) {
         if (timeout_id) clearTimeout(timeout_id);
         object.current_hook = null;


### PR DESCRIPTION
Finally tracked down a long standing annoyance that I've had with TLS.   If the client drops the connection after TLS negotiation fails, then the hook timer is never cancelled and you end up with a load of 'plugin tls timed out on hook unrecognized_command' messages in the logs.