### PR TITLE
smtp_forward: remove redundant outbound hook

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -21,7 +21,7 @@
 * TLS: don't abort loading certs in config/tls dir when an error is encountered.
   Process every cert file and then emit errors. #2729
 * fix connection pool not being unique when hosts and ports were equal between domains #2788
-
+* smtp_forward: this plugin does not use the queue_outbound hook anymore #2795
 
 ## 2.8.25 - 2019-10-11
 

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -26,9 +26,7 @@ exports.register = function () {
 
     plugin.register_hook('queue', 'queue_forward');
 
-    plugin.register_hook('queue_outbound', 'queue_forward');
-
-    plugin.register_hook('get_mx', 'get_mx');
+    plugin.register_hook('get_mx', 'get_mx'); // for relaying outbound messages
 }
 
 exports.load_smtp_forward_ini = function () {


### PR DESCRIPTION
Fixes #2795

Fixes #

Changes proposed in this pull request:
- Remove the redundant use of outbound hook

Checklist:
- [X ] docs updated
- [X ] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
