### PR TITLE
STARTTLS "TLS NO-GO" improvements

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -7,6 +7,7 @@
 * restore TLS version info, set correctly #2723
 * fix broken bannering on nested mime parts #2736
 * better error message when invalid HELO hostname is rejected
+* bring STARTTLS "TLS NO-GO" feature in line with Outbound's
 
 ### New features
 

--- a/config/tls.ini
+++ b/config/tls.ini
@@ -42,8 +42,11 @@
 ; host = 127.0.0.1
 ; "TLS NO-GO" db
 ; db = 3
-; Expiry time in seconds
+; TLS NO-GO Expiry time in seconds
 ; disable_expiry = 604800
+
+; TLS NO-GO Inbound expiry time in seconds
+; disable_inbound_expiry = 3600
 
 ; no_tls_hosts - disable TLS for servers with broken TLS. (applies to inbound only)
 [no_tls_hosts]

--- a/docs/plugins/tls.md
+++ b/docs/plugins/tls.md
@@ -178,3 +178,13 @@ mail, put them under an `[inbound]` parameter group. Outbound options
 can go under an `[outbound]` parameter group, and plugins that use
 SMTP tls for queueing such as `smtp_proxy` and `smtp_forward` can
 use that plugin name for plugin specific options.
+
+## `[redis]` section
+
+This section is mainly used to enable so called _TLS NO-GO_ feature that essentially stops advertising/using TLS if there was a problem setting it up previously. We use `no_tls|ip.add.re.ss` key to store the flag in redis. There are a couple of settings that control the behavior:
+
+`disable_for_failed_hosts = true` to enable the feature
+
+`disable_expiry = 604800` to set for how long we disable TLS for failing host, in seconds
+
+`disable_inbound_expiry = 3600` same as above, but applies to inbound (aka STARTTLS capability) only

--- a/outbound/tls.js
+++ b/outbound/tls.js
@@ -95,7 +95,7 @@ class OutboundTLS {
 
         logger.lognotice(obtls, `TLS connection failed. Marking ${host} as non-TLS for ${expiry} seconds`);
 
-        obtls.db.setex(dbkey, expiry, new Date(), (err, dbr) => {
+        obtls.db.setex(dbkey, expiry, (new Date()).toISOString(), (err, dbr) => {
             if (err) logger.logerror(obtls, `Redis returned error: ${err}`);
             cb();
         });


### PR DESCRIPTION
Right now, when there's a STARTTLS failure, we note the host in redis. It connects again and we skip the STARTTLS capability in addition to clearing the `no_tls` flag in redis. Which means next time it connects, STARTTLS is advertised again and the process repeats. 

There are 2 downsides to this:
* client on win7 (tlsv1.0) connecting to nodejs >11 (min tlsv1.2 unless passed a CLI flag) will get a failure, then no STARTTLS cap (and essentially an error on the client because of missing STARTTLS cap), then rinse and repeat...
* the `no_tls|1.2.3.4` flag in redis never expires and this has potential to clash with outbound's TLS NO-GO feature where we mark remote host as TLS NO-GO for `tls.ini/redis.disable_expiry` secs. 

My proposal is to align STARTTLS with Outbound TLS blackout code. Another config param is introduced, `disable_inbound_expiry` that will "blackout" STARTTLS for remote host for that many seconds.

Checklist:
- [x] docs updated
- [?] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
