### PR TITLE
support requiring verified TLS certs on specific ports

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,13 +12,17 @@
 
 * Implement SIGTERM graceful shutdown if pid is 1 #2547
 
+### New Features
+
+* tls: require validated certs on some ports with requireAuthorized
+
 ### Fixes
 
 * mf.resolvable: reduce timeout by one second (so < plugin.timeout) #2544
 * invalid DKIM when empty body #2410
 
-## 2.8.23 - Nov 18, 2018
 
+## 2.8.23 - Nov 18, 2018
 
 ### Changes
 

--- a/config/tls.ini
+++ b/config/tls.ini
@@ -15,6 +15,12 @@
 ; requestCert=true
 ; requestOCSP=false
 
+; rejectUnauthorized above requires verified TLS certs on EVERY TLS connection. When
+; rejectUnauthorized=false (default), you can require verified TLS certs on only the
+; ports you specify.
+; requireAuthorized[]=465
+; requireAuthorized[]=587
+
 
 [redis]
 ; options in this block require redis to be enabled in config/plugins.

--- a/docs/plugins/tls.md
+++ b/docs/plugins/tls.md
@@ -8,16 +8,19 @@ For this plugin to work you must have SSL certificates installed correctly.
 
 Defaults are shown and can be overridden in `config/tls.ini`.
 
-    key=tls_key.pem
-    cert=tls_cert.pem
-    dhparam=dhparams.pem
-
+```ini
+key=tls_key.pem
+cert=tls_cert.pem
+dhparam=dhparams.pem
+```
 
 ## Certificate Directory
 
 If the directory `config/tls` exists, each file within the directory is expected to be a PEM encoded TLS bundle. Generate the PEM bundles in The Usual Way[TM] by concatenating the key, certificate, and CA/chain certs in that order. Example:
 
-    cat example.com.key example.com.crt ca.crt > config/tls/example.com.pem
+```sh
+cat example.com.key example.com.crt ca.crt > config/tls/example.com.pem
+```
 
 An example [acme.sh](https://acme.sh) deployment [script](https://github.com/msimerson/Mail-Toaster-6/blob/master/provision-letsencrypt.sh) demonstrates how to install [Let's Encrypt](https://letsencrypt.org) certificates to the Haraka `config/tls`directory.
 
@@ -57,16 +60,20 @@ Specifies an alternative location for the key file. For multiple keys, use `key[
 To configure a single key and a cert chain, located in the `config/`
 directory, use the following in `tls.ini`:
 
-    key=example.com.key.pem
-    cert=example.com.crt-chain.pem
+```ini
+key=example.com.key.pem
+cert=example.com.crt-chain.pem
+```
 
 To use multiple pairs of key and cert chain files outside of the haraka
 `config/` directory, configure instead:
 
-    key[]=/etc/ssl/private/example.com.rsa.key.pem
-    cert[]=/etc/ssl/private/example.com.rsa.crt-chain.pem
-    key[]=/etc/ssl/private/example.com.ecdsa.key.pem
-    cert[]=/etc/ssl/private/example.com.ecdsa.crt-chain.pem
+```ini
+key[]=/etc/ssl/private/example.com.rsa.key.pem
+cert[]=/etc/ssl/private/example.com.rsa.crt-chain.pem
+key[]=/etc/ssl/private/example.com.ecdsa.key.pem
+cert[]=/etc/ssl/private/example.com.ecdsa.crt-chain.pem
+```
 
 ### cert
 
@@ -76,10 +83,11 @@ Specifies the location(s) for the certificate chain file. For multiple certifica
 
 If needed, add this section to the `config/tls.ini` file and list any IP ranges that have broken TLS hosts. Ex:
 
-    [no_tls_hosts]
-    192.168.1.3
-    172.16.0.0/16
-
+```ini
+[no_tls_hosts]
+192.168.1.3
+172.16.0.0/16
+```
 
 The [Node.js TLS](http://nodejs.org/api/tls.html) page has additional information about the following options.
 
@@ -116,6 +124,16 @@ Whether Haraka should request a certificate from a connecting client.
 Reject connections from clients without a CA validated TLS certificate.
 
     rejectUnauthorized=[true|false]  (default: false)
+
+
+### requireAuthorized
+
+When `rejectUnauthorized=false`, require validated TLS certificates on just the specified ports.
+
+```ini
+requireAuthorized[]=465
+;requireAuthorized[]=587
+```
 
 
 ### secureProtocol

--- a/plugins/queue/discard.js
+++ b/plugins/queue/discard.js
@@ -1,7 +1,7 @@
 // discard
 
 exports.register = function () {
-    this.register_hook('queue', 'discard');
+    this.register_hook('queue',          'discard');
     this.register_hook('queue_outbound', 'discard');
 }
 
@@ -24,5 +24,5 @@ exports.discard = function (next, connection) {
     if (process.env.YES_REALLY_DO_DISCARD) return discard();
 
     // Allow other queue plugins to deliver
-    return next();
+    next();
 }

--- a/server.js
+++ b/server.js
@@ -324,7 +324,7 @@ Server.createServer = function (params) {
 Server.load_default_tls_config = function (done) {
     // this fn exists solely for testing
     if (Server.config.root_path != tls_socket.config.root_path) {
-        logger.loginfo('resetting tls_config.config path');
+        logger.loginfo(`resetting tls_config.config path to ${Server.config.root_path}`);
         tls_socket.config = tls_socket.config.module_config(path.dirname(Server.config.root_path));
     }
     tls_socket.getSocketOpts('*', (opts) => {
@@ -352,7 +352,10 @@ Server.get_smtp_server = function (host, port, inactivity_timeout, done) {
     if (port === Server.cfg.main.smtps_port) {
         logger.loginfo('getting SocketOpts for SMTPS server');
         tls_socket.getSocketOpts('*', opts => {
-            logger.loginfo(`Creating TLS server on ${host}:${Server.cfg.main.smtps_port}`);
+            logger.loginfo(`Creating TLS server on ${host}:${port}`);
+
+            opts.rejectUnauthorized = tls_socket.get_rejectUnauthorized(opts.rejectUnauthorized, port, tls_socket.cfg.main.requireAuthorized)
+
             server = tls.createServer(opts, onConnect);
             tls_socket.addOCSP(server);
             server.has_tls=true;

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -372,8 +372,7 @@ exports.onCapabilitiesOutbound = function (smtp_client, secured, connection, con
                 serverBanned = net_utils.ip_in_list(smtp_client.tls_config.no_tls_hosts, smtp_client.remote_ip);
             }
 
-            if (!hostBanned && !serverBanned && config.enable_tls)
-            {
+            if (!hostBanned && !serverBanned && config.enable_tls) {
                 smtp_client.socket.on('secure', on_secured);
                 smtp_client.secured = false;  // have to wait in forward plugin before we can do auth, even if capabilities are there on first EHLO
                 smtp_client.send_command('STARTTLS');
@@ -464,7 +463,7 @@ exports.get_client_plugin = function (plugin, connection, c, callback) {
                 return;
             }
 
-            if (c.auth.type === null || typeof (c.auth.type) === 'undefined') { return; } // Ignore blank
+            if (c.auth.type === null || typeof (c.auth.type) === 'undefined') return; // Ignore blank
             const auth_type = c.auth.type.toLowerCase();
             if (smtp_client.auth_capabilities.indexOf(auth_type) === -1) {
                 throw new Error(`Auth type "${auth_type}" not supported by server (supports: ${smtp_client.auth_capabilities.join(',')})`);

--- a/tests/config/tls.ini
+++ b/tests/config/tls.ini
@@ -7,6 +7,8 @@ ciphers = ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256
 rejectUnauthorized=false
 requestCert=true
 honorCipherOrder=true
+requireAuthorized[]=2465
+requireAuthorized[]=2587
 
 
 [redis]

--- a/tests/server.js
+++ b/tests/server.js
@@ -445,7 +445,7 @@ exports.requireAuthorized_SMTPS = {
                         test.equal(error.message, 'socket hang up')
                     }
                     else {     // node 10+
-                        test.equal(error.message, 'Client network socket disconnected before secure TLS connection was established';
+                        test.equal(error.message, 'Client network socket disconnected before secure TLS connection was established');
                     }
                 }
                 test.done();

--- a/tests/server.js
+++ b/tests/server.js
@@ -150,25 +150,28 @@ exports.get_http_docroot = {
     },
 }
 
-function _setupServer (done) {
+function _setupServer (test, ip_port, done) {
     process.env.YES_REALLY_DO_DISCARD=1;   // for queue/discard plugin
     process.env.HARAKA_TEST_DIR=path.resolve('tests');
 
-    // this sets the default path for plugin instances to the test dir
+    // test sets the default path for plugin instances to the test dir
     const test_cfg_path=path.resolve('tests');
 
-    this.server = require('../server');
-    this.config = require('haraka-config').module_config(test_cfg_path);
-    this.server.logger.loglevel = 6;  // INFO
+    test.server = require('../server');
+    test.config = require('haraka-config').module_config(test_cfg_path);
+    test.server.logger.loglevel = 6;  // INFO
 
     // set the default path for the plugin loader
-    this.server.config = this.config.module_config(test_cfg_path);
-    this.server.plugins.config = this.config.module_config(test_cfg_path);
-    // this.server.outbound.config = this.config.module_config(test_cfg_path);
+    test.server.config = test.config.module_config(test_cfg_path);
+    test.server.plugins.config = test.config.module_config(test_cfg_path);
+    // test.server.outbound.config = test.config.module_config(test_cfg_path);
 
-    this.server.load_smtp_ini();
-    this.server.load_default_tls_config(() => {
-        this.server.createServer({});
+    test.server.load_smtp_ini();
+    test.server.cfg.main.listen = ip_port;
+    test.server.cfg.main.smtps_port = 2465;
+    // console.log(test.server.cfg);
+    test.server.load_default_tls_config(() => {
+        test.server.createServer({});
         done();
     })
 }
@@ -184,7 +187,9 @@ function _tearDownServer (done) {
 }
 
 exports.smtp_client = {
-    setUp : _setupServer,
+    setUp : function (done) {
+        _setupServer(this, 'localhost:2500', done);
+    },
     tearDown: _tearDownServer,
     'accepts SMTP message': function (test) {
 
@@ -244,7 +249,9 @@ exports.smtp_client = {
 }
 
 exports.nodemailer = {
-    setUp : _setupServer,
+    setUp : function (done) {
+        _setupServer(this, 'localhost:2503', done);
+    },
     tearDown: _tearDownServer,
     'accepts SMTP message': function (test) {
 
@@ -252,7 +259,7 @@ exports.nodemailer = {
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
             host: 'localhost',
-            port: 2500,
+            port: 2503,
             tls: {
                 // do not fail on invalid certs
                 rejectUnauthorized: false
@@ -286,7 +293,7 @@ exports.nodemailer = {
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
             host: 'localhost',
-            port: 2500,
+            port: 2503,
             auth: {
                 user: 'matt',
                 pass: 'goodPass'
@@ -325,7 +332,7 @@ exports.nodemailer = {
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
             host: 'localhost',
-            port: 2500,
+            port: 2503,
             auth: {
                 user: 'matt',
                 pass: 'badPass'
@@ -363,7 +370,7 @@ exports.nodemailer = {
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
             host: 'localhost',
-            port: 2500,
+            port: 2503,
             tls: {
                 // do not fail on invalid certs
                 rejectUnauthorized: false
@@ -396,5 +403,89 @@ exports.nodemailer = {
             console.log('Message sent: ' + info.response);
             test.done();
         });
+    },
+}
+
+exports.requireAuthorized_SMTPS = {
+    setUp : function (done) {
+        _setupServer(this, 'localhost:2465', done);
+    },
+    tearDown: _tearDownServer,
+    'rejects non-validated SMTPS connection': function (test) {
+
+        test.expect(1);
+        const nodemailer = require('nodemailer');
+        const transporter = nodemailer.createTransport({
+            host: 'localhost',
+            port: 2465,
+            secure: true,
+            tls: {
+                // do not fail on invalid certs
+                rejectUnauthorized: false
+            }
+        });
+
+        // give the SMTPS listener a second to start listening
+        setTimeout(function () {
+            transporter.sendMail({
+                from: '"Testalicious Matt" <harakamail@gmail.com>',
+                to:   'nobody-will-see-this@haraka.local',
+                envelope: {
+                    from: 'Haraka Test <test@haraka.local>',
+                    to:   'Discard Queue <discard@haraka.local>',
+                },
+                subject: 'Hello ✔',
+                text: 'Hello world ?',
+                html: '<b>Hello world ?</b>',
+            },
+            function (error, info) {
+                if (error) {
+                    // console.log(error);
+                    test.equal(error.message, ['socket hang up'])
+                }
+                test.done();
+            });
+        }, 500);
+    },
+}
+
+exports.requireAuthorized_STARTTLS = {
+    setUp : function (done) {
+        _setupServer(this, 'localhost:2587', done);
+    },
+    'rejects non-validated STARTTLS connection': function (test) {
+
+        test.expect(1);
+        const nodemailer = require('nodemailer');
+        const transporter = nodemailer.createTransport({
+            host: 'localhost',
+            port: 2587,
+            tls: {
+                // do not fail on invalid certs
+                rejectUnauthorized: false
+            }
+        });
+
+        // give the SMTPS listener a second to start listening
+        setTimeout(function () {
+            transporter.sendMail({
+                from: '"Testalicious Matt" <harakamail@gmail.com>',
+                to:   'nobody-will-see-this@haraka.local',
+                envelope: {
+                    from: 'Haraka Test <test@haraka.local>',
+                    to:   'Discard Queue <discard@haraka.local>',
+                },
+                subject: 'Hello ✔',
+                text: 'Hello world ?',
+                html: '<b>Hello world ?</b>',
+            },
+            function (error, info) {
+                if (error) {
+                    // console.log(error);
+                    test.equal(error.message, ['Unexpected socket close'])
+                }
+                test.done();
+            });
+        }, 500);
     },
 }

--- a/tests/server.js
+++ b/tests/server.js
@@ -441,7 +441,12 @@ exports.requireAuthorized_SMTPS = {
             function (error, info) {
                 if (error) {
                     // console.log(error);
-                    test.equal(error.message, ['socket hang up'])
+                    if (error.message === 'socket hang up') {   // node 6 & 8
+                        test.equal(error.message, 'socket hang up')
+                    }
+                    else {     // node 10+
+                        test.equal(error.message, 'Client network socket disconnected before secure TLS connection was established';
+                    }
                 }
                 test.done();
             });

--- a/tests/tls_socket.js
+++ b/tests/tls_socket.js
@@ -127,6 +127,7 @@ exports.load_tls_ini = {
                     honorCipherOrder: true,
                     requestOCSP: false,
                     // enableOCSPStapling: false,
+                    requireAuthorized: [],
                 },
                 redis: { disable_for_failed_hosts: false },
                 no_tls_hosts: {}
@@ -147,6 +148,7 @@ exports.load_tls_ini = {
                 cert: 'tls_cert.pem',
                 dhparam: 'dhparams.pem',
                 ciphers: 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384',
+                requireAuthorized: [2465],
             },
             redis: { disable_for_failed_hosts: false },
             no_tls_hosts: {},

--- a/tests/tls_socket.js
+++ b/tests/tls_socket.js
@@ -114,8 +114,12 @@ exports.ensureDhparams = {
     },
 }
 
-exports.load_tls_ini = {
-    setUp : _setup,
+exports.load_tls_ini2 = {
+    setUp : function (done) {
+        this.socket = require('../tls_socket');
+        delete process.env.HARAKA_TEST_DIR;
+        done();
+    },
     'loads missing tls.ini default config': function (test) {
         test.expect(1);
         this.socket.config = this.socket.config.module_config(path.resolve('non-exist'));
@@ -137,7 +141,6 @@ exports.load_tls_ini = {
     'loads tls.ini from test dir': function (test) {
         test.expect(1);
         this.socket.config = this.socket.config.module_config(path.resolve('tests'));
-        // console.log(this.socket);
         test.deepEqual(this.socket.load_tls_ini(), {
             main: {
                 requestCert: true,
@@ -148,7 +151,7 @@ exports.load_tls_ini = {
                 cert: 'tls_cert.pem',
                 dhparam: 'dhparams.pem',
                 ciphers: 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384',
-                requireAuthorized: [2465],
+                requireAuthorized: [2465, 2587],
             },
             redis: { disable_for_failed_hosts: false },
             no_tls_hosts: {},

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -214,7 +214,7 @@ exports.parse_x509 = string => {
 exports.load_tls_ini = (opts) => {
     const tlss = this;
 
-    log.loginfo('loading tls.ini');
+    log.loginfo(`loading tls.ini`); // from ${this.config.root_path}`);
 
     const cfg = exports.config.get('tls.ini', {
         booleans: [
@@ -253,6 +253,13 @@ exports.load_tls_ini = (opts) => {
         catch (ignore) {
             log.lognotice("OCSP Stapling not available.");
         }
+    }
+
+    if (cfg.main.requireAuthorized === undefined) {
+        cfg.main.requireAuthorized = [];
+    }
+    else if (!Array.isArray(cfg.main.requireAuthorized)) {
+        cfg.main.requireAuthorized = [cfg.main.requireAuthorized];
     }
 
     tlss.cfg = cfg;
@@ -596,6 +603,20 @@ function cleanOcspCache () {
 exports.certsByHost = certsByHost;
 exports.ocsp = ocsp;
 
+exports.get_rejectUnauthorized = function (rejectUnauthorized, port, port_list) {
+    // console.log(`rejectUnauthorized: ${rejectUnauthorized}, port ${port}, list: ${port_list}`)
+    if (rejectUnauthorized) {
+        // console.log('true for all ports');
+        return true;
+    }
+    if (port_list.includes(port)) {
+        // console.log('port matched true');
+        return true;
+    }
+    // console.log('returning default false');
+    return false;
+}
+
 function createServer (cb) {
     const server = net.createServer(cryptoSocket => {
 
@@ -612,6 +633,8 @@ function createServer (cb) {
 
             const options = Object.assign({}, certsByHost['*']);
             options.server = server;  // TLSSocket needs server for SNI to work
+
+            options.rejectUnauthorized = exports.get_rejectUnauthorized(options.rejectUnauthorized, cryptoSocket.localPort, exports.cfg.main.requireAuthorized);
 
             const cleartext = new tls.TLSSocket(cryptoSocket, options);
 


### PR DESCRIPTION
Fixes #2543 

This is largely the same as #2543 except:

- includes tests (which surfaced a couple issues)
- config setting named `requireAuthorized` instead of `authorizationRequired`
- no boolean option (simpler, easier to document)
- has support for SMTPS server (was only for STARTTLS)
- more GFM formatting in tls.ini

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
