### PR TITLE
Log dkim_sign parse errors with connection ID

### DIFF
--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -340,7 +340,7 @@ exports.get_sender_domain = function (connection) {
         addrs = addrparser.parse(from_hdr);
     }
     catch (e) {
-        plugin.logerror(`address-rfc2822 failed to parse From header: ${from_hdr}`)
+        connection.logerror(plugin, `address-rfc2822 failed to parse From header: ${from_hdr}`)
         return domain;
     }
     if (!addrs || ! addrs.length) return domain;
@@ -363,7 +363,7 @@ exports.get_sender_domain = function (connection) {
             domain = (addrparser.parse(sender))[0].host().toLowerCase();
         }
         catch (e) {
-            plugin.logerror(e);
+            connection.logerror(plugin, e);
         }
     }
     return domain;


### PR DESCRIPTION
Changes proposed in this pull request:
- plugin.logerror(...) -> connection.logerror(plugin, ...)

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
