### PR TITLE
prevent running secureConnect callback multiple times

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,6 +21,7 @@
 * mf.resolvable: reduce timeout by one second (so < plugin.timeout) #2544
 * LMTP blocks under stress #2556
 * invalid DKIM when empty body #2410
+* prevent running callback multiple times on TLS unix socket #2509
 
 
 ## 2.8.23 - Nov 18, 2018

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -707,7 +707,7 @@ function connect (port, host, cb) {
             }
         })
 
-        cleartext.on('secureConnect', function () {
+        cleartext.once('secureConnect', function () {
             log.logdebug('client TLS secured.');
             if (cb2) cb2(
                 cleartext.authorized,


### PR DESCRIPTION
Fixes #2509

Changes proposed in this pull request:
- .on to .once at secureConnect event listener

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
