### PR TITLE
Make outbound temp_fail_queue and delivery_queue accessible

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -15,6 +15,7 @@
 * tls: require validated certs on some ports with requireAuthorized #2554
 * spamassassin: disable checks when requested #2564
 * clamd: permit skipping for relay clients #2564
+* outbound: exported outbound.temp_fail_queue, outbound.delivery_queue and add TimerQueue.discard() 
 
 ### Fixes
 

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -27,6 +27,9 @@ const queue_dir = queuelib.queue_dir;
 const temp_fail_queue = queuelib.temp_fail_queue;
 const delivery_queue = queuelib.delivery_queue;
 
+exports.temp_fail_queue = temp_fail_queue;
+exports.delivery_queue = delivery_queue;
+
 exports.net_utils = net_utils;
 exports.config    = config;
 

--- a/outbound/queue.js
+++ b/outbound/queue.js
@@ -132,7 +132,7 @@ exports.load_queue_files = function (pid, cb_name, files, callback) {
                         load_queue.push(new_filename);
                     }
                     else {
-                        temp_fail_queue.add(next_process - self.cur_time, function () {
+                        temp_fail_queue.add(new_filename, next_process - self.cur_time, function () {
                             load_queue.push(new_filename);
                         });
                     }
@@ -194,7 +194,7 @@ exports.load_queue_files = function (pid, cb_name, files, callback) {
                 }
                 else {
                     logger.logdebug("[outbound] File needs processing later: " + (next_process - self.cur_time) + "ms");
-                    temp_fail_queue.add(next_process - self.cur_time, function () { load_queue.push(file);});
+                    temp_fail_queue.add(file, next_process - self.cur_time, function () { load_queue.push(file);});
                 }
                 async.setImmediate(cb);
             }
@@ -294,7 +294,7 @@ exports._add_file = function (hmail) {
         delivery_queue.push(hmail);
     }
     else {
-        temp_fail_queue.add(hmail.next_process - exports.cur_time, function () {
+        temp_fail_queue.add(hmail.filename, hmail.next_process - exports.cur_time, function () {
             delivery_queue.push(hmail);
         });
     }

--- a/outbound/timer_queue.js
+++ b/outbound/timer_queue.js
@@ -4,7 +4,8 @@ const logger = require('../logger');
 
 class TQTimer {
 
-    constructor (fire_time, cb) {
+    constructor (id, fire_time, cb) {
+        this.id = id;
         this.fire_time = fire_time;
         this.cb = cb;
     }
@@ -24,10 +25,10 @@ class TimerQueue {
         this.interval_timer = setInterval(function () { self.fire(); }, interval);
     }
 
-    add (ms, cb) {
+    add (id, ms, cb) {
         const fire_time = Date.now() + ms;
 
-        const timer = new TQTimer(fire_time, cb);
+        const timer = new TQTimer(id, fire_time, cb);
 
         if ((this.queue.length === 0) ||
             fire_time >= this.queue[this.queue.length - 1].fire_time) {
@@ -43,6 +44,17 @@ class TimerQueue {
         }
 
         throw "Should never get here";
+    }
+
+    discard (id) {
+        for (let i = 0; i < this.queue.length; i++) {
+            if (this.queue[i].id === id) {
+                this.queue[i].cancel();
+                return this.queue.splice(i, 1);
+            }
+        }
+
+        throw `${id} not found`;
     }
 
     fire () {

--- a/tests/outbound/index.js
+++ b/tests/outbound/index.js
@@ -252,8 +252,8 @@ exports.timer_queue = {
     'can add items': function (test) {
         test.expect(1);
 
-        this.ob_timer_queue.add(1000);
-        this.ob_timer_queue.add(2000);
+        this.ob_timer_queue.add("1", 1000);
+        this.ob_timer_queue.add("2", 2000);
 
         const tq_length = this.ob_timer_queue.length();
 
@@ -263,8 +263,8 @@ exports.timer_queue = {
     'can drain items': function (test) {
         test.expect(2);
 
-        this.ob_timer_queue.add(1000);
-        this.ob_timer_queue.add(2000);
+        this.ob_timer_queue.add("1", 1000);
+        this.ob_timer_queue.add("2", 2000);
 
         let tq_length = this.ob_timer_queue.length();
 
@@ -277,4 +277,22 @@ exports.timer_queue = {
 
         test.done();
     },
+    'can discard items by id': function (test) {
+        test.expect(3);
+
+        this.ob_timer_queue.add("1", 1000);
+        this.ob_timer_queue.add("2", 2000);
+
+        let tq_length = this.ob_timer_queue.length();
+
+        test.equal(tq_length, 2);
+
+        this.ob_timer_queue.discard("2");
+        tq_length = this.ob_timer_queue.length();
+
+        test.equal(tq_length, 1);
+        test.equal(this.ob_timer_queue.queue[0].id, "1");
+
+        test.done();
+    }
 }


### PR DESCRIPTION
Currently there is no way to see what is inside temp_fail_queue or delivery_queue. And even if we access content there is no way how to list TimerQueue and get some usefull info (callback variables are sadly not accessible). Future idea is to have ability to list/push/discard emails on waiting list through plugin.

Changes proposed in this pull request:
- export temp_fail_queue, delivery_queue from outbound
- add id(=filename) to TimerQueue items to see what is inside temp_fail_queue
- add discard method on TimerQueue

Checklist:
- [ ] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
