### PR TITLE
Fix connection pool not being unique when hosts and ports were equal between domains

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -19,6 +19,7 @@
 
 * TLS: don't abort loading certs in config/tls dir when an error is encountered.
   Process every cert file and then emit errors. #2729
+* fix connection pool not being unique when hosts and ports were equal between domains #2788
 
 
 ## 2.8.25 - 2019-10-11

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -295,7 +295,8 @@ exports.get_pool = (server, port, host, cfg) => {
     if (cfg === undefined) cfg = {};
     const connect_timeout = cfg.connect_timeout || 30;
     const pool_timeout = cfg.pool_timeout || cfg.timeout || 300;
-    const name = `${port}:${host}:${pool_timeout}`;
+    const auth_user = cfg.auth_user || 'no_user';
+    const name = `${port}:${host}:${pool_timeout}:${auth_user}`;
     if (!server.notes.pool) server.notes.pool = {};
     if (server.notes.pool[name]) return server.notes.pool[name];
 

--- a/tests/smtp_client/auth.js
+++ b/tests/smtp_client/auth.js
@@ -4,7 +4,7 @@ test.expect(22);
 const server = {notes: {}};
 
 exports.get_pool(server);
-const pool_name = '25:localhost:300';
+const pool_name = '25:localhost:300:no_user';
 test.equals(1, Object.keys(server.notes.pool).length);
 test.equals(pool_name, Object.keys(server.notes.pool)[0]);
 test.equals(0, server.notes.pool[pool_name].getPoolSize());

--- a/tests/smtp_client/basic.js
+++ b/tests/smtp_client/basic.js
@@ -4,7 +4,7 @@ test.expect(21);
 const server = {notes: {}};
 
 exports.get_pool(server);
-const pool_name = '25:localhost:300';
+const pool_name = '25:localhost:300:no_user';
 test.equals(1, Object.keys(server.notes.pool).length);
 test.equals(pool_name, Object.keys(server.notes.pool)[0]);
 test.equals(0, server.notes.pool[pool_name].getPoolSize());


### PR DESCRIPTION
Fixes #2788

Changes proposed in this pull request:
- As discussed in the issue, the usage of the account user will now be used as well to identify a pool.

Checklist:
- [x] docs updated (no need)
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
