### PR TITLE
use node v10's mkdir instead of mkdirp

### DIFF
--- a/bin/haraka
+++ b/bin/haraka
@@ -10,7 +10,6 @@ const nopt = require('nopt');
 const path = require('path');
 const os   = require('os');
 
-const mkdirp  = require('mkdirp');
 const utils   = require('haraka-utils');
 const sprintf = require('sprintf-js').sprintf;
 const base = path.join(__dirname, '..');
@@ -136,8 +135,8 @@ function mkDir (dstPath) {
     catch (ignore) {}
 
     try {
-        mkdirp.sync(dstPath);
-        create(dstPath)
+        fs.mkdirSync(dstPath, { recursive: true });
+        create(dstPath);
     }
     catch (e) {
         // File exists

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "haraka-results"        : "^2.0.0",
     "haraka-tld"            : "*",
     "haraka-utils"          : "*",
-    "mkdirp"                : "~1.0.0",
     "openssl-wrapper"       : "^0.3.4",
     "sockaddr"              : "^1.0.1"
   },

--- a/plugins/queue/quarantine.js
+++ b/plugins/queue/quarantine.js
@@ -1,7 +1,6 @@
 // quarantine
 
 const fs   = require('fs');
-const mkdirp = require('mkdirp');
 const path = require('path');
 
 exports.register = function () {
@@ -72,7 +71,7 @@ exports.get_base_dir = function () {
 exports.init_quarantine_dir = function (done) {
     const plugin = this;
     const tmp_dir = path.join(plugin.get_base_dir(), 'tmp');
-    mkdirp(tmp_dir)
+    fs.promises.mkdir(tmp_dir, { recursive: true })
         .then(made => plugin.loginfo(`created ${tmp_dir}`))
         .catch(err => plugin.logerror(`Unable to create ${tmp_dir}`))
         .finally(done);
@@ -108,7 +107,7 @@ exports.quarantine = function (next, connection) {
     // successful we hardlink the file to the final destination and then
     // remove the temporary file to guarantee a complete file in the
     // final destination.
-    mkdirp(msg_dir)
+    fs.promises.mkdir(msg_dir, { recursive: true })
         .catch(err => {
             connection.logerror(plugin, `Error creating directory: ${msg_dir}`);
             next();


### PR DESCRIPTION
Just a suggestion.

Changes proposed in this pull request:
- use node v10's `fs.mkdir` rather than dependening on `mkdirp`

Checklist:
- **N/A** [ ] docs updated
- **N/A** [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
