### PR TITLE
spf: add config option to fail on NONE

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,11 @@
 
+## NEXT
+
+### New features
+
+* spf: add config option to fail on NONE #2644
+
+
 ## 2.8.24 - Mar 12, 2019
 
 ### Changes

--- a/docs/plugins/spf.md
+++ b/docs/plugins/spf.md
@@ -80,10 +80,12 @@ There's a special setting that would allow the plugin to emit a funny explanatio
     mfrom_temperror
 
     [deny]
+    helo_none
     helo_softfail
     helo_fail
     helo_permerror
 
+    mfrom_none
     mfrom_softfail
     mfrom_fail
     mfrom_permerror
@@ -96,10 +98,12 @@ There's a special setting that would allow the plugin to emit a funny explanatio
     mfrom_temperror
 
     [deny_relay]
+    helo_none
     helo_softfail
     helo_fail
     helo_permerror
 
+    mfrom_none
     mfrom_softfail
     mfrom_fail
     mfrom_permerror

--- a/plugins/spf.js
+++ b/plugins/spf.js
@@ -29,19 +29,23 @@ exports.load_spf_ini = function () {
             '-defer_relay.helo_temperror',
             '-defer_relay.mfrom_temperror',
 
+            '-deny.helo_none',
             '-deny.helo_softfail',
             '-deny.helo_fail',
             '-deny.helo_permerror',
             '-deny.openspf_text',
 
+            '-deny.mfrom_none',
             '-deny.mfrom_softfail',
             '-deny.mfrom_fail',
             '-deny.mfrom_permerror',
 
+            '-deny_relay.helo_none',
             '-deny_relay.helo_softfail',
             '-deny_relay.helo_fail',
             '-deny_relay.helo_permerror',
 
+            '-deny_relay.mfrom_none',
             '-deny_relay.mfrom_softfail',
             '-deny_relay.mfrom_fail',
             '-deny_relay.mfrom_permerror',
@@ -262,6 +266,11 @@ exports.return_results = function (next, connection, spf, scope, result, sender)
 
     switch (result) {
         case spf.SPF_NONE:
+            if (plugin.cfg[deny][`${scope}_none`]) {
+                text = plugin.cfg[deny].openspf_text ? text : `${msgpre} SPF record not found`;
+                return next(DENY, text);
+            }
+            return next();
         case spf.SPF_NEUTRAL:
         case spf.SPF_PASS:
             return next();

--- a/tests/plugins/spf.js
+++ b/tests/plugins/spf.js
@@ -25,12 +25,22 @@ const _set_up = function (done) {
 
 exports.return_results = {
     setUp : _set_up,
-    'result, none': function (test) {
+    'result, none, reject=false': function (test) {
         function next () {
             test.equal(undefined, arguments[0]);
             test.done();
         }
         test.expect(1);
+        this.plugin.cfg.deny.mfrom_none=false;
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_NONE, 'test@example.com');
+    },
+    'result, none, reject=true': function (test) {
+        function next () {
+            test.equal(DENY, arguments[0]);
+            test.done();
+        }
+        test.expect(1);
+        this.plugin.cfg.deny.mfrom_none=true;
         this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_NONE, 'test@example.com');
     },
     'result, neutral': function (test) {

--- a/tests/plugins/spf.js
+++ b/tests/plugins/spf.js
@@ -31,7 +31,7 @@ exports.return_results = {
             test.done();
         }
         test.expect(1);
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.NONE, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_NONE, 'test@example.com');
     },
     'result, neutral': function (test) {
         function next () {
@@ -39,7 +39,7 @@ exports.return_results = {
             test.done();
         }
         test.expect(1);
-        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.NEUTRAL, 'test@example.com');
+        this.plugin.return_results(next, this.connection, spf, 'mfrom', spf.SPF_NEUTRAL, 'test@example.com');
     },
     'result, pass': function (test) {
         function next () {


### PR DESCRIPTION
Changes proposed in this pull request:
- spf: Add config option to deny mail when no SPF record exists. This is the behaviour adopted by GMail and others.

Checklist:
- [X] docs updated
- [X] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
