### PR TITLE
dkim_sign: reduce log severity, improve log messages

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,7 +5,7 @@
 ### Fixes
 ### Changes
 
-* dkim_sign: improved log messages
+* dkim_sign: improved log messages #2499
 
 
 ## 2.8.21 - Jul 20, 2018

--- a/Changes.md
+++ b/Changes.md
@@ -1,9 +1,11 @@
 
 ## 2.8.22 - Mmm DD, 2018
 
-* New Features
-* Fixes
-* Changes
+### New Features
+### Fixes
+### Changes
+
+* dkim_sign: improved log messages
 
 
 ## 2.8.21 - Jul 20, 2018

--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -166,6 +166,7 @@ exports.load_key = function (file) {
 exports.hook_queue_outbound = exports.hook_pre_send_trans_email = function (next, connection) {
     const plugin = this;
     if (plugin.cfg.main.disabled) return next();
+
     if (connection.transaction.notes.dkim_signed) {
         connection.logdebug(plugin, 'email already signed');
         return next();
@@ -248,15 +249,15 @@ exports.has_key_data = function (conn, domain, selector, private_key) {
 
     // Make sure we have all the relevant configuration
     if (!private_key) {
-        conn.logerror(plugin, 'skipped: missing dkim private key');
+        conn.lognotice(plugin, 'skipped: missing dkim private key');
         return false;
     }
     if (!selector) {
-        conn.logerror(plugin, 'skipped: missing selector');
+        conn.lognotice(plugin, 'skipped: missing selector');
         return false;
     }
     if (!domain) {
-        conn.logerror(plugin, 'skipped: missing domain');
+        conn.lognotice(plugin, 'skipped: missing domain');
         return false;
     }
 
@@ -285,7 +286,10 @@ exports.get_headers_to_sign = function () {
 
 exports.get_sender_domain = function (txn) {
     const plugin = this;
-    if (!txn) return;
+    if (!txn) {
+        plugin.logerror('no transaction!')
+        return;
+    }
 
     // a fallback, when header parsing fails
     let domain;

--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -273,10 +273,10 @@ exports.has_key_data = function (conn, domain, selector, private_key) {
 
     if (missing) {
         if (domain) {
-            conn.lognotice(plugin, `skipped: missing ${missing} for ${domain}`);
+            conn.lognotice(plugin, `skipped: no ${missing} for ${domain}`);
         }
         else {
-            conn.lognotice(plugin, `skipped: missing ${missing}`);
+            conn.lognotice(plugin, `skipped: no ${missing}`);
         }
         return false;
     }

--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -247,21 +247,30 @@ exports.get_key_dir = function (connection, done) {
 exports.has_key_data = function (conn, domain, selector, private_key) {
     const plugin = this;
 
+    let missing = undefined;
+
     // Make sure we have all the relevant configuration
     if (!private_key) {
-        conn.lognotice(plugin, 'skipped: missing dkim private key');
-        return false;
+        missing = 'dkim private key';
     }
-    if (!selector) {
-        conn.lognotice(plugin, 'skipped: missing selector');
-        return false;
+    else if (!selector) {
+        missing = 'selector';
     }
-    if (!domain) {
-        conn.lognotice(plugin, 'skipped: missing domain');
+    else if (!domain) {
+        missing = 'domain';
+    }
+
+    if (missing) {
+        if (domain) {
+            conn.lognotice(plugin, `skipped: missing ${missing} for ${domain}`);
+        }
+        else {
+            conn.lognotice(plugin, `skipped: missing ${missing}`);
+        }
         return false;
     }
 
-    conn.logprotocol(plugin, `selector: ${selector}`);
+    conn.logprotocol(plugin, `using selector: ${selector} at domain ${domain}`);
     return true;
 }
 

--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -168,31 +168,42 @@ exports.hook_queue_outbound = exports.hook_pre_send_trans_email = function (next
     if (plugin.cfg.main.disabled) return next();
 
     if (connection.transaction.notes.dkim_signed) {
-        connection.logdebug(plugin, 'email already signed');
+        connection.logdebug(plugin, 'already signed');
         return next();
     }
 
-    plugin.get_key_dir(connection, function (err, keydir) {
+    let selector;
+    let private_key;
+    let domain = plugin.get_sender_domain(connection);
+
+    if (!domain) {
+        connection.transaction.results.add(plugin, {skip: "sending domain not detected", emit: true });
+
+        if (!plugin.cfg.main.domain || !plugin.private_key || !plugin.cfg.main.selector) {
+            return next();
+        }
+
+        connection.transaction.results.add(plugin, {msg: "using default key", emit: true });
+
+        domain = plugin.cfg.main.domain;
+        private_key = plugin.private_key;
+        selector = plugin.cfg.main.selector;
+    }
+
+    plugin.get_key_dir(connection, domain, function (err, keydir) {
         if (err) {
             connection.logerror(plugin, err);
             return next(DENYSOFT, "Error getting key_dir in dkim_sign");
         }
-        let domain;
-        let selector;
-        let private_key;
-        if (!keydir) {
-            domain = plugin.cfg.main.domain;
-            private_key = plugin.private_key;
-            selector = plugin.cfg.main.selector;
-        }
-        else {
+
+        if (keydir) {
             domain = path.basename(keydir);
             private_key = plugin.load_key(path.join('dkim', domain, 'private'));
             selector    = plugin.load_key(path.join('dkim', domain, 'selector')).trim();
         }
 
         if (!plugin.has_key_data(connection, domain, selector, private_key)) return next();
-        connection.logdebug(plugin, 'dkim_domain: ' + domain);
+        connection.logdebug(plugin, `domain: ${domain}`);
 
         const headers_to_sign = plugin.get_headers_to_sign();
         const txn = connection.transaction;
@@ -202,12 +213,12 @@ exports.hook_queue_outbound = exports.hook_pre_send_trans_email = function (next
                 txn.results.add(plugin, {err: err2.message});
             }
             else {
-                connection.loginfo(plugin, 'signed for ' + domain);
+                connection.loginfo(plugin, `signed for ${domain}`);
                 txn.results.add(plugin, {pass: dkim_header});
                 txn.add_header('DKIM-Signature', dkim_header);
             }
             connection.transaction.notes.dkim_signed = true;
-            return next();
+            next();
         }
 
         txn.message_stream.pipe(
@@ -216,10 +227,10 @@ exports.hook_queue_outbound = exports.hook_pre_send_trans_email = function (next
     });
 }
 
-exports.get_key_dir = function (connection, done) {
+exports.get_key_dir = function (connection, domain, done) {
     const plugin = this;
-    const domain = plugin.get_sender_domain(connection.transaction);
-    if (!domain) return done();
+
+    if (!domain) return done(new Error('missing domain'));
 
     // split the domain name into labels
     const labels     = domain.split('.');
@@ -251,7 +262,7 @@ exports.has_key_data = function (conn, domain, selector, private_key) {
 
     // Make sure we have all the relevant configuration
     if (!private_key) {
-        missing = 'dkim private key';
+        missing = 'private key';
     }
     else if (!selector) {
         missing = 'selector';
@@ -277,9 +288,7 @@ exports.has_key_data = function (conn, domain, selector, private_key) {
 exports.get_headers_to_sign = function () {
     const plugin = this;
     let headers = [];
-    if (!plugin.cfg.main.headers_to_sign) {
-        return headers;
-    }
+    if (!plugin.cfg.main.headers_to_sign) return headers;
 
     headers = plugin.cfg.main.headers_to_sign
         .toLowerCase()
@@ -293,18 +302,22 @@ exports.get_headers_to_sign = function () {
     return headers;
 }
 
-exports.get_sender_domain = function (txn) {
+exports.get_sender_domain = function (connection) {
     const plugin = this;
-    if (!txn) {
-        plugin.logerror('no transaction!')
+    if (!connection.transaction) {
+        connection.logerror(plugin, 'no transaction!')
         return;
     }
 
-    // a fallback, when header parsing fails
+    const txn = connection.transaction;
+
+    // fallback to Envelope FROM when header parsing fails
     let domain;
-    try { domain = txn.mail_from.host && txn.mail_from.host.toLowerCase(); }
-    catch (e) {
-        plugin.logerror(e);
+    if (txn.mail_from.host) {
+        try { domain = txn.mail_from.host.toLowerCase(); }
+        catch (e) {
+            connection.logerror(plugin, e);
+        }
     }
 
     if (!txn.header) return domain;


### PR DESCRIPTION
Log messages before:

````
[ERROR] [-] [dkim_sign] skipped: no dkim private key
[INFO] [BDE4364C-CB43-4A13-9E1C-EC8E4E6176A3.1] [dkim_sign] signed for simerson.net
[INFO] [CB12CF81-2224-433B-B327-68DA69F3D2C7.1] [dkim_sign] signed for tnpi.net
[INFO] [-] [dkim_sign] signed for tnpi.net
[ERROR] [-] [dkim_sign] skipped: no dkim private key
````

After:

````
[NOTICE] [-] [dkim_sign] skipped: no private key for id.apple.com
[INFO] [CEDF1642-90A0-41BB-8CE7-962CFA37E5C5.1] [dkim_sign] signed for tnpi.net
[NOTICE] [-] [dkim_sign] skipped: no private key for sapres.org
[INFO] [25916E16-8E53-44E1-A860-18C2EF84E5B5.1] [dkim_sign] signed for tnpi.net
[NOTICE] [-] [dkim_sign] skipped: no private key for e.qvcemail.com
[NOTICE] [-] [dkim_sign] skipped: no private key for hellomerch.com
[NOTICE] [-] [dkim_sign] skipped: no private key for mail.zillow.com
````

The biggest differences are that a missing `config/dkim/${domain}` dir doesn't emit an `[ERROR]` any longer, and the light refactoring permits the skip messages to include the detected sending domain, which makes it easy to see why the directory doesn't exist.

Checklist:
- [ ] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated