### PR TITLE
Implement SIGTERM graceful shutdown if pid is 1

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 
 ## 2.8.23 - Mmm DD, 201Y
 ### Changes
+* Implement SIGTERM graceful shutdown if pid is 1 #2547
 ### New Features
 ### Fixes
 

--- a/haraka.js
+++ b/haraka.js
@@ -38,7 +38,13 @@ process.on('uncaughtException', err => {
 });
 
 let shutting_down = false;
-['SIGINT'].forEach((sig) => {
+const signals = ['SIGINT'];
+
+if (process.pid === 1) {
+    signals.push('SIGTERM')
+}
+
+signals.forEach((sig) => {
     process.on(sig, () => {
         if (shutting_down) return process.exit(1);
         shutting_down = true;


### PR DESCRIPTION
Related: https://blog.ghaiklor.com/avoid-running-nodejs-as-pid-1-under-docker-images-when-running-them-on-mesosphere-kubernetes-or-b7bd505657f9

Like in the blog described node has some signal issues if it runs as pid 1 (usually inside a container).
Currently on docker stop docker sends SIGTERM to node which will be ignored because not handled somewhere.

Haraka on docker or even on kubernetes has to be killed unless you use workarounds like `tini`. I would prefer that haraka initiate a graceful shutdown on docker stop.

Changes proposed in this pull request:
- Implement SIGTERM graceful shutdown if pid is 1

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
