### PR TITLE
handle arrays in .ini files

### DIFF
--- a/tests/configfile.js
+++ b/tests/configfile.js
@@ -153,6 +153,45 @@ exports.load_ini_config = {
     },
 };
 
+exports.get_filetype_reader  = {
+    setUp: _set_up,
+    'binary': function (test) {
+        test.expect(2);
+        var reader = this.cfreader.get_filetype_reader('binary');
+        test.equal(typeof reader.load, 'function');
+        test.equal(typeof reader.empty, 'function');
+        test.done();
+    },
+    'flat': function (test) {
+        test.expect(2);
+        var reader = this.cfreader.get_filetype_reader('flat');
+        test.equal(typeof reader.load, 'function');
+        test.equal(typeof reader.empty, 'function');
+        test.done();
+    },
+    'json': function (test) {
+        test.expect(2);
+        var reader = this.cfreader.get_filetype_reader('json');
+        test.equal(typeof reader.load, 'function');
+        test.equal(typeof reader.empty, 'function');
+        test.done();
+    },
+    'ini': function (test) {
+        test.expect(2);
+        var reader = this.cfreader.get_filetype_reader('ini');
+        test.equal(typeof reader.load, 'function');
+        test.equal(typeof reader.empty, 'function');
+        test.done();
+    },
+    'yaml': function (test) {
+        test.expect(2);
+        var r = this.cfreader.load_ini_config('tests/config/test.ini');
+        test.deepEqual(['first_host', 'second_host', 'third_host'], r.array_test.hostlist);
+        test.deepEqual([123, 456, 789], r.array_test.intlist);
+        test.done();
+    },
+};
+
 exports.non_existing = {
     setUp: _set_up,
 


### PR DESCRIPTION
msimerson commented in a pull request https://github.com/haraka/Haraka/pull/1333#issuecomment-184313920

    One thing that might be worth changing is the way the host pool is
    configured. A method that already has widespread use is to specify an array
    for the host value instead of a string. This would necessitate extending our
    ini parser to recognize the array syntax.

The syntax looks like this. There is no "official" .ini syntax for arrays, but
this seems to be common.

    hosts[] = first_host
    hosts[] = second_host
    hosts[] = third_host

This squashed merge from the feature branch also includes

commit e778a5420b4703c2679a291974c334e2daa021bc
Author: Kevin M. Goess <kgoess@craigslist.org>
Date:   Thu Feb 18 09:28:25 2016 -0800

    whitespace fix for eslint

commit 669b0d94ac39dd31612493505516ca38eebe63f0
Author: Kevin M. Goess <kgoess@craigslist.org>
Date:   Thu Feb 18 09:21:50 2016 -0800

    fix test for .ini arrays

    hand-applying msimerson's 86e69a316cd

Fixes #

Changes proposed in this pull request:
- 
- 

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
