### PR TITLE
Allow web interface to be bound to a unix socket

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@
 * connection_close_message: added ability to override close connection message replacing `closing connection. Have a jolly good day.`
 * tls: add configurable minVersion to tls socket options
 * add JSON format for logging
+* support binding web interface to unix socket
 
 ### Fixes
 

--- a/config/http.ini
+++ b/config/http.ini
@@ -3,5 +3,9 @@
 ; default: [::]:80 (port 80 on all IPv4 and IPv6 addresses)
 ; listen=[::]:80
 
+; listen can also be a unix socket path, with an optional 3-digit permission mask
+; e.g. listen=/path/to/some.sock or listen=/path/to/some.sock:777
+; if no mask is specified, the default permissions are determined by the umask.
+
 ; docroot: the directory where web content is served from
 ;docroot=/usr/local/haraka/html

--- a/endpoint.js
+++ b/endpoint.js
@@ -1,0 +1,66 @@
+'use strict';
+// Socket address parser/formatter and server binding helper
+
+const fs = require('fs');
+const sockaddr = require('sockaddr');
+
+module.exports = function endpoint (addr, defaultPort) {
+    try {
+        if ('string' === typeof addr || 'number' === typeof addr) {
+            addr = sockaddr(addr, {defaultPort});
+            const match = /^(.*):([0-7]{3})$/.exec(addr.path || '');
+            if (match) {
+                addr.path = match[1];
+                addr.mode = match[2];
+            }
+        }
+    }
+    catch (err) {
+        // Return the parse exception instead of throwing it
+        return err;
+    }
+    return new Endpoint(addr);
+}
+
+class Endpoint {
+
+    constructor (addr) {
+        if (addr.path) {
+            this.path = addr.path;
+            if (addr.mode) this.mode = addr.mode;
+        }
+        else {
+            // Handle server.address() return as well as parsed host/port
+            const host = addr.address || addr.host || '::0';
+            // Normalize '::' to '::0'
+            this.host = ('::' === host) ? '::0' : host ;
+            this.port = parseInt(addr.port, 10);
+        }
+    }
+
+    toString () {
+        if (this.mode) return `${this.path}:${this.mode}`;
+        if (this.path) return this.path;
+        if (this.host.indexOf(':') >= 0) return `[${this.host}]:${this.port}`;
+        return `${this.host}:${this.port}`;
+    }
+
+    // Make server listen on this endpoint, w/optional options
+    bind (server, opts) {
+        let done;
+        opts = Object.assign({}, opts || {});
+        if (this.path) {
+            const path = opts.path = this.path;
+            const mode = this.mode ? parseInt(this.mode, 8) : false;
+            if (mode) {
+                done = () => fs.chmodSync(path, mode);
+            }
+            if (fs.existsSync(path)) fs.unlinkSync(path);
+        }
+        else {
+            opts.host = this.host;
+            opts.port = this.port;
+        }
+        server.listen(opts, done);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "haraka-tld"            : "*",
     "haraka-utils"          : "*",
     "mkdirp"                : "~1.0.0",
-    "openssl-wrapper"       : "^0.3.4"
+    "openssl-wrapper"       : "^0.3.4",
+    "sockaddr"              : "^1.0.1"
   },
   "optionalDependencies": {
     "haraka-plugin-access"  : "*",
@@ -68,6 +69,7 @@
   "devDependencies": {
     "nodeunit"              : "*",
     "haraka-test-fixtures"  : ">=1.0.27",
+    "mock-require"          : "^3.0.3",
     "eslint"                : ">=6",
     "eslint-plugin-haraka"  : "*",
     "nodemailer"            : "6.2.1"

--- a/tests/endpoint.js
+++ b/tests/endpoint.js
@@ -1,0 +1,128 @@
+const mock = require('mock-require');
+const endpoint = require('../endpoint');
+
+module.exports = {
+
+    'Endpoint toString()' (test) {
+        test.expect(5);
+        test.equal( endpoint(25),                         '[::0]:25' );
+        test.equal( endpoint('10.0.0.3', 42),             '10.0.0.3:42' );
+        test.equal( endpoint('/foo/bar.sock'),            '/foo/bar.sock' );
+        test.equal( endpoint('/foo/bar.sock:770'),        '/foo/bar.sock:770' );
+        test.equal( endpoint({address: '::0', port: 80}), '[::0]:80' );
+        test.done();
+    },
+
+    'Endpoint parse': {
+        'Number as port' (test) {
+            test.expect(1);
+            test.deepEqual( endpoint(25), {host:'::0', port:25} );
+            test.done();
+        },
+        'Default port if only host' (test) {
+            test.expect(1);
+            test.deepEqual( endpoint('10.0.0.3', 42), {host:'10.0.0.3', port:42} );
+            test.done();
+        },
+        'Unix socket' (test) {
+            test.expect(1);
+            test.deepEqual( endpoint('/foo/bar.sock'), {path:'/foo/bar.sock'} );
+            test.done();
+        },
+        'Unix socket w/mode' (test) {
+            test.expect(1);
+            test.deepEqual( endpoint('/foo/bar.sock:770'), {path:'/foo/bar.sock', mode:'770'} );
+            test.done();
+        },
+    },
+
+    'Endpoint bind()': {
+        setUp (done) {
+            // Mock filesystem and log server + fs method calls
+            const modes = this.modes = {}
+            const log = this.log = []
+
+            this.server = {
+                listen (opts, cb) {
+                    log.push(['listen', opts]);
+                    if (cb) cb();
+                }
+            }
+
+            this.mockfs = {
+                existsSync (path, ...args) {
+                    log.push(['existsSync', path, ...args]);
+                    return ('undefined' !== typeof modes[path]);
+                },
+                chmodSync (path, mode, ...args) {
+                    log.push(['chmodSync', path, mode, ...args]);
+                    modes[path] = mode;
+                },
+                unlinkSync (path, ...args) {
+                    log.push(['unlinkSync', path, ...args]);
+                    if ('undefined' !== typeof modes[path]) {
+                        delete modes[path];
+                    }
+                    else {
+                        log.push(['unlink without existing socket']);
+                    }
+                },
+            };
+
+            mock('fs', this.mockfs);
+            this.endpoint = mock.reRequire('../endpoint');
+            done();
+        },
+
+        tearDown (done) {
+            mock.stop('fs');
+            done();
+        },
+
+        'IP socket' (test) {
+            test.expect(1);
+            this.endpoint('10.0.0.3:42').bind(this.server, {backlog:19});
+            test.deepEqual(
+                this.log, [
+                    ['listen', {host: '10.0.0.3', port: 42, backlog: 19}],
+                ]);
+            test.done();
+        },
+
+        'Unix socket' (test) {
+            test.expect(1);
+            this.endpoint('/foo/bar.sock').bind(this.server, {readableAll:true});
+            test.deepEqual(
+                this.log, [
+                    ['existsSync', '/foo/bar.sock'],
+                    ['listen', {path: '/foo/bar.sock', readableAll: true}],
+                ]);
+            test.done();
+        },
+
+        'Unix socket (pre-existing)' (test) {
+            test.expect(1);
+            this.modes['/foo/bar.sock'] = 0o755;
+            this.endpoint('/foo/bar.sock').bind(this.server);
+            test.deepEqual(
+                this.log, [
+                    ['existsSync', '/foo/bar.sock'],
+                    ['unlinkSync', '/foo/bar.sock'],
+                    ['listen', {path: '/foo/bar.sock'}],
+                ]);
+            test.done();
+        },
+
+        'Unix socket w/mode' (test) {
+            test.expect(1);
+            this.endpoint('/foo/bar.sock:764').bind(this.server);
+            test.deepEqual(
+                this.log, [
+                    ['existsSync', '/foo/bar.sock'],
+                    ['listen', {path: '/foo/bar.sock'}],
+                    ['chmodSync', '/foo/bar.sock', 0o764],
+                ]);
+            test.done();
+        },
+    },
+}

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const endpoint = require('../endpoint');
 
 function _set_up (done) {
 
@@ -100,7 +101,7 @@ exports.get_smtp_server = {
         this.server.load_default_tls_config(() => done());
     },
     'gets a net server object' (test) {
-        this.server.get_smtp_server('0.0.0.0', 2501, 10, (server) => {
+        this.server.get_smtp_server(endpoint('0.0.0.0:2501'), 10, (server) => {
             if (!server) {
                 console.error('unable to bind to 0.0.0.0:2501');
                 // test.expect(0);
@@ -120,7 +121,7 @@ exports.get_smtp_server = {
     },
     'gets a TLS net server object' (test) {
         this.server.cfg.main.smtps_port = 2502;
-        this.server.get_smtp_server('0.0.0.0', 2502, 10, (server) => {
+        this.server.get_smtp_server(endpoint('0.0.0.0:2502'), 10, (server) => {
             if (!server) {
                 console.error('unable to bind to 0.0.0.0:2502');
                 // test.expect(0);


### PR DESCRIPTION
Changes proposed in this pull request:

To better support embedded use of Haraka, this change adds support for specifying listener addresses as /path/to/some.sock[:mode], where `mode` is an optional octal permissions spec for chmod.  Removal of an existing socket is handled automatically.

This change also consolidates listening-endpoint address parsing and formatting to a single class, removing duplicated code and simplifying the setup of servers.

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
