### PR TITLE
outbound cleanups

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,6 +8,7 @@
 * dockerfile: update to node 10 #2552
 * Update deprecated usages of Buffer #2553
 * early_talker: extend reasons to skip checking #2564
+* outbound: little cleanups #2572
 
 ### New Features
 

--- a/outbound/fsync_writestream.js
+++ b/outbound/fsync_writestream.js
@@ -6,28 +6,28 @@ class FsyncWriteStream extends fs.WriteStream {
     constructor (path, options) {
         super(path, options);
     }
-}
 
-FsyncWriteStream.prototype.close = function (cb) {
-    const self = this;
-    if (cb)
-        this.once('close', cb);
-    if (this.closed || 'number' !== typeof this.fd) {
-        if ('number' !== typeof this.fd) {
-            this.once('open', close);
-            return;
-        }
-        return setImmediate(this.emit.bind(this, 'close'));
-    }
-    this.closed = true;
-    close();
+    close (cb) {
+        const self = this;
+        if (cb) this.once('close', cb);
 
-    function close (fd) {
-        fs.fsync(fd || self.fd, function (er) {
-            if (er) {
-                self.emit('error', er);
+        if (this.closed || 'number' !== typeof this.fd) {
+            if ('number' !== typeof this.fd) {
+                this.once('open', close);
+                return;
             }
-            else {
+            return setImmediate(this.emit.bind(this, 'close'));
+        }
+        this.closed = true;
+        close();
+
+        function close (fd) {
+            fs.fsync(fd || self.fd, function (er) {
+                if (er) {
+                    self.emit('error', er);
+                    return;
+                }
+
                 fs.close(fd || self.fd, function (err) {
                     if (err) {
                         self.emit('error', err);
@@ -37,10 +37,9 @@ FsyncWriteStream.prototype.close = function (cb) {
                     }
                 });
                 self.fd = null;
-            }
-        });
+            });
+        }
     }
 }
 
 module.exports = FsyncWriteStream;
-

--- a/outbound/index.js
+++ b/outbound/index.js
@@ -251,7 +251,7 @@ exports.send_trans_email = function (transaction, next) {
 
     logger.add_log_methods(connection);
     if (!transaction.results) {
-        logger.logerror('adding missing results store');
+        logger.logdebug('adding results store');
         transaction.results = new ResultStore(connection);
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- ob/index: change misleading error level message to debug
- ob/fsync: move close into class declaration
- ob/client_pool: reduce indent with early fn exit
- ob/client_pool: conslidate 5x duped removeAllListeners into array

Checklist:
- [ ] docs updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
