### PR TITLE
conn: use is_local instead of localhost addr tests

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -1249,7 +1249,7 @@ class Connection {
 
     cmd_internalcmd (line) {
         const self = this;
-        if (self.remote.ip != '127.0.0.1' && self.remote.ip != '::1') {
+        if (!self.remote.is_local) {
             return this.respond(501, "INTERNALCMD not allowed remotely");
         }
         const results = (String(line)).split(/ +/);


### PR DESCRIPTION
### Issue

When I run a command like `haraka -c /data --qunstick example.com` I get back an error telling me I'm not allowed to run INTERNALCMD remotely. Combined with haraka/haraka-net-utils#40, this fixes that by extending the `is_local_ip` checks to include IPs bound to local interfaces.

Related to haraka/haraka-net-utils#40

Checklist:
- [ ] docs updated
- [x] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated