### PR TITLE
Fixed hook name

### DIFF
--- a/plugins/toobusy.js
+++ b/plugins/toobusy.js
@@ -17,7 +17,7 @@ exports.register = function () {
 
     plugin.loadConfig();
 
-    plugin.register_hook('connect_pre', 'check_busy');
+    plugin.register_hook('connect_init', 'check_busy');
 }
 
 exports.loadConfig = function () {


### PR DESCRIPTION
Changes proposed in this pull request:
- Changed hook name from connect_pre to connect_init 
As far as I can tell connect_pre doesn't exist in the current version of Haraka.
