### PR TITLE
enable tls/ssl for rabbitmq amqplib plugin

### DIFF
--- a/docs/plugins/queue/rabbitmq_amqplib.md
+++ b/docs/plugins/queue/rabbitmq_amqplib.md
@@ -17,6 +17,8 @@ Configuration
     
         [rabbitmq]
         ; Connection
+		; Protocol. Either "amqp" or "amqps"
+		protocol = amqp
 		host = localhost
 		port = 5672
 		;Virtual Host. Start with "/". Leave blank or not use if you don't want to use virtual hosts.

--- a/plugins/queue/rabbitmq_amqplib.js
+++ b/plugins/queue/rabbitmq_amqplib.js
@@ -27,6 +27,7 @@ exports.init_amqp_connection = function () {
     const plugin = this;
     const cfg = this.config.get("rabbitmq.ini").rabbitmq;
 
+    const protocol = cfg.protocol || "amqp";
     const host = cfg.host || "127.0.0.1";
     const port = cfg.port || "5672";
     const vhost = cfg.vhost || "";
@@ -40,7 +41,7 @@ exports.init_amqp_connection = function () {
     const autoDelete = cfg.autoDelete === "true" || false;
     deliveryMode = cfg.deliveryMode || 2;
 
-    amqp.connect("amqp://"+encodeURIComponent(user)+":"+encodeURIComponent(password)+"@"+host+":"+port+vhost, function (err, conn){
+    amqp.connect(protocol+"://"+encodeURIComponent(user)+":"+encodeURIComponent(password)+"@"+host+":"+port+vhost, function (err, conn){
         if (err) {
             plugin.logerror("Connection to rabbitmq failed: " + err);
             return;


### PR DESCRIPTION
This PR adds a new config option to `rabbitmq_amqplib`, allowing the default URI Scheme of `amqp` to optionally be replaced with `amqps` in the connection string.

Changes proposed in this pull request:
- adds a new configuration option `protocol` to the `rabbitmq_amqplib` plugin

Checklist:
- [x] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
