### PR TITLE
tls: support local CA list

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,11 +3,11 @@
 
 ### Changes
 
-* Implement SIGTERM graceful shutdown if pid is 1 #2547
 * early_talker: skip if sender has good karma #2551
 * dockerfile: update to node 10 #2552
 * Update deprecated usages of Buffer #2553
 * early_talker: extend reasons to skip checking #2564
+* tls: add 'ca' option (for CA root file) #2571
 
 ### New Features
 

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -348,13 +348,17 @@ exports.load_default_opts = () => {
         tlss.saveOpt('*', 'dhparam', tlss.config.get(cfg.dhparam, 'binary'));
     }
 
+    if (cfg.ca && typeof cfg.ca === 'string') {
+        log.loginfo(`loading CA certs from ${cfg.ca}`);
+        tlss.saveOpt('*', 'ca', tlss.config.get(cfg.ca, 'binary'));
+    }
+
     // make non-array key/cert option into Arrays with one entry
     if (!(Array.isArray(cfg.key ))) cfg.key  = [cfg.key];
     if (!(Array.isArray(cfg.cert))) cfg.cert = [cfg.cert];
 
     if (cfg.key.length != cfg.cert.length) {
-        log.logerror("number of keys (" + cfg.key.length +
-            ") not equal to certs (" + cfg.cert.length + ").");
+        log.logerror(`number of keys (${cfg.key.length}) not equal to certs (${cfg.cert.length}).`);
     }
 
     // if key file has already been loaded, it'll be a Buffer.


### PR DESCRIPTION
permits specifying the path to a local CA root file (likely ca_root_nss, the Mozilla CA list), but could be user generated.

When not specified, the CA roots that node.js bundles is the default.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
