### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Plugins are provided for running mail through [SpamAssassin][9], validating
 Haraka requires [node.js][1] to run. Install Haraka with [npm][2]:
 
 ```sh
+# If the second command gives "nobody" errors, uncomment & run the next command
+# npm -g config set user root
 npm install -g Haraka
 ```
 


### PR DESCRIPTION
https://stackoverflow.com/questions/44633419/no-access-permission-error-with-npm-global-install-on-docker-image

On a Debian 8 / Node 12 setup, I was unable to install Haraka unless I set npm to install as "root", instead of "nobody"

Fixes #

Changes proposed in this pull request:
- 
- 

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
