### PR TITLE
add clamd check options for skipping

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,8 @@
 
 ### Changes
 
+* clamd: add check.authenticated, check.private_ip, check.local_ip option 
+
 * dkim_sign: improved log messages #2499
 
 * ehlo_hello_message: config/ehlo_hello_message can be used to overwrite the EHLO/HELO msg replacing `, Haraka is at your service` #2498

--- a/docs/plugins/clamd.md
+++ b/docs/plugins/clamd.md
@@ -89,6 +89,29 @@ The following options are enabled by default in clamd but ClamAV suggests
 using them only for scoring.
 
     * Phishing=false
+    
+## [check]
+
+The optional check section can allow skipping ClamAV check for remote connection
+meeting following criteria.
+
+- authenticated
+
+    Default: true
+
+    If true, messages from authenticated users will be scanned.
+
+- private\_ip
+
+    Default: true
+
+    If true, messages from private IPs will be scanned.
+
+- local\_ip
+
+    Default: true
+
+    If true, messages from localhost will be scanned.
 
 ## clamd.excludes
 
@@ -116,4 +139,3 @@ using them only for scoring.
 # Phishing
 Heuristics.Phishing.*
 `````
-

--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -172,10 +172,7 @@ exports.hook_data_post = function (next, connection) {
     const txn = connection.transaction;
     const cfg = plugin.cfg;
 
-    if (!plugin.should_check(connection)) {
-        txn.results.add(plugin, {skip: 'criteria match'});
-        return next();
-    }
+    if (!plugin.should_check(connection)) return next();
 
     // Do we need to run?
     if (cfg.main.only_with_attachments && !txn.notes.clamd_found_attachment) {

--- a/tests/plugins/clamd.js
+++ b/tests/plugins/clamd.js
@@ -96,6 +96,36 @@ exports.hook_data_post = {
         }.bind(this);
         this.plugin.hook_data_post(next, this.connection);
     },
+    'skip authenticated': function (test) {
+        this.connection.notes.auth_user = 'user';
+        this.plugin.cfg.check.authenticated = false;
+        test.expect(1);
+        const next = function () {
+            test.ok(this.connection.transaction.results.get('clamd').skip);
+            test.done();
+        }.bind(this);
+        this.plugin.hook_data_post(next, this.connection);
+    },
+    'skip private IP': function (test) {
+        this.connection.remote.is_private = true;
+        this.plugin.cfg.check.private_ip = false;
+        test.expect(1);
+        const next = function () {
+            test.ok(this.connection.transaction.results.get('clamd').skip);
+            test.done();
+        }.bind(this);
+        this.plugin.hook_data_post(next, this.connection);
+    },
+    'skip local IP': function (test) {
+        this.connection.remote.is_local = true;
+        this.plugin.cfg.check.local_ip = false;
+        test.expect(1);
+        const next = function () {
+            test.ok(this.connection.transaction.results.get('clamd').skip);
+            test.done();
+        }.bind(this);
+        this.plugin.hook_data_post(next, this.connection);
+    },
     'message too big': function (test) {
         this.connection.transaction.data_bytes=513;
         this.plugin.cfg.main.max_size=512;

--- a/tests/plugins/clamd.js
+++ b/tests/plugins/clamd.js
@@ -91,7 +91,7 @@ exports.hook_data_post = {
         this.plugin.cfg.main.only_with_attachments=true;
         test.expect(1);
         const next = function () {
-            test.ok(this.connection.transaction.results.get('clamd').skip);
+            test.ok(this.connection.transaction.results.get('clamd').skip.length > 0);
             test.done();
         }.bind(this);
         this.plugin.hook_data_post(next, this.connection);
@@ -101,27 +101,87 @@ exports.hook_data_post = {
         this.plugin.cfg.check.authenticated = false;
         test.expect(1);
         const next = function () {
-            test.ok(this.connection.transaction.results.get('clamd').skip);
+            test.ok(this.connection.transaction.results.get('clamd').skip.length > 0);
             test.done();
         }.bind(this);
         this.plugin.hook_data_post(next, this.connection);
     },
-    'skip private IP': function (test) {
-        this.connection.remote.is_private = true;
-        this.plugin.cfg.check.private_ip = false;
+    'checks local IP': function (test) {
+        this.connection.remote.is_local = true;
+        this.plugin.cfg.check.local_ip = true;
+
         test.expect(1);
         const next = function () {
-            test.ok(this.connection.transaction.results.get('clamd').skip);
+            test.ok(this.connection.transaction.results.get('clamd').skip.length === 0);
             test.done();
         }.bind(this);
         this.plugin.hook_data_post(next, this.connection);
     },
-    'skip local IP': function (test) {
+    'skips local IP': function (test) {
         this.connection.remote.is_local = true;
         this.plugin.cfg.check.local_ip = false;
+
         test.expect(1);
         const next = function () {
-            test.ok(this.connection.transaction.results.get('clamd').skip);
+            test.ok(this.connection.transaction.results.get('clamd').skip.length > 0);
+            test.done();
+        }.bind(this);
+        this.plugin.hook_data_post(next, this.connection);
+    },
+    'checks private IP': function (test) {
+        this.connection.remote.is_private = true;
+        this.plugin.cfg.check.private_ip = true;
+
+        test.expect(1);
+        const next = function () {
+            test.ok(this.connection.transaction.results.get('clamd').skip.length === 0);
+            test.done();
+        }.bind(this);
+        this.plugin.hook_data_post(next, this.connection);
+    },
+    'skips private IP': function (test) {
+        this.connection.remote.is_private = true;
+        this.plugin.cfg.check.private_ip = false;
+
+        test.expect(1);
+        const next = function () {
+            test.ok(this.connection.transaction.results.get('clamd').skip.length > 0);
+            test.done();
+        }.bind(this);
+        this.plugin.hook_data_post(next, this.connection);
+    },
+    'checks public ip': function (test) {
+        test.expect(1);
+        const next = function () {
+            test.ok(this.connection.transaction.results.get('clamd').skip.length === 0);
+            test.done();
+        }.bind(this);
+        this.plugin.hook_data_post(next, this.connection);
+    },
+    'skip localhost if check.local_ip = false and check.private_ip = true': function (test) {
+        this.connection.remote.is_local = true;
+        this.connection.remote.is_private = true;
+
+        this.plugin.cfg.check.local_ip = false;
+        this.plugin.cfg.check.private_ip = true;
+
+        test.expect(1);
+        const next = function () {
+            test.ok(this.connection.transaction.results.get('clamd').skip.length > 0);
+            test.done();
+        }.bind(this);
+        this.plugin.hook_data_post(next, this.connection);
+    },
+    'checks localhost if check.local_ip = true and check.private_ip = false': function (test) {
+        this.connection.remote.is_local = true;
+        this.connection.remote.is_private = true;
+
+        this.plugin.cfg.check.local_ip = true;
+        this.plugin.cfg.check.private_ip = false;
+
+        test.expect(1);
+        const next = function () {
+            test.ok(this.connection.transaction.results.get('clamd').skip.length === 0);
             test.done();
         }.bind(this);
         this.plugin.hook_data_post(next, this.connection);
@@ -131,7 +191,7 @@ exports.hook_data_post = {
         this.plugin.cfg.main.max_size=512;
         test.expect(1);
         const next = function () {
-            test.ok(this.connection.transaction.results.get('clamd').skip);
+            test.ok(this.connection.transaction.results.get('clamd').skip.length > 0);
             test.done();
         }.bind(this);
         this.plugin.hook_data_post(next, this.connection);


### PR DESCRIPTION
Changes proposed in this pull request:
- added check.authenticated, check.private_ip, check.local_ip for ability to skip some connections (same as rspamd plugin)
- depends on https://github.com/haraka/Haraka/pull/2532

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
