### PR TITLE
spamassassin: strip useless WS from tests

### DIFF
--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -105,7 +105,7 @@ exports.hook_data_post = function (next, connection) {
         if (!connection.transaction) return next();
 
         if (spamd_response.headers && spamd_response.headers.Tests) {
-            spamd_response.tests = spamd_response.headers.Tests;
+            spamd_response.tests = spamd_response.headers.Tests.replace(/\s/g, '');
         }
         if (spamd_response.tests === undefined) {
             // strip the 'tests' from the X-Spam-Status header
@@ -116,7 +116,7 @@ exports.hook_data_post = function (next, connection) {
                 const tests = /tests=((?:(?!autolearn)[^ ])+)/.exec(
                     spamd_response.headers.Status.replace(/\r?\n\t/g,'')
                 );
-                if (tests) { spamd_response.tests = tests[1]; }
+                if (tests) spamd_response.tests = tests[1];
             }
         }
 
@@ -137,7 +137,7 @@ exports.hook_data_post = function (next, connection) {
 
         plugin.munge_subject(connection, spamd_response.score);
 
-        return next();
+        next();
     });
 }
 


### PR DESCRIPTION
### before

`[spamassassin] status=No, score=-7.7, required=5.0, reject=0, tests="BAYES_99,BAYES_999,DCC_CHECK,DKIMWL_WL_HIGH,DKIM_SIGNED,\r 	DKIM_VALID,DKIM_VALID_AU,HTML_MESSAGE,LOW_PRICE,RCVD_IN_DNSWL_NONE,\r 	SPF_PASS,URI_HEX,USER_IN_DEF_DKIM_WL,USER_IN_DEF_SPF_WL"`

note the silly "\r       " plus invisible whitespace which doesn't wrap in the console/logs anyway.

### after

`[spamassassin] status=No, score=-4.4, required=5.0, reject=0, tests="BAYES_00,DCC_CHECK,DKIMWL_WL_HIGH,DKIM_SIGNED,DKIM_VALID,DKIM_VALID_AU,FROM_EXCESS_BASE64,HTML_IMAGE_RATIO_04,HTML_MESSAGE,RCVD_IN_DNSWL_NONE,RCVD_IN_RP_CERTIFIED,RCVD_IN_RP_SAFE,SPF_PASS"`
