### PR TITLE
release client when successfully finished delivery

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 * mf.resolvable: reduce timeout by one second (so < plugin.timeout) #2544
+* LMTP blocks under stress #2556
 
 ## 2.8.23 - Nov 18, 2018
 

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -618,10 +618,12 @@ class HMailItem extends events.EventEmitter {
             else {
                 self.discard();
             }
-            if (cfg.pool_concurrency_max && !mx.using_lmtp) {
+
+            if (cfg.pool_concurrency_max && success) {
+                client_pool.release_client(socket, port, host, mx.bind, fin_sent);
+            } else if (cfg.pool_concurrency_max && !mx.using_lmtp) {
                 send_command('RSET');
-            }
-            else {
+            } else {
                 send_command('QUIT');
             }
         }

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -621,9 +621,11 @@ class HMailItem extends events.EventEmitter {
 
             if (cfg.pool_concurrency_max && success) {
                 client_pool.release_client(socket, port, host, mx.bind, fin_sent);
-            } else if (cfg.pool_concurrency_max && !mx.using_lmtp) {
+            }
+            else if (cfg.pool_concurrency_max && !mx.using_lmtp) {
                 send_command('RSET');
-            } else {
+            }
+            else {
                 send_command('QUIT');
             }
         }


### PR DESCRIPTION
Fixes #2556

There is question with this PR: do we need to send RSET after finished email? Most servers I've tested have no problem with that, RFC is clear about using it, LMTP doesn't have rset at all. But still there is maybe corner case which I don't know.

Changes proposed in this pull request:
- RSET is not sent when SMTP|LMTP delivery is finished with success and we release client immediately
- if delivery ends without success then we send QUIT to LMTP and RSET to SMTP

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
