### PR TITLE
Fix invalid DKIM when empty body

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 * mf.resolvable: reduce timeout by one second (so < plugin.timeout) #2544
+* invalid DKIM when empty body #2410
 
 ## 2.8.23 - Nov 18, 2018
 

--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -89,6 +89,12 @@ class DKIMSignStream extends Stream {
             this.hash.update(le);
             this.buffer = { ar: [], len: 0 };
         }
+        
+        // If body is empty it still requires to contain CRLF
+        // RFC6376 - 3.4.3. The "simple" Body Canonicalization Algorithm
+        if (this.buffer.len == 0) {
+            this.hash.update(new Buffer("\r\n"));
+        }
 
         const bodyhash = this.hash.digest('base64');
 


### PR DESCRIPTION
Fixes #2410

Changes proposed in this pull request:
- calculate hash from CRLF when empty body per RFC6376

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
