### PR TITLE
skip early_talker test if sender has already good karma

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@
 ## 2.8.23 - Mmm DD, 201Y
 ### Changes
 * Implement SIGTERM graceful shutdown if pid is 1 #2547
+* early_talker: skip if sender has good karma
 ### New Features
 ### Fixes
 

--- a/config/plugins
+++ b/config/plugins
@@ -13,6 +13,7 @@
 
 # CONNECT
 #toobusy
+#karma
 #relay
 # control which IPs, rDNS hostnames, HELO hostnames, MAIL FROM addresses, and
 # RCPT TO address you accept mail from. See 'haraka -h access'.
@@ -59,7 +60,6 @@ data.headers
 #clamd
 #spamassassin
 #dkim_sign
-#karma
 #limit
 
 # QUEUE

--- a/plugins/early_talker.js
+++ b/plugins/early_talker.js
@@ -53,6 +53,13 @@ exports.early_talker = function (next, connection) {
         return next();
     }
 
+    // Don't delay historically good senders
+    const karma = connection.results.get('karma');
+    if (karma && karma.good > 0) {
+        connection.results.add(plugin, { skip: 'good karma' });
+        return next();
+    }
+
     const check = function () {
         if (!connection) return next();
         if (!connection.early_talker) {

--- a/tests/plugins/early_talker.js
+++ b/tests/plugins/early_talker.js
@@ -92,6 +92,19 @@ exports.early_talker = {
         this.connection.early_talker = true;
         this.plugin.early_talker(next, this.connection);
     },
+    'relay good senders': function (test) {
+        test.expect(3);
+        const next = function (rc, msg) {
+            test.equal(undefined, rc);
+            test.equal(undefined, msg);
+            test.ok(this.connection.results.has('early_talker', 'skip', 'good karma'));
+            test.done();
+        }.bind(this);
+        this.plugin.pause = 1000;
+        this.connection.results.add('karma', {good: 10});
+        this.connection.early_talker = true;
+        this.plugin.early_talker(next, this.connection);
+    },
     'test loading ip list': function (test) {
         const whitelist = this.plugin.load_ip_list(['123.123.123.123', '127.0.0.0/16']);
         test.expect(2);


### PR DESCRIPTION
Changes proposed in this pull request:
- move karma plugin to the top of config to be able to read results of karma at early talker plugin
- added code to skip connections with results karma.good > 0

Checklist:
- [ ] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
