### PR TITLE
Actually enforce using key for INTERNALCMD

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -1264,6 +1264,8 @@ class Connection {
                 return this.respond(501, "Invalid internalcmd_key - check config");
             }
             results.shift();
+        } else if (config.get('internalcmd_key')) {
+            return this.respond(501, "Missing internalcmd_key - check config");
         }
 
         // Now send the internal command to the master process


### PR DESCRIPTION
Right now you can issue `INTERNALCMD` SMTP commands without a key – even when the `internalcmd_key` file exists. This renders having an `internalcmd_key` file moot.

This pull requests rejects `INTERNALCMD` commands without a key when a key is configured.