### PR TITLE
nodemailer 5 changed dns resolver, use IPv4 addr

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,5 +1,5 @@
 
-## 2.8.24 - Mmm DD, 201Y
+## 2.8.24 - Jan DD, 2019
 
 ### Changes
 
@@ -11,6 +11,7 @@
 * outbound: little cleanups #2572
 * smtp_client: pass pool_timeout to new SMTPClient #2574
 * server: default to nodes=1 (was undefined) #2573
+* test/server: use IPv4 127.0.0.1 instead of localhost #2584
 
 ### New Features
 

--- a/tests/server.js
+++ b/tests/server.js
@@ -250,7 +250,7 @@ exports.smtp_client = {
 
 exports.nodemailer = {
     setUp : function (done) {
-        _setupServer(this, 'localhost:2503', done);
+        _setupServer(this, '127.0.0.1:2503', done);
     },
     tearDown: _tearDownServer,
     'accepts SMTP message': function (test) {
@@ -258,7 +258,7 @@ exports.nodemailer = {
         test.expect(1);
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
-            host: 'localhost',
+            host: '127.0.0.1',
             port: 2503,
             tls: {
                 // do not fail on invalid certs
@@ -292,7 +292,7 @@ exports.nodemailer = {
         test.expect(1);
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
-            host: 'localhost',
+            host: '127.0.0.1',
             port: 2503,
             auth: {
                 user: 'matt',
@@ -331,7 +331,7 @@ exports.nodemailer = {
         test.expect(1);
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
-            host: 'localhost',
+            host: '127.0.0.1',
             port: 2503,
             auth: {
                 user: 'matt',
@@ -369,7 +369,7 @@ exports.nodemailer = {
         test.expect(1);
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
-            host: 'localhost',
+            host: '127.0.0.1',
             port: 2503,
             tls: {
                 // do not fail on invalid certs
@@ -416,7 +416,7 @@ exports.requireAuthorized_SMTPS = {
         test.expect(1);
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
-            host: 'localhost',
+            host: '127.0.0.1',
             port: 2465,
             secure: true,
             tls: {
@@ -463,7 +463,7 @@ exports.requireAuthorized_STARTTLS = {
         test.expect(1);
         const nodemailer = require('nodemailer');
         const transporter = nodemailer.createTransport({
-            host: 'localhost',
+            host: '127.0.0.1',
             port: 2587,
             tls: {
                 // do not fail on invalid certs


### PR DESCRIPTION
Fixes #2578

Changes proposed in this pull request:
- replace `localhost` with `127.0.0.1` so nodemailer DNS resolver change doesn't break tests 

Checklist:
- [ ] docs updated
- [x] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
