### PR TITLE
#1532 Possibility to hide Haraka is at your service from HELO/EHLO for security reasons.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@
 * Fixes
 * Changes
 
-* ehlo_hello_exclude_haraka: config/ehlo_hello_exclude_haraka allows you to hide `Haraka is at your service` from EHLO/HELO msg for security reasons 
+* ehlo_hello_message: config/ehlo_hello_message can be used to overwrite the EHLO/HELO msg replacing `, Haraka is at your service` #2498
 
 
 ## 2.8.21 - Jul 20, 2018

--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@
 * Fixes
 * Changes
 
+* ehlo_hello_exclude_haraka: config/ehlo_hello_exclude_haraka allows you to hide `Haraka is at your service` from EHLO/HELO msg for security reasons 
+
 
 ## 2.8.21 - Jul 20, 2018
 

--- a/connection.js
+++ b/connection.js
@@ -100,7 +100,7 @@ class Connection {
         this.transaction = null;
         this.tran_count = 0;
         this.capabilities = null;
-        this.ehlo_hello_exclude_haraka = config.get('ehlo_hello_exclude_haraka') ? true : false;
+        this.ehlo_hello_message = config.get('ehlo_hello_message') || null;
         this.banner_includes_uuid = config.get('banner_includes_uuid') ? true : false;
         this.deny_includes_uuid = config.get('deny_includes_uuid') || null;
         this.early_talker = false;
@@ -868,7 +868,7 @@ class Connection {
             default:
                 // RFC5321 section 4.1.1.1
                 // Hostname/domain should appear after 250
-                this.respond(250, `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_exclude_haraka ? '': ', Haraka is at your service.'}`);
+                this.respond(250, `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_message ? this.ehlo_hello_message: ', Haraka is at your service.'}`);
         }
     }
     ehlo_respond (retval, msg) {
@@ -902,7 +902,7 @@ class Connection {
                 // Hostname/domain should appear after 250
 
                 const response = [
-                    `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_exclude_haraka ? '': ', Haraka is at your service.'}`,
+                    `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_message ? this.ehlo_hello_message: ', Haraka is at your service.'}`,
                     "PIPELINING",
                     "8BITMIME",
                     "SMTPUTF8",

--- a/connection.js
+++ b/connection.js
@@ -100,6 +100,7 @@ class Connection {
         this.transaction = null;
         this.tran_count = 0;
         this.capabilities = null;
+        this.ehlo_hello_exclude_haraka = config.get('ehlo_hello_exclude_haraka') ? true : false;
         this.banner_includes_uuid = config.get('banner_includes_uuid') ? true : false;
         this.deny_includes_uuid = config.get('deny_includes_uuid') || null;
         this.early_talker = false;
@@ -867,7 +868,7 @@ class Connection {
             default:
                 // RFC5321 section 4.1.1.1
                 // Hostname/domain should appear after 250
-                this.respond(250, `${this.local.host} Hello ${this.get_remote('host')}, Haraka is at your service.`);
+                this.respond(250, `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_exclude_haraka ? '': ', Haraka is at your service.'}`);
         }
     }
     ehlo_respond (retval, msg) {
@@ -901,7 +902,7 @@ class Connection {
                 // Hostname/domain should appear after 250
 
                 const response = [
-                    `${this.local.host} Hello ${this.get_remote('host')}, Haraka is at your service.`,
+                    `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_exclude_haraka ? '': ', Haraka is at your service.'}`,
                     "PIPELINING",
                     "8BITMIME",
                     "SMTPUTF8",

--- a/connection.js
+++ b/connection.js
@@ -100,7 +100,7 @@ class Connection {
         this.transaction = null;
         this.tran_count = 0;
         this.capabilities = null;
-        this.ehlo_hello_message = config.get('ehlo_hello_message') || null;
+        this.ehlo_hello_message = config.get('ehlo_hello_message') || 'Haraka is at your service.'
         this.banner_includes_uuid = config.get('banner_includes_uuid') ? true : false;
         this.deny_includes_uuid = config.get('deny_includes_uuid') || null;
         this.early_talker = false;
@@ -868,7 +868,7 @@ class Connection {
             default:
                 // RFC5321 section 4.1.1.1
                 // Hostname/domain should appear after 250
-                this.respond(250, `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_message ? this.ehlo_hello_message: ', Haraka is at your service.'}`);
+                this.respond(250, `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_message}`);
         }
     }
     ehlo_respond (retval, msg) {
@@ -902,7 +902,7 @@ class Connection {
                 // Hostname/domain should appear after 250
 
                 const response = [
-                    `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_message ? this.ehlo_hello_message: ', Haraka is at your service.'}`,
+                    `${this.local.host} Hello ${this.get_remote('host')}${this.ehlo_hello_message}`,
                     "PIPELINING",
                     "8BITMIME",
                     "SMTPUTF8",


### PR DESCRIPTION
Possibility to hide Haraka is at your service from HELO/EHLO for security reasons.
Added the option to just hide it instead of adding your own message because this might break more than it solves. 

Excluding the "Haraka is at your service" message from HELO/EHLO message is as easy as creating a file config/ehlo_hello_exclude_haraka with the value "true" which is a standard method in this file.

Fixes #

Changes proposed in this pull request:
- #1532 

Checklist:
- [na] docs updated
- [na] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated