### PR TITLE
haraka.service: Type=simple

### DIFF
--- a/contrib/haraka.service
+++ b/contrib/haraka.service
@@ -1,8 +1,9 @@
 #
 # systemd service file for Haraka
 #
-# Put this file in /usr/lib/systemd/system, modify the paths to suit
-# then run:
+# Ensure that `daemonize` in `smpt.ini` is set to `false` (which is the default value).
+#
+# Put this file in /etc/systemd/system,  modify the paths to suit, then run:
 # sudo systemctl enable haraka
 # sudo systemctl start haraka
 #

--- a/contrib/haraka.service
+++ b/contrib/haraka.service
@@ -12,7 +12,7 @@ Description=Haraka MTA
 After=syslog.target network.target remote-fs.target nss-lookup.target
 
 [Service]
-Type=forking
+Type=simple
 PIDFile=/var/run/haraka.pid
 ExecStart=/usr/bin/haraka -c /path/to/your/config
 KillMode=process


### PR DESCRIPTION
`systemctl start hakara.service` was hanging, but the service was started ok. This is because the process wasn't forking and does not appear to have an option to do so. 

https://superuser.com/a/1274913/117296

> a) If the service starts and keeps running, and the prompt does not return until you press Control-C or stop the service in some other way: then Type = simple is the right choice.
> b) If the prompt returns but the service keeps running in the background (i.e. the service daemonizes itself on its own), then Type = forking is the right choice.

Fixes #

Changes proposed in this pull request: none 

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
