### PR TITLE
remove max_unrecognized_commands from config

### DIFF
--- a/config/plugins
+++ b/config/plugins
@@ -68,7 +68,4 @@ data.headers
 # Queue mail via smtp - see config/smtp_forward.ini for where your mail goes
 queue/smtp_forward
 
-# Disconnect client if they spew bad SMTP commands at us
-max_unrecognized_commands
-
 #watch


### PR DESCRIPTION
It was subsumed into the [limit](https://github.com/haraka/haraka-plugin-limit) plugin.

Related to #2746 

