### PR TITLE
Prevent node crash with zero byte file

### DIFF
--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -93,6 +93,11 @@ class HMailItem extends events.EventEmitter {
                 this.temp_fail(errMsg);
                 return
             }
+            
+            if (bytes.length === 0) {
+                this.logerror(`Error reading queue file ${this.filename}: no bytes read`);
+                return
+            }
 
             const todo_len = bytes.readUInt32BE(0);
             this.logdebug(`todo header length: ${todo_len}`);


### PR DESCRIPTION
When there is 0 byte file in queue it causes terrible node.js crash with ERR_BUFFER_OUT_OF_BOUNDS message
