### PR TITLE
replace all _ chars in hostnames with code points

### DIFF
--- a/outbound/qfile.js
+++ b/outbound/qfile.js
@@ -10,9 +10,9 @@ const _qfile = module.exports = {
     hostname : function (hostname) {
         if (!hostname) hostname = os.hostname();
         return hostname
-            .replace(/\\/, '\\057')
-            .replace(/:/,  '\\072')
-            .replace(/_/,  '\\137');
+            .replace(/\\/g, '\\057')
+            .replace(/:/g,  '\\072')
+            .replace(/_/g,  '\\137');
     },
 
     name : function (overrides) {

--- a/tests/outbound/qfile.js
+++ b/tests/outbound/qfile.js
@@ -52,16 +52,16 @@ exports.hostname = {
     },
     'hostname, replaces \\ char': function (test) {
         test.expect(1)
-        const r = qfile.hostname('mta1.exam\\ple.com')
+        const r = qfile.hostname('mt\\a1.exam\\ple.com')
         // console.log(r)
-        test.deepEqual(r, 'mta1.exam\\057ple.com')
+        test.deepEqual(r, 'mt\\057a1.exam\\057ple.com')
         test.done()
     },
     'hostname, replaces _ char': function (test) {
         test.expect(1)
-        const r = qfile.hostname('mta1.exam_ple.com')
+        const r = qfile.hostname('mt_a1.exam_ple.com')
         // console.log(r)
-        test.deepEqual(r, 'mta1.exam\\137ple.com')
+        test.deepEqual(r, 'mt\\137a1.exam\\137ple.com')
         test.done()
     }
 }


### PR DESCRIPTION
Fixes # 

https://github.com/haraka/Haraka/pull/2324

i think that the replace pattern should use /g expression maybe?
![image](https://user-images.githubusercontent.com/8831920/43373818-b9d7ce66-93de-11e8-9e96-1a8b3020b4dd.png)


Changes proposed in this pull request:
- add /g to replace pattern

Checklist:
- [ ] docs updated
- [x] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
