### PR TITLE
Fix mkdirp to use promise api

### DIFF
--- a/plugins/queue/quarantine.js
+++ b/plugins/queue/quarantine.js
@@ -109,7 +109,7 @@ exports.quarantine = function (next, connection) {
     // remove the temporary file to guarantee a complete file in the
     // final destination.
     mkdirp(msg_dir)
-        .catch(err => { 
+        .catch(err => {
             connection.logerror(plugin, `Error creating directory: ${msg_dir}`);
             next();
         })
@@ -140,6 +140,6 @@ exports.quarantine = function (next, connection) {
                     return next(action);
                 });
             });
-            txn.message_stream.pipe(ws, { line_endings: '\n' });   
-        }); 
+            txn.message_stream.pipe(ws, { line_endings: '\n' });
+        });
 }

--- a/plugins/queue/quarantine.js
+++ b/plugins/queue/quarantine.js
@@ -108,38 +108,38 @@ exports.quarantine = function (next, connection) {
     // successful we hardlink the file to the final destination and then
     // remove the temporary file to guarantee a complete file in the
     // final destination.
-    mkdirp(msg_dir, error => {
-        if (error) {
+    mkdirp(msg_dir)
+        .catch(err => { 
             connection.logerror(plugin, `Error creating directory: ${msg_dir}`);
-            return next();
-        }
+            next();
+        })
+        .then(ok => {
+            const ws = fs.createWriteStream(tmp_path);
 
-        const ws = fs.createWriteStream(tmp_path);
-
-        ws.on('error', err => {
-            connection.logerror(plugin, `Error writing quarantine file: ${err.message}`);
-            return next();
-        });
-        ws.on('close', () => {
-            fs.link(tmp_path, msg_path, err => {
-                if (err) {
-                    connection.logerror(plugin, `Error writing quarantine file: ${err}`);
-                }
-                else {
-                    // Add a note to where we stored the message
-                    txn.notes.quarantined = msg_path;
-                    txn.results.add(plugin, { pass: msg_path, emit: true });
-                    // Now delete the temporary file
-                    fs.unlink(tmp_path, () => {});
-                }
-                // Using notes.quarantine_action to decide what to do after the message is quarantined.
-                // Format can be either action = [ code, msg ] or action = code
-                const action = (connection.notes.quarantine_action || txn.notes.quarantine_action);
-                if (!action) return next();
-                if (Array.isArray(action)) return next(action[0], action[1]);
-                return next(action);
+            ws.on('error', err => {
+                connection.logerror(plugin, `Error writing quarantine file: ${err.message}`);
+                return next();
             });
-        });
-        txn.message_stream.pipe(ws, { line_endings: '\n' });
-    });
+            ws.on('close', () => {
+                fs.link(tmp_path, msg_path, err => {
+                    if (err) {
+                        connection.logerror(plugin, `Error writing quarantine file: ${err}`);
+                    }
+                    else {
+                        // Add a note to where we stored the message
+                        txn.notes.quarantined = msg_path;
+                        txn.results.add(plugin, { pass: msg_path, emit: true });
+                        // Now delete the temporary file
+                        fs.unlink(tmp_path, () => {});
+                    }
+                    // Using notes.quarantine_action to decide what to do after the message is quarantined.
+                    // Format can be either action = [ code, msg ] or action = code
+                    const action = (connection.notes.quarantine_action || txn.notes.quarantine_action);
+                    if (!action) return next();
+                    if (Array.isArray(action)) return next(action[0], action[1]);
+                    return next(action);
+                });
+            });
+            txn.message_stream.pipe(ws, { line_endings: '\n' });   
+        }); 
 }

--- a/plugins/queue/quarantine.js
+++ b/plugins/queue/quarantine.js
@@ -72,13 +72,10 @@ exports.get_base_dir = function () {
 exports.init_quarantine_dir = function (done) {
     const plugin = this;
     const tmp_dir = path.join(plugin.get_base_dir(), 'tmp');
-    mkdirp(tmp_dir, err => {
-        if (err) {
-            plugin.logerror(`Unable to create ${tmp_dir}`);
-        }
-        plugin.loginfo(`created ${tmp_dir}`);
-        done();
-    });
+    mkdirp(tmp_dir)
+        .then(made => plugin.loginfo(`created ${tmp_dir}`))
+        .catch(err => plugin.logerror(`Unable to create ${tmp_dir}`))
+        .finally(done);
 }
 
 exports.quarantine = function (next, connection) {


### PR DESCRIPTION
Fixing error caused by upgrade to latest mkdirp:
```
Plugin queue/quarantine failed: TypeError: invalid options argument
2020-02-11 10:40:58.367367500      at optsArg (/usr/lib/node_modules/Haraka/node_modules/mkdirp/lib/opts-arg.js:13:11)
2020-02-11 10:40:58.367368500      at mkdirp (/usr/lib/node_modules/Haraka/node_modules/mkdirp/index.js:11:10)
2020-02-11 10:40:58.367369500      at Plugin.exports.init_quarantine_dir (/usr/lib/node_modules/Haraka/plugins/queue/quarantine.js:75:5)
2020-02-11 10:40:58.367370500      at Plugin.exports.hook_init_master (/usr/lib/node_modules/Haraka/plugins/queue/quarantine.js:17:10)
2020-02-11 10:40:58.367370500      at Object.plugins.run_next_hook (/usr/lib/node_modules/Haraka/plugins.js:535:28)
2020-02-11 10:40:58.367371500      at callback (/usr/lib/node_modules/Haraka/plugins.js:493:32)
2020-02-11 10:40:58.367372500      at /usr/lib/node_modules/Haraka/plugins/attachment.js:76:16
2020-02-11 10:40:58.367373500      at /usr/lib/node_modules/Haraka/plugins/attachment.js:55:28
2020-02-11 10:40:58.367373500      at FSReqCallback.oncomplete (fs.js:158:21)
```