### PR TITLE
Status plugin: use queued item's callback instead of setting fire_time to -1

### DIFF
--- a/plugins/status.js
+++ b/plugins/status.js
@@ -153,7 +153,7 @@ exports.queue_push = function (file, cb) {
     for (let i = 0; i < queue.length; i++) {
         if (queue[i].id !== file) continue;
 
-        let item = queue.splice(i, 1)[0];
+        const item = queue.splice(i, 1)[0];
         item.cb();
         
         break;

--- a/plugins/status.js
+++ b/plugins/status.js
@@ -155,7 +155,7 @@ exports.queue_push = function (file, cb) {
 
         const item = queue.splice(i, 1)[0];
         item.cb();
-        
+
         break;
     }
 

--- a/plugins/status.js
+++ b/plugins/status.js
@@ -153,7 +153,9 @@ exports.queue_push = function (file, cb) {
     for (let i = 0; i < queue.length; i++) {
         if (queue[i].id !== file) continue;
 
-        queue[i].fire_time = -1;
+        let item = queue.splice(i, 1)[0];
+        item.cb();
+        
         break;
     }
 


### PR DESCRIPTION
Fixes problem where pushed emails are not actually processed due waiting items earlier at queue, see https://github.com/haraka/Haraka/blob/e9128d6dea02f3509abcb5104f796e3a9a73313e/outbound/timer_queue.js#L60-L69

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
