### PR TITLE
server: warn when nodes=undefined

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@
 * early_talker: extend reasons to skip checking #2564
 * tls: add 'ca' option (for CA root file) #2571
 * outbound: little cleanups #2572
+* server: default to nodes=1 (was undefined) #2573
 
 ### New Features
 

--- a/server.js
+++ b/server.js
@@ -38,12 +38,17 @@ Server.load_smtp_ini = function () {
         Server.load_smtp_ini();
     });
 
+    if (Server.cfg.main.nodes === undefined) {
+        logger.logwarn(`smtp.ini.nodes unset, using 1, see https://github.com/haraka/Haraka/wiki/Performance-Tuning`)
+    }
+
     const defaults = {
         inactivity_timeout: 600,
         daemon_log_file: '/var/log/haraka.log',
         daemon_pid_file: '/var/run/haraka.pid',
         force_shutdown_timeout: 30,
         smtps_port: 465,
+        nodes: 1,
     };
 
     for (const key in defaults) {

--- a/tests/config/smtp.ini
+++ b/tests/config/smtp.ini
@@ -2,6 +2,8 @@ listen=0.0.0.0:2500
 
 ignore_bad_plugins=0
 
+nodes=0
+
 daemonize=false
 
 spool_dir=tests/tmp/queue


### PR DESCRIPTION
Fixes #2388 

Changes proposed in this pull request:
- server: warn when nodes=undefined
- default to nodes=1

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated