### PR TITLE
adjust should_check logic, extend to spamassassin

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,10 +11,10 @@
 ### New Features
 
 * Implement SIGTERM graceful shutdown if pid is 1 #2547
-
-### New Features
-
 * tls: require validated certs on some ports with requireAuthorized
+* spamassassin: disable checks when requested
+* early_talker: extend reasons to skip checking
+* clamd: permit skipping for relay clients
 
 ### Fixes
 

--- a/Changes.md
+++ b/Changes.md
@@ -7,14 +7,14 @@
 * early_talker: skip if sender has good karma #2551
 * dockerfile: update to node 10 #2552
 * Update deprecated usages of Buffer #2553
+* early_talker: extend reasons to skip checking #2564
 
 ### New Features
 
 * Implement SIGTERM graceful shutdown if pid is 1 #2547
-* tls: require validated certs on some ports with requireAuthorized
-* spamassassin: disable checks when requested
-* early_talker: extend reasons to skip checking
-* clamd: permit skipping for relay clients
+* tls: require validated certs on some ports with requireAuthorized #2554
+* spamassassin: disable checks when requested #2564
+* clamd: permit skipping for relay clients #2564
 
 ### Fixes
 

--- a/config/spamassassin.ini
+++ b/config/spamassassin.ini
@@ -42,3 +42,9 @@ modern_status_syntax=1
 
 ; the header that is sent to spamc
 ;spamc_auth_header = X-Haraka-Relay
+
+[check]
+;authenticated=false
+;private_ip=false
+;local_ip=false
+;relay=false

--- a/plugins/early_talker.js
+++ b/plugins/early_talker.js
@@ -39,28 +39,9 @@ exports.load_config = function () {
 exports.early_talker = function (next, connection) {
     const plugin = this;
     if (!plugin.pause) return next();
+    if (!plugin.should_check(connection)) return next();
 
-    if (connection.relaying) {    // Don't delay AUTH/RELAY clients
-        if (connection.early_talker) {
-            connection.results.add(plugin, { skip: 'relay client'});
-        }
-        return next();
-    }
-
-    // Don't delay whitelisted IPs
-    if (plugin.ip_in_list(connection.remote.ip)) { // check connecting IP
-        connection.results.add(plugin, { skip: 'whitelist' });
-        return next();
-    }
-
-    // Don't delay historically good senders
-    const karma = connection.results.get('karma');
-    if (karma && karma.good > 0) {
-        connection.results.add(plugin, { skip: 'good karma' });
-        return next();
-    }
-
-    const check = function () {
+    function check () {
         if (!connection) return next();
         if (!connection.early_talker) {
             connection.results.add(plugin, {pass: 'early'});
@@ -69,7 +50,7 @@ exports.early_talker = function (next, connection) {
         connection.results.add(plugin, {fail: 'early'});
         if (!plugin.cfg.main.reject) return next();
         return next(DENYDISCONNECT, "You talk too soon");
-    };
+    }
 
     let pause = plugin.pause;
     if (plugin.hook === 'connect_init') {
@@ -94,9 +75,7 @@ exports.early_talker = function (next, connection) {
 exports.ip_in_list = function (ip) {
     const plugin = this;
 
-    if (!plugin.whitelist) {
-        return false;
-    }
+    if (!plugin.whitelist) return false;
 
     const ipobj = ipaddr.parse(ip);
 
@@ -136,4 +115,42 @@ exports.load_ip_list = function (list) {
         }
     }
     return whitelist;
+}
+
+exports.should_check = function (connection) {
+    const plugin = this;
+    // Skip delays for privileged senders
+
+    if (connection.notes.auth_user) {
+        connection.results.add(plugin, { skip: 'authed'});
+        return false;
+    }
+
+    if (connection.relaying) {
+        connection.results.add(plugin, { skip: 'relay'});
+        return false;
+    }
+
+    if (plugin.ip_in_list(connection.remote.ip)) {
+        connection.results.add(plugin, { skip: 'whitelist' });
+        return false;
+    }
+
+    const karma = connection.results.get('karma');
+    if (karma && karma.good > 0) {
+        connection.results.add(plugin, { skip: '+karma' });
+        return false;
+    }
+
+    if (connection.remote.is_local) {
+        connection.results.add(plugin, { skip: 'local_ip'});
+        return false;
+    }
+
+    if (connection.remote.is_private) {
+        connection.results.add(plugin, { skip: 'private_ip'});
+        return false;
+    }
+
+    return true;
 }

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -14,6 +14,10 @@ exports.load_spamassassin_ini = function () {
     plugin.cfg = plugin.config.get('spamassassin.ini', {
         booleans: [
             '+add_headers',
+            '-check.authenticated',
+            '-check.private_ip',
+            '-check.local_ip',
+            '-check.relay',
         ],
     }, function () {
         plugin.load_spamassassin_ini();

--- a/tests/plugins/early_talker.js
+++ b/tests/plugins/early_talker.js
@@ -97,7 +97,7 @@ exports.early_talker = {
         const next = function (rc, msg) {
             test.equal(undefined, rc);
             test.equal(undefined, msg);
-            test.ok(this.connection.results.has('early_talker', 'skip', 'good karma'));
+            test.ok(this.connection.results.has('early_talker', 'skip', '+karma'));
             test.done();
         }.bind(this);
         this.plugin.pause = 1000;


### PR DESCRIPTION
I need a mechanism to skip spamassassin checks for IP based relaying clients. Haraka already has similar mechanisms for this in rspamd and clamd via their `check` config settings and the `should_check()` function. This PR (and [rspamd #13](haraka/haraka-plugin-rspamd#13)) extends `should_check()` to support relay clients.

Aside: auth clients **are** relaying clients, but relay might also be set by other plugins, such as IP lists in the `relay` plugin.

Changes proposed in this pull request:
- adjust should_check logic to be flow-through
    - easier to read/parse/grok and extend
    - shows if a connection was skipped for more than one reason
- copy `should_check()` to spamassassin
- early_talker had similar inline checks which I refactored into `should_check()`

related to #2551  (skip early_talker if +karma)
related to haraka/haraka-plugin-rspamd#13
related to #2533 (add clamd skip options)

It might be useful to abstract `should_check()` into plugin.js and have a "standard" set of config settings that each plugin can skip processing for. At present, we have:

```ini
[check]
;authenticated=false
;relay=false
;private_ip=false
;local_ip=false
```

The `early_talker` plugin also has *karma* as a criteria, which could be useful elsewhere as well. 

Checklist:
- [ ] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated