### PR TITLE
Add the JSON logging format

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,8 @@
 
 * lint: add 'prefer-template'
 * restore TLS version info, set correctly #2723
+* add JSON format for logging
+
 
 ### New features
 

--- a/docs/Logging.md
+++ b/docs/Logging.md
@@ -55,15 +55,35 @@ This is implemented by testing for argument type in
 the logger.js log\* method. objects-as-arguments are then sniffed
 to try to determine if they're a connection or plugin instance.
 
-The logfmt format is also supported and can be enabled by changing the format
-from `default` to `logfmt` in the `config/log.ini` file which will
-start logging in the following format below.
+### Log formats
+
+Apart from the default log format described above, Haraka also supports logging
+as [`logfmt`](https://brandur.org/logfmt) and JSON. These can be used by
+changing the `format` attribute in `log.ini` to the desired format, e.g.:
+
+```ini
+; format=default
+; format=json
+format=logfmt
+```
+
+Here's an example of a log line generated with `logfmt`:
 
     level=PROTOCOL uuid=9FF7F70E-5D57-435A-AAD9-EA069B6159D9.1 source=core message="S: 354 go ahead, make my day"
 
-Any objects you pass through will also be appeneded to the log line as
-key=value and will look like this:
+And the same line formatted as JSON:
+
+```json
+{"level":"PROTOCOL","uuid":"9FF7F70E-5D57-435A-AAD9-EA069B6159D9.1","source":"core","message":"S: 354 go ahead, make my day"}
+```
+
+Any objects passed to the log methods will also have their properties included
+in the log line. For example, using `logfmt`:
 
     level=NOTICE uuid=9FF7F70E-5D57-435A-AAD9-EA069B6159D9.1 source=core message=disconnect ip=127.0.0.1 rdns=Unknown helo=3h2dnz8a0if relay=N early=N esmtp=N tls=N pipe=N errors=0 txns=1 rcpts=1/0/0 msgs=1/0/0 bytes=222 lr="" time=0.052
 
-You can find out more about logfmt here: [https://brandur.org/logfmt](https://brandur.org/logfmt)
+And using JSON:
+
+```json
+{"level":"NOTICE","uuid":"9FF7F70E-5D57-435A-AAD9-EA069B6159D9.1","source":"core","message":"disconnect","ip":"127.0.0.1","rdns":"Unknown","helo":"3h2dnz8a0if","relay":"N","early":"N","esmtp":"N","tls":"N","pipe":"N","errors":0,"txns":1,"rcpts":"1/0/0","msgs":"1/0/0","bytes":222,"lr":"","time":0.052}
+```

--- a/logger.js
+++ b/logger.js
@@ -57,6 +57,7 @@ for (const le in logger.levels) {
 logger.formats = {
     DEFAULT: "DEFAULT",
     LOGFMT: "LOGFMT",
+    JSON: "JSON",
 }
 
 logger.loglevel      = logger.levels.WARN;
@@ -282,6 +283,10 @@ logger.log_if_level = (level, key, plugin) => function () {
             logger.format === logger.formats.LOGFMT && data.constructor === Object) {
             logobj = Object.assign(logobj, data);
         }
+        else if (
+            logger.format === logger.formats.JSON && data.constructor === Object) {
+            logobj = Object.assign(logobj, data);
+        }
         else if (typeof data === 'object' && Object.prototype.hasOwnProperty.call(data, "uuid")) {
             logobj.uuid = data.uuid;
         }
@@ -298,6 +303,12 @@ logger.log_if_level = (level, key, plugin) => function () {
             logger.log(
                 level,
                 stringify(logobj)
+            );
+            return true;
+        case logger.formats.JSON:
+            logger.log(
+                level,
+                JSON.stringify(logobj)
             );
             return true;
         case logger.formats.DEFAULT:

--- a/tests/logger.js
+++ b/tests/logger.js
@@ -46,7 +46,23 @@ exports.log = {
         test.equal(1, this.logger.deferred_logs.length);
         test.done();
     },
-    'log in logfmt w/deffered' (test) {
+    'log in logfmt w/deferred' (test) {
+        test.expect(1);
+        this.logger.plugins = { plugin_list: true };
+        this.logger.deferred_logs.push( { level: 'INFO', data: 'log test info'} );
+        test.ok(this.logger.log('INFO', 'another test info'));
+        test.done();
+    },
+    'log in json' (test) {
+        this.logger.deferred_logs = [];
+        test.expect(3);
+        this.logger.format = this.logger.formats.JSON;
+        test.equal(0, this.logger.deferred_logs.length);
+        test.ok(this.logger.log('WARN','test warning'));
+        test.equal(1, this.logger.deferred_logs.length);
+        test.done();
+    },
+    'log in json w/deferred' (test) {
         test.expect(1);
         this.logger.plugins = { plugin_list: true };
         this.logger.deferred_logs.push( { level: 'INFO', data: 'log test info'} );
@@ -81,6 +97,13 @@ exports.set_format = {
         this.logger.format = '';
         this.logger.set_format('LOGFMT');
         test.equal(this.logger.format, this.logger.formats.LOGFMT);
+        test.done();
+    },
+    'set format to JSON' (test) {
+        test.expect(1);
+        this.logger.format = '';
+        this.logger.set_format('JSON');
+        test.equal(this.logger.format, this.logger.formats.JSON);
         test.done();
     },
     'set format to DEFAULT if empty' (test) {


### PR DESCRIPTION
Fixes #?

Changes proposed in this pull request:
- Add a JSON format for logging

About the tests, I've basically copied what was there for `logfmt`, if some more comprehensive testing is needed, please let me know and I'll improve them.

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated