### PR TITLE
spf: avoid 2nd EHLO evaluation if EHLO host is identical

### DIFF
--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -99,6 +99,10 @@ exports.hook_helo = exports.hook_ehlo = function (next, connection, helo) {
         return next();
     }
 
+    // avoid 2nd EHLO evaluation if EHLO host is identical
+    const results = connection.results.get(plugin);
+    if (results && results.domain === helo) return next();
+
     let timeout = false;
     const spf = new SPF();
     const timer = setTimeout(function () {


### PR DESCRIPTION
patch suggested by matt in PR 2590

Changes proposed in this pull request:
- avoid 2nd EHLO evaluation if EHLO host is identical
