### PR TITLE
Fix problems with multiline encoded headers and UTF body

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@
 
 * mailheader: fully quality header name in _remove_more #2647
 * haraka: Connection.createConnection is not a constructor #2816
+* problems with japanese characters in body and part header #2675
 
 
 ## 2.8.24 - Mar 12, 2019

--- a/mailbody.js
+++ b/mailbody.js
@@ -227,12 +227,7 @@ class Body extends events.EventEmitter {
         }
 
         if (/UTF-?8/i.test(enc)) {
-            if (this.decode_function === this.decode_8bit) {
-                // source string was UTF-8 but parsed as binary
-                this.bodytext = buf.toString('binary');
-            } else {
-                this.bodytext = buf.toString();
-            }
+            this.bodytext = buf.toString();
             return;
         }
 
@@ -368,6 +363,9 @@ class Body extends events.EventEmitter {
     }
 
     decode_8bit (line) {
+        if (/UTF-?8/i.test(this.body_encoding)) {
+            return Buffer.from(line, 'utf-8');
+        }
         return Buffer.from(line, 'binary');
     }
 }

--- a/tests/mailbody.js
+++ b/tests/mailbody.js
@@ -85,6 +85,7 @@ exports.basic = {
             ['iso-8859-2', '8-bit', "\x50\xF8\x69\x68\x6C\x61\xB9\x6F\x76\x61\x63\xED\x20\xFA\x64\x61\x6A\x65\x0A", "Přihlašovací údaje\n"],
             ['iso-8859-2', 'quoted-printable', "P=F8ihla=B9ovac=ED =FAdaje\n", "Přihlašovací údaje\n"],
             ['iso-8859-2', 'base64', "UPhpaGxhuW92YWPtIPpkYWplCgo=\n", "Přihlašovací údaje\n\n"],
+            ['utf-8', '8-bit', "どうぞ宜しくお願い申し上げます", "どうぞ宜しくお願い申し上げます"]
         ];
 
         test.expect(tests.length);

--- a/tests/mailheader.js
+++ b/tests/mailheader.js
@@ -98,3 +98,18 @@ exports.remove = {
         test.done()
     }
 }
+
+exports.decode = {
+    'multiline 8bit header (#2675)': test => {
+        this.h = new Header();
+        this.h.parse ([
+            "Content-Disposition: attachment;\n",
+            " filename*0*=utf-8''%E8%AC%9B%E6%BC%94%E4%BC%9A%E6;\n",
+            " filename*1*=%A1%88%E5%86%85%E6%9B%B8%EF%BC%86%E7%94%B3%E8%BE%BC%E6%9B%B8;\n",
+            " filename*2*=%E6%94%B9%2Etxt\n"
+        ]);
+        console.log(this.h.get_decoded('content-disposition'));
+        test.ok(this.h.get_decoded('content-disposition').includes('講演会案内書＆申込書改.txt'));
+        test.done();
+    }
+}


### PR DESCRIPTION
Fixes #2675 

Changes proposed in this pull request:
- if body is in utf-8 then don't decode it as binary
- multiline headers are decoded after merge, not before

Checklist:
- [ ] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
