### PR TITLE
don't send RSET to LMTP

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,9 @@
 
 ### New Features
 ### Fixes
-* connection: nove max_mime_part config load to connection init #2528
+
+* hmail: don't send RSET to LMTP #2530
+* connection: move max_mime_part config load to connection init #2528
 
 ### Changes
 

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -618,7 +618,7 @@ class HMailItem extends events.EventEmitter {
             else {
                 self.discard();
             }
-            if (cfg.pool_concurrency_max) {
+            if (cfg.pool_concurrency_max && !mx.using_lmtp) {
                 send_command('RSET');
             }
             else {
@@ -690,7 +690,7 @@ class HMailItem extends events.EventEmitter {
                     rcpt.dsn_smtp_response = response.join(' ');
                     rcpt.dsn_remote_mta = mx.exchange;
                 });
-                send_command(cfg.pool_concurrency_max ? 'RSET' : 'QUIT');
+                send_command(cfg.pool_concurrency_max && !mx.using_lmtp ? 'RSET' : 'QUIT');
                 processing_mail = false;
                 return self.temp_fail(`Upstream error: ${code}${(extc) ? `${extc} ` : ''}${reason}`);
             }
@@ -728,7 +728,7 @@ class HMailItem extends events.EventEmitter {
                         rcpt.dsn_smtp_response = response.join(' ');
                         rcpt.dsn_remote_mta = mx.exchange;
                     });
-                    send_command(cfg.pool_concurrency_max ? 'RSET' : 'QUIT');
+                    send_command(cfg.pool_concurrency_max && !mx.using_lmtp ? 'RSET' : 'QUIT');
                     processing_mail = false;
                     return self.temp_fail(`Upstream error: ${code} ${(extc) ? `${extc} ` : ''}${reason}`);
                 }
@@ -775,7 +775,7 @@ class HMailItem extends events.EventEmitter {
                         rcpt.dsn_smtp_response = response.join(' ');
                         rcpt.dsn_remote_mta = mx.exchange;
                     });
-                    send_command(cfg.pool_concurrency_max ? 'RSET' : 'QUIT');
+                    send_command(cfg.pool_concurrency_max && !mx.using_lmtp ? 'RSET' : 'QUIT');
                     processing_mail = false;
                     return self.bounce(reason, { mx: mx });
                 }


### PR DESCRIPTION
I've experienced "Error: We are already running hooks! Fatal error!" and "Shuting down" due haraka sending "RSET" to dovecot with specialy formatted email. It also causes infinity delivery if haraka is autorestarted (cluster maybe affected too).

```
[INFO] [-] [core] [outbound] acquired socket D954D55A-11AB-4AE4-A3EF-39ABC7550010 for outbound::24:127.0.0.1:undefined:50
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 220 mail.server Dovecot ready.\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] C: LHLO mail.server
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 250-mail.server\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 250-8BITMIME\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 250-ENHANCEDSTATUSCODES\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 250 PIPELINING\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] C: MAIL FROM:<root@bdd6a10d8c79>
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 250 2.1.0 OK\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] C: RCPT TO:<root@server>
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 250 2.1.5 OK\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] C: DATA
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 354 OK\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] C: .
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 250 2.0.0 <root@server> MOFlAVh73FuiHAAAaI4zhw Saved\r\n
[NOTICE] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound]  delivered file=1541175254725_1541175254725_0_4704_ppr5YZ_4_bdd6a10d8c79 domain=server host=127.0.0.1 ip=127.0.0.1 port=24 mode=LMTP tls=N auth=N response="<root@server> MOFlAVh73FuiHAAAaI4zhw Saved" delay=897.319 fails=0 rcpts=1/0/0
[DEBUG] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] running delivered hooks
[DEBUG] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] running delivered hook in stats plugin
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] C: RSET
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 502 5.5.2 Unknown command\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] C: RSET
[INFO] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] bouncing mail: 502 5.5.2 Unknown command
[DEBUG] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] running bounce hooks
[DEBUG] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] running bounce hook in stats plugin
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] S: 502 5.5.2 Unknown command\r\n
[PROTOCOL] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] C: RSET
[INFO] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] bouncing mail: 502 5.5.2 Unknown command
[DEBUG] [20991B81-A096-4459-8C12-E0302D9A4DD1.1.1] [outbound] running bounce hooks
[CRIT] [-] [core] Error: We are already running hooks! Fatal error!
[CRIT] [-] [core]     at Object.plugins.run_hooks (/usr/lib/node_modules/Haraka/plugins.js:404:15)
[CRIT] [-] [core]     at HMailItem._bounce (/usr/lib/node_modules/Haraka/outbound/hmail.js:1217:17)
[CRIT] [-] [core]     at HMailItem.bounce (/usr/lib/node_modules/Haraka/outbound/hmail.js:1206:14)
[CRIT] [-] [core]     at pluggableStream.<anonymous> (/usr/lib/node_modules/Haraka/outbound/hmail.js:780:33)
[CRIT] [-] [core]     at emitOne (events.js:116:13)
[CRIT] [-] [core]     at pluggableStream.emit (events.js:211:7)
[CRIT] [-] [core]     at pluggableStream.on_socket_data (/usr/lib/node_modules/Haraka/line_socket.js:25:20)
[CRIT] [-] [core]     at emitOne (events.js:116:13)
[CRIT] [-] [core]     at pluggableStream.emit (events.js:211:7)
[CRIT] [-] [core]     at Socket.<anonymous> (/usr/lib/node_modules/Haraka/tls_socket.js:59:18)
[NOTICE] [-] [core] Shutting down
```

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
