### PR TITLE
restore TLS version, correctly

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,8 @@
 
 ### Changes
 
+* restore TLS version info, set correctly #2723
+
 ### New features
 
 ### Fixes

--- a/connection.js
+++ b/connection.js
@@ -1449,7 +1449,7 @@ class Connection {
         let sslheader;
 
         if (this.get('tls.cipher.version')) {
-            sslheader = `(cipher=${this.tls.cipher.name}`;
+            sslheader = `(version=${this.tls.cipher.version} cipher=${this.tls.cipher.name}`;
             if (this.tls.verified) {
                 sslheader += ' verify=OK)';
             }

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -55,15 +55,12 @@ exports.advertise_starttls = function (next, connection) {
             return enable_tls();
         }
 
-        if (!dbr) {
-            connection.results.add(plugin, { msg: 'no_tls unset'});
-            return enable_tls();
-        }
+        if (!dbr) return enable_tls();
 
         // last TLS attempt failed
         redis.del(dbkey); // retry TLS next connection.
 
-        connection.results.add(plugin, { msg: 'tls disabled'});
+        connection.results.add(plugin, { msg: 'no_tls'});
         return next();
     });
 }

--- a/server.js
+++ b/server.js
@@ -346,8 +346,11 @@ Server.get_smtp_server = (host, port, inactivity_timeout, done) => {
 
         if (!server.has_tls) return;
 
+        const cipher = client.getCipher();
+        cipher.version = client.getProtocol(); // replace min with actual
+
         connection.setTLS({
-            cipher: client.getCipher(),
+            cipher,
             verified: client.authorized,
             verifyError: client.authorizationError,
             peerCertificate: client.getPeerCertificate(),

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -652,11 +652,13 @@ function createServer (cb) {
                 .on('secure', () => {
                     log.logdebug('TLS secured.');
                     socket.emit('secure');
+                    const cipher = cleartext.getCipher();
+                    cipher.version = cleartext.getProtocol();
                     if (cb2) cb2(
                         cleartext.authorized,
                         cleartext.authorizationError,
                         cleartext.getPeerCertificate(),
-                        cleartext.getCipher()
+                        cipher
                     );
                 })
 
@@ -713,11 +715,13 @@ function connect (port, host, cb) {
 
         cleartext.once('secureConnect', () => {
             log.logdebug('client TLS secured.');
+            const cipher = cleartext.getCipher();
+            cipher.version = cleartext.getProtocol();
             if (cb2) cb2(
                 cleartext.authorized,
                 cleartext.authorizationError,
                 cleartext.getPeerCertificate(),
-                cleartext.getCipher()
+                cipher
             );
         });
 


### PR DESCRIPTION
Related to: #2634, #2648, and #2708 

Changes proposed in this pull request:
- add cipher version back to header
- this time, use the current connections version, not the minimum supported

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
