### PR TITLE
use get_decoded on headers that may be encoded

### DIFF
--- a/plugins/data.headers.js
+++ b/plugins/data.headers.js
@@ -278,7 +278,7 @@ exports.from_match = function (next, connection) {
         return next();
     }
 
-    const hdr_from = connection.transaction.header.get('From');
+    const hdr_from = connection.transaction.header.get_decoded('From');
     if (!hdr_from) {
         connection.transaction.results.add(plugin, {fail: 'from_match(missing)'});
         return next();

--- a/plugins/data.uribl.js
+++ b/plugins/data.uribl.js
@@ -320,7 +320,7 @@ exports.hook_data_post = function (next, connection) {
 
     // From header
     const do_from_header = function (cb) {
-        const from = trans.header.get('from');
+        const from = trans.header.get_decoded('from');
         const fmatch = email_re.exec(from);
         if (fmatch) {
             return plugin.do_lookups(connection, cb, fmatch[1], 'from');

--- a/plugins/messagesniffer.js
+++ b/plugins/messagesniffer.js
@@ -107,7 +107,7 @@ exports.hook_data_post = function (next, connection) {
 
     const tag_subject = function () {
         const tag = cfg.main.tag_string || '[SPAM]';
-        const subj = txn.header.get('Subject');
+        const subj = txn.header.get_decoded('Subject');
         // Try and prevent any double subject modifications
         const subject_re = new RegExp('^' + tag);
         if (!subject_re.test(subj)) {

--- a/tests/mailheader.js
+++ b/tests/mailheader.js
@@ -8,6 +8,8 @@ const lines = [
     '       (version=TLSv1/SSLv3 cipher=OTHER);',
     '       Thu, 31 Mar 2016 12:51:37 -0700 (PDT)',
     'From: Matt Sergeant <helpme@gmail.com>',
+    `FromUTF8: =?UTF-8?B?S29obOKAmXM=?=
+ <Kohls@s.kohls.com>`,
     'Content-Type: multipart/alternative;',
     '   boundary=Apple-Mail-F2C5DAD3-7EB3-409D-9FE0-135C9FD43B69',
     'Content-Type2: multipart/mixed; boundary="nqp=nb64=()I9WT8XjoN"',
@@ -26,21 +28,22 @@ for (let i=0; i<lines.length; i++) {
 
 exports.basic = {
     parse_basic: function (test) {
-        test.expect(2);
+        test.expect(3);
         const h = new Header();
         h.parse(lines);
-        test.equal(h.lines().length, 12);
+        test.equal(h.lines().length, 13);
         test.equal(
             h.get_decoded('content-type'),
             'multipart/alternative;   boundary=Apple-Mail-F2C5DAD3-7EB3-409D-9FE0-135C9FD43B69'
         );
+        test.equal(h.get_decoded('fromUTF8'), 'Kohl’s <Kohls@s.kohls.com>');
         test.done();
     },
     'content type w/parens': function (test) {
         test.expect(2);
         const h = new Header();
         h.parse(lines);
-        test.equal(h.lines().length, 12);
+        test.equal(h.lines().length, 13);
         const ct = h.get_decoded('content-type2');
         test.equal(ct, 'multipart/mixed; boundary="nqp=nb64=()I9WT8XjoN"');
         test.done();
@@ -55,7 +58,7 @@ exports.add_headers = {
         h.add('Foo', 'bar');
         test.equal(h.lines()[0], 'Foo: bar\n');
         h.add_end('Fizz', 'buzz');
-        test.equal(h.lines()[13], 'Fizz: buzz\n');
+        test.equal(h.lines()[14], 'Fizz: buzz\n');
         test.done();
     },
     add_utf8: function (test) {


### PR DESCRIPTION
Fixes this graceless error:

````
Nov 13 15:26:39 haraka haraka: [CRIT] [742245BE-0DAA-40A9-A556-BF93BC9B2C8F.1] [core] Plugin access failed: Error: No results     
at Object.parse (/root/Haraka/node_modules/address-rfc2822/index.js:20:22)     
at Plugin.exports.data_any (/root/Haraka/node_modules/haraka-plugin-access/index.js:401:28)     
at Object.plugins.run_next_hook (/root/Haraka/plugins.js:508:28)     
at Object.plugins.run_hooks (/root/Haraka/plugins.js:422:13)     
at MessageStream.end_callback (/root/Haraka/connection.js:1650:21)     
at MessageStream._write (/root/Haraka/messagestream.js:137:41)     
at ChunkEmitter.<anonymous> (/root/Haraka/messagestream.js:63:22)     
at emitOne (events.js:116:13)     at ChunkEmitter.emit (events.js:211:7)     
at ChunkEmitter.end (/root/Haraka/chunkemitter.js:58:18
````

Which happens when a From header has contents that look like this:

````
From: =?UTF-8?B?QmVkIEJhdGggJiBCZXlvbmQ=?= 
    <BedBath&Beyond@emailbedbathandbeyond.com>
````
