### PR TITLE
smtp_client little cleanups

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -9,6 +9,7 @@
 * early_talker: extend reasons to skip checking #2564
 * tls: add 'ca' option (for CA root file) #2571
 * outbound: little cleanups #2572
+* smtp_client: pass pool_timeout to new SMTPClient #2574
 
 ### New Features
 

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -34,14 +34,14 @@ class SMTPClient extends events.EventEmitter {
         super();
         this.uuid = utils.uuid();
         this.connect_timeout = parseInt(connect_timeout) || 30;
-        this.socket =  socket || line_socket.connect(port, host);
+        this.socket = socket || line_socket.connect(port, host);
         this.socket.setTimeout(this.connect_timeout * 1000);
         this.socket.setKeepAlive(true);
         this.state = STATE.IDLE;
         this.command = 'greeting';
         this.response = [];
         this.connected = false;
-        this.authenticating=false;
+        this.authenticating= false;
         this.authenticated = false;
         this.auth_capabilities = [];
         this.host = host;
@@ -68,15 +68,15 @@ class SMTPClient extends events.EventEmitter {
 
             if (client.command === 'auth' || client.authenticating) {
                 logger.loginfo(`SERVER RESPONSE, CLIENT ${client.command}, authenticating=${client.authenticating},code=${code},cont=${cont},msg=${msg}`);
-                if (code.match(/^3/) && msg === 'VXNlcm5hbWU6') {
+                if (/^3/.test(code) && msg === 'VXNlcm5hbWU6') {
                     client.emit('auth_username');
                     return;
                 }
-                if (code.match(/^3/) && msg === 'UGFzc3dvcmQ6') {
+                if (/^3/.test(code) && msg === 'UGFzc3dvcmQ6') {
                     client.emit('auth_password');
                     return;
                 }
-                if (code.match(/^2/) && client.authenticating) {
+                if (/^2/.test(code) && client.authenticating) {
                     logger.loginfo('AUTHENTICATED');
                     client.authenticating = false;
                     client.authenticated = true;
@@ -96,15 +96,20 @@ class SMTPClient extends events.EventEmitter {
                     return;
                 }
             }
-            if (client.command === 'xclient' && code.match(/^5/)) {
+            if (client.command === 'xclient' && /^5/.test(code)) {
                 // XCLIENT command was rejected (no permission?)
                 // Carry on without XCLIENT
                 client.command = 'helo';
             }
-            else if (code.match(/^[45]/)) {
+            else if (/^[45]/.test(code)) {
                 client.emit('bad_code', code, client.response.join(' '));
                 if (client.state !== STATE.ACTIVE) {
                     return;
+                }
+            }
+            if (/^441/.test(code)) {
+                if (/Connection timed out/i.test(msg)) {
+                    //
                 }
             }
             switch (client.command) {
@@ -141,8 +146,8 @@ class SMTPClient extends events.EventEmitter {
         });
 
         client.socket.on('connect', () => {
-            // Remove connection timeout and set idle timeout
-            client.socket.setTimeout(((idle_timeout) ? idle_timeout : 300) * 1000);
+            // Replace connection timeout with idle timeout
+            client.socket.setTimeout((idle_timeout || 300) * 1000);
             if (!client.socket.remoteAddress) {
                 // "Value may be undefined if the socket is destroyed"
                 logger.logdebug('socket.remoteAddress undefined');
@@ -158,8 +163,7 @@ class SMTPClient extends events.EventEmitter {
                 }
                 // msg is e.g. "errored" or "timed out"
                 // error is e.g. "Error: connect ECONNREFUSED"
-                const errMsg = `${client.uuid}: [${client.host}:${client.port}] ` +
-                    `SMTP connection ${msg} ${error}`;
+                const errMsg = `${client.uuid}: [${client.host}:${client.port}] SMTP connection ${msg} ${error}`;
                 if (client.state === STATE.ACTIVE) {
                     client.emit('error', errMsg);
                 }
@@ -171,8 +175,7 @@ class SMTPClient extends events.EventEmitter {
                         break;
                     default:
                 }
-                if ((msg === 'errored' || msg === 'timed out')
-                      && client.state === STATE.DESTROYED){
+                if ((msg === 'errored' || msg === 'timed out') && client.state === STATE.DESTROYED) {
                     client.emit('connection-error', errMsg);
                 } // don't return, continue (original behavior)
 
@@ -222,21 +225,14 @@ class SMTPClient extends events.EventEmitter {
             return;
         }
         this.state = STATE.RELEASED;
-        this.removeAllListeners('greeting');
-        this.removeAllListeners('capabilities');
-        this.removeAllListeners('xclient');
-        this.removeAllListeners('helo');
-        this.removeAllListeners('mail');
-        this.removeAllListeners('rcpt');
-        this.removeAllListeners('data');
-        this.removeAllListeners('dot');
-        this.removeAllListeners('rset');
-        this.removeAllListeners('auth');
-        this.removeAllListeners('client_protocol');
-        this.removeAllListeners('server_protocol');
-        this.removeAllListeners('error');
-        this.removeAllListeners('connection-error');
-        this.removeAllListeners('bad_code');
+
+        [
+            'auth',   'bad_code', 'capabilities', 'client_protocol', 'connection-error',
+            'data',   'dot',      'error',        'greeting',        'helo',
+            'mail',   'rcpt',     'rset',         'server_protocol', 'xclient',
+        ].forEach(l => {
+            this.removeAllListeners(l);
+        })
 
         this.on('bad_code', (code, msg) => {
             this.destroy();
@@ -244,9 +240,8 @@ class SMTPClient extends events.EventEmitter {
 
         this.on('rset', () => {
             logger.logdebug(`[smtp_client_pool] ${this.uuid} releasing, state=${this.state}`);
-            if (this.state === STATE.DESTROYED) {
-                return;
-            }
+            if (this.state === STATE.DESTROYED) return;
+
             this.state = STATE.IDLE;
             this.removeAllListeners('rset');
             this.removeAllListeners('bad_code');
@@ -304,7 +299,7 @@ exports.get_pool = (server, port, host, cfg) => {
     const pool = generic_pool.Pool({
         name: name,
         create: function (callback) {
-            const smtp_client = new SMTPClient(port, host, connect_timeout);
+            const smtp_client = new SMTPClient(port, host, connect_timeout, pool_timeout);
             logger.logdebug(`[smtp_client_pool] uuid=${smtp_client.uuid} host=${host}` +
                 ` port=${port} pool_timeout=${pool_timeout} created`);
             callback(null, smtp_client);
@@ -349,18 +344,18 @@ exports.get_client = function (server, callback, port, host, cfg) {
 
 exports.onCapabilitiesOutbound = function (smtp_client, secured, connection, config, on_secured) {
     for (const line in smtp_client.response) {
-        if (smtp_client.response[line].match(/^XCLIENT/)) {
+        if (/^XCLIENT/.test(smtp_client.response[line])) {
             if (!smtp_client.xclient) {
                 smtp_client.send_command('XCLIENT', `ADDR=${connection.remote.ip}`);
                 return;
             }
         }
 
-        if (smtp_client.response[line].match(/^SMTPUTF8/)) {
+        if (/^SMTPUTF8/.test(smtp_client.response[line])) {
             smtp_client.smtputf8 = true;
         }
 
-        if (smtp_client.response[line].match(/^STARTTLS/) && !secured) {
+        if (/^STARTTLS/.test(smtp_client.response[line]) && !secured) {
 
             let hostBanned = false
             let serverBanned = false
@@ -486,12 +481,10 @@ exports.get_client_plugin = function (plugin, connection, c, callback) {
 
         smtp_client.on('auth', () => {
             // if authentication has been handled by plugin(s)
-            if (smtp_client.authenticating) {
-                return;
-            }
-            if (smtp_client.is_dead_sender(plugin, connection)) {
-                return;
-            }
+            if (smtp_client.authenticating) return;
+
+            if (smtp_client.is_dead_sender(plugin, connection)) return;
+
             smtp_client.authenticated = true;
             smtp_client.send_command('MAIL', `FROM:${connection.transaction.mail_from.format(!smtp_client.smtp_utf8)}`);
         });
@@ -508,7 +501,7 @@ exports.get_client_plugin = function (plugin, connection, c, callback) {
             logger.logerror(`backend failure: ${smtp_client.host}:${smtp_client.port} - ${error}`);
             const host_pool = connection.server.notes.host_pool;
             // only exists for if forwarding_host_pool is set in the config
-            if (host_pool){
+            if (host_pool) {
                 host_pool.failed(smtp_client.host, smtp_client.port);
             }
             smtp_client.call_next();
@@ -540,9 +533,8 @@ function get_hostport (connection, server, cfg) {
         }
 
         const host = server.notes.host_pool.get_host();
-        if (host) {
-            return host; // { host: 1.2.3.4, port: 567 }
-        }
+        if (host) return host; // { host: 1.2.3.4, port: 567 }
+
         logger.logerror('[smtp_client_pool] no backend hosts in pool!');
         throw new Error("no backend hosts found in pool!");
     }

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -96,6 +96,7 @@ class SMTPClient extends events.EventEmitter {
                     return;
                 }
             }
+
             if (client.command === 'xclient' && /^5/.test(code)) {
                 // XCLIENT command was rejected (no permission?)
                 // Carry on without XCLIENT
@@ -107,11 +108,7 @@ class SMTPClient extends events.EventEmitter {
                     return;
                 }
             }
-            if (/^441/.test(code)) {
-                if (/Connection timed out/i.test(msg)) {
-                    //
-                }
-            }
+
             switch (client.command) {
                 case 'xclient':
                     client.xclient = true;
@@ -154,7 +151,7 @@ class SMTPClient extends events.EventEmitter {
                 return;
             }
             client.remote_ip = ipaddr.process(client.socket.remoteAddress).toString();
-        });
+        })
 
         function closed (msg) {
             return function (error) {


### PR DESCRIPTION
Changes proposed in this pull request:
- when not using RE match, use test
- a slight change in functionality is passing the pool_timeout argument to SMTPClient. This permits overriding the default 300s, which kind of answers the question "are there any pool settings to close the active connection after a certain period" from #2321 

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated