### PR TITLE
Add connection.remote.is_local

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@
 
 * ehlo_hello_message: config/ehlo_hello_message can be used to overwrite the EHLO/HELO msg replacing `, Haraka is at your service` #2498
 
+* connection: add connection.remote.is_local flag for detecting loopback and link local IPs
 
 ## 2.8.21 - Jul 20, 2018
 

--- a/connection.js
+++ b/connection.js
@@ -264,9 +264,12 @@ class Connection {
 
         // Set is_private, is_local automatically when remote.ip is set
         if (prop_str === 'remote.ip') {
-            this.set('remote.is_private', net_utils.is_private_ip(this.remote.ip));
-            this.set('remote.is_local', net_utils.is_local_ipv4(this.remote.ip) ||
-                net_utils.is_local_ipv6(this.remote.ip));
+            this.set('remote.is_local', net_utils.is_local_ip(this.remote.ip));
+            if (this.remote.is_local) {
+                this.set('remote.is_private', true);
+            } else {
+                this.set('remote.is_private', net_utils.is_private_ipv4(this.remote.ip));
+            }
         }
 
         // sunset 3.0.0

--- a/connection.js
+++ b/connection.js
@@ -69,6 +69,7 @@ class Connection {
             info: null,          // c.remote_info
             closed: false,       // c.remote_closed
             is_private: false,
+            is_local: false,
         };
         this.hello = {
             host: null,          // c.hello_host
@@ -261,9 +262,11 @@ class Connection {
             loc[part] = val;
         }
 
-        // Set is_private automatically when remote.ip is set
+        // Set is_private, is_local automatically when remote.ip is set
         if (prop_str === 'remote.ip') {
             this.set('remote.is_private', net_utils.is_private_ip(this.remote.ip));
+            this.set('remote.is_local', net_utils.is_local_ipv4(this.remote.ip) ||
+                net_utils.is_local_ipv6(this.remote.ip));
         }
 
         // sunset 3.0.0

--- a/docs/Connection.md
+++ b/docs/Connection.md
@@ -15,6 +15,7 @@ A unique UUID for this connection.
     * ip   - remote IP address
     * host - reverse DNS of the remote hosts IP
     * is_private - true if the remote IP is from a private (loopback, RFC 1918, link local, etc.) IP address.
+    * is_local - true if the remote IP is localhost (loopback, link local)
 
 * connection.local - info about the host that is running Haraka
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "haraka-config"         : ">=1.0.15",
     "haraka-constants"      : ">=1.0.5",
     "haraka-dsn"            : "*",
-    "haraka-net-utils"      : ">=1.0.10",
+    "haraka-net-utils"      : ">=1.1.2",
     "haraka-notes"          : "*",
     "haraka-results"        : "^2.0.0",
     "haraka-tld"            : "*",

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -38,7 +38,8 @@ exports.connectionRaw = {
             host: null,
             info: null,
             closed: false,
-            is_private: false
+            is_private: false,
+            is_local: false
         });
         // backwards compat, sunset v3.0.0
         test.equal(this.connection.remote_ip, null);
@@ -136,9 +137,10 @@ exports.connectionRaw = {
         test.equal(true, this.connection.tls.enabled);
         test.done();
     },
-    'sets remote.is_private': function (test) {
-        test.expect(1);
+    'sets remote.is_private and remote.is_local': function (test) {
+        test.expect(2);
         test.equal(false, this.connection.remote.is_private);
+        test.equal(false, this.connection.remote.is_local);
         test.done();
     },
     'has legacy proxy property set' : function (test) {
@@ -195,9 +197,36 @@ exports.connectionPrivate = {
         done();
     },
     tearDown : _tear_down,
-    'sets remote.is_private': function (test) {
-        test.expect(2);
+    'sets remote.is_private and remote.is_local': function (test) {
+        test.expect(3);
         test.equal(true, this.connection.remote.is_private);
+        test.equal(false, this.connection.remote.is_local);
+        test.equal(2525, this.connection.remote.port);
+        test.done();
+    },
+}
+
+exports.connectionLocal = {
+    setUp: function (done) {
+        const client = {
+            remotePort: 2525,
+            remoteAddress: '127.0.0.2',
+            destroy: function () { true; },
+        };
+        const server = {
+            ip_address: '127.0.0.1',
+            address: function () {
+                return this.ip_address;
+            }
+        };
+        this.connection = connection.createConnection(client, server);
+        done();
+    },
+    tearDown : _tear_down,
+    'sets remote.is_private and remote.is_local': function (test) {
+        test.expect(3);
+        test.equal(true, this.connection.remote.is_private);
+        test.equal(true, this.connection.remote.is_local);
         test.equal(2525, this.connection.remote.port);
         test.done();
     },


### PR DESCRIPTION
Changes proposed in this pull request:
- add  connection.remote.is_local flag for detecting loopback and link_local addresses

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
