### PR TITLE
Connection.createConnection is not a constructor

### DIFF
--- a/bin/haraka
+++ b/bin/haraka
@@ -531,7 +531,7 @@ else if (parsed.test) {
         },
         notes: new Notes(),
     }
-    const connection = new Connection.createConnection(client, server);
+    const connection = Connection.createConnection(client, server);
     if (parsed['set-relay']) connection.relaying = true;
 
     const run_next_hook = function () {


### PR DESCRIPTION
Fixes #2617

Changes proposed in this pull request:
- removing new keywoard

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
