### PR TITLE
spf: add option to disable mfrom and/or ehlo checks

### DIFF
--- a/docs/plugins/spf.md
+++ b/docs/plugins/spf.md
@@ -27,6 +27,15 @@ In that use case, Haraka should use context=myself.
     * context=sender    evaluate SPF based on the sender (connection.remote.ip)
     * context=myself    evaluate SPF based on Haraka's public IP
 
+By default, the plugin does SPF checks for the domain in EHLO/HELO string as
+well as the Envelope From. This can be selectively disabled:
+
+    [check]
+    ; SPF check the domain in helo string
+    helo=true
+    ; SPF check the domain in MAIL FROM
+    mfrom=true
+
 The rest of the optional settings (disabled by default) permit deferring or
 denying mail from senders whose SPF fails the checks.
 

--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -46,6 +46,9 @@ exports.load_config = function () {
             '-deny_relay.mfrom_permerror',
             '-deny_relay.openspf_text',
 
+            '+check.helo',
+            '+check.mfrom',
+
             '-skip.relaying',
             '-skip.auth',
         ]
@@ -73,10 +76,19 @@ exports.load_config = function () {
         plugin.cfg.relay = { context: 'sender' };  // default/legacy
     }
 
+    if (plugin.cfg.check.helo) {
+        plugin.register_hook('helo', 'check_helo');
+        plugin.register_hook('ehlo', 'check_helo');
+    }
+
+    if (plugin.cfg.check.mfrom) {
+        plugin.register_hook('mail', 'check_mail');
+    }
+
     plugin.cfg.lookup_timeout = plugin.cfg.main.lookup_timeout || plugin.timeout - 1;
 };
 
-exports.hook_helo = exports.hook_ehlo = function (next, connection, helo) {
+exports.check_helo = function (next, connection, helo) {
     const plugin = this;
 
     // bypass auth'ed or relay'ing hosts if told to
@@ -128,7 +140,7 @@ exports.hook_helo = exports.hook_ehlo = function (next, connection, helo) {
     });
 }
 
-exports.hook_mail = function (next, connection, params) {
+exports.check_mail = function (next, connection, params) {
     const plugin = this;
 
     const txn = connection.transaction;

--- a/tests/plugins/spf.js
+++ b/tests/plugins/spf.js
@@ -131,7 +131,7 @@ exports.return_results = {
     },
 }
 
-exports.hook_helo = {
+exports.check_helo = {
     setUp : _set_up,
     'rfc1918': function (test) {
         let completed = 0;
@@ -142,8 +142,8 @@ exports.hook_helo = {
         }
         test.expect(2);
         this.connection.remote.is_private=true;
-        this.plugin.hook_helo(next, this.connection);
-        this.plugin.hook_helo(next, this.connection, 'helo.sender.com');
+        this.plugin.check_helo(next, this.connection);
+        this.plugin.check_helo(next, this.connection, 'helo.sender.com');
     },
     'IPv4 literal': function (test) {
         function next (rc) {
@@ -152,14 +152,14 @@ exports.hook_helo = {
         }
         test.expect(1);
         this.connection.remote.ip='190.168.1.1';
-        this.plugin.hook_helo(next, this.connection, '[190.168.1.1]' );
+        this.plugin.check_helo(next, this.connection, '[190.168.1.1]' );
     },
 
 }
 
 const test_addr = new Address('<test@example.com>');
 
-exports.hook_mail = {
+exports.check_mail = {
     setUp : _set_up,
     'rfc1918': function (test) {
         function next () {
@@ -169,7 +169,7 @@ exports.hook_mail = {
         test.expect(1);
         this.connection.remote.is_private=true;
         this.connection.remote.ip='192.168.1.1';
-        this.plugin.hook_mail(next, this.connection, [test_addr]);
+        this.plugin.check_mail(next, this.connection, [test_addr]);
     },
     'rfc1918 relaying': function (test) {
         function next () {
@@ -180,7 +180,7 @@ exports.hook_mail = {
         this.connection.set('remote.is_private', true);
         this.connection.set('remote.ip','192.168.1.1');
         this.connection.relaying=true;
-        this.plugin.hook_mail(next, this.connection, [test_addr]);
+        this.plugin.check_mail(next, this.connection, [test_addr]);
     },
     'no txn': function (test) {
         function next () {
@@ -190,7 +190,7 @@ exports.hook_mail = {
         test.expect(1);
         this.connection.remote.ip='207.85.1.1';
         delete this.connection.transaction;
-        this.plugin.hook_mail(next, this.connection);
+        this.plugin.check_mail(next, this.connection);
     },
     'txn, no helo': function (test) {
         function next () {
@@ -200,7 +200,7 @@ exports.hook_mail = {
         test.expect(1);
         this.plugin.cfg.deny.mfrom_fail = false;
         this.connection.remote.ip='207.85.1.1';
-        this.plugin.hook_mail(next, this.connection, [test_addr]);
+        this.plugin.check_mail(next, this.connection, [test_addr]);
     },
     'txn': function (test) {
         function next (rc) {
@@ -210,7 +210,7 @@ exports.hook_mail = {
         test.expect(1);
         this.connection.set('remote', 'ip', '207.85.1.1');
         this.connection.set('hello', 'host', 'mail.example.com');
-        this.plugin.hook_mail(next, this.connection, [test_addr]);
+        this.plugin.check_mail(next, this.connection, [test_addr]);
     },
     'txn, relaying': function (test) {
         function next (rc) {
@@ -221,7 +221,7 @@ exports.hook_mail = {
         this.connection.set('remote.ip', '207.85.1.1');
         this.connection.relaying=true;
         this.connection.set('hello.host', 'mail.example.com');
-        this.plugin.hook_mail(next, this.connection, [test_addr]);
+        this.plugin.check_mail(next, this.connection, [test_addr]);
     },
     'txn, relaying, is_private': function (test) {
         function next (rc) {
@@ -236,6 +236,6 @@ exports.hook_mail = {
         this.connection.relaying = true;
         this.connection.set('hello.host', 'www.tnpi.net');
         this.plugin.nu.public_ip = '66.128.51.165';
-        this.plugin.hook_mail(next, this.connection, [new Address('<nonexist@tnpi.net>')]);
+        this.plugin.check_mail(next, this.connection, [new Address('<nonexist@tnpi.net>')]);
     },
 }


### PR DESCRIPTION
SPF checks on the EHLO string is not really required (http://www.openspf.org/FAQ/Envelope_from_scope). This option allow us to turn it off.

Checklist:
- [X] docs updated
- [X] tests updated
