### PR TITLE
Update hmail.js

### DIFF
--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -582,7 +582,7 @@ class HMailItem extends events.EventEmitter {
                 () => { // Clear to GO
                     self.logdebug(`Trying TLS for domain: ${self.todo.domain}, host: ${host}`);
 
-                    socket.on('secure', () => {
+                    socket.once('secure', () => {
                         // Set this flag so we don't try STARTTLS again if it
                         // is incorrectly offered at EHLO once we are secured.
                         secured = true;


### PR DESCRIPTION
(running Node v12.18.4 and Haraka master branch)

My autobuild started to fail without any code change in special case when email is forced through smarthost and that smarthost should deliver to target location. Haraka here acts as smarthost and only in that case Haraka emits twice EHLOs and then communication will start to loose continuity like that:

```
2020-09-21T12:23:16.715Z [1] [PROTOCOL] [outbound] C: STARTTLS
2020-09-21T12:23:16.716Z [1] [PROTOCOL] [outbound] S: 220 Go ahead.\r\n
2020-09-21T12:23:16.728Z [1] [INFO] [outbound] secured verified=false cipher=ECDHE-RSA-AES128-GCM-SHA256 version=TLSv1.2 error=CERT_HAS_EXPIRED cn=server organization=QSMTPD issuer=QSMTPD expires="Sep 17 08:11:42 2020 GMT" fingerprint=D7:7D:DB:97:67:B0:C7:76:0E:A3:AA:0E:51:5B:9D:BA:F4:68:4B:63

2020-09-21T12:23:16.728Z [1] [PROTOCOL] [outbound] C: EHLO mail.server-2.com
2020-09-21T12:23:16.728Z [1] [PROTOCOL] [outbound] C: EHLO mail.server-2.com
2020-09-21T12:23:16.746Z [1] [PROTOCOL] [outbound] S: 250-mail.server-3.com Hello pro.server-2.com.pro_mynet [172.22.0.20], Server is at your service\r\n
2020-09-21T12:23:16.746Z [1] [PROTOCOL] [outbound] S: 250-PIPELINING\r\n
2020-09-21T12:23:16.746Z [1] [PROTOCOL] [outbound] S: 250-8BITMIME\r\n
2020-09-21T12:23:16.746Z [1] [PROTOCOL] [outbound] S: 250-SMTPUTF8\r\n
2020-09-21T12:23:16.746Z [1] [PROTOCOL] [outbound] S: 250-SIZE 26214400\r\n
2020-09-21T12:23:16.746Z [1] [PROTOCOL] [outbound] S: 250 AUTH PLAIN LOGIN\r\n

2020-09-21T12:23:16.746Z [1] [PROTOCOL] [outbound] C: MAIL FROM:<sourcesmtp2route621172996@server-1.com>
2020-09-21T12:23:16.770Z [1] [PROTOCOL] [outbound] S: 250-mail.server-3.com Hello pro.server-2.com.pro_mynet [172.22.0.20], Server is at your service\r\n
2020-09-21T12:23:16.771Z [1] [PROTOCOL] [outbound] S: 250-PIPELINING\r\n
2020-09-21T12:23:16.771Z [1] [PROTOCOL] [outbound] S: 250-8BITMIME\r\n
2020-09-21T12:23:16.771Z [1] [PROTOCOL] [outbound] S: 250-SMTPUTF8\r\n
2020-09-21T12:23:16.771Z [1] [PROTOCOL] [outbound] S: 250-SIZE 26214400\r\n
2020-09-21T12:23:16.771Z [1] [PROTOCOL] [outbound] S: 250 AUTH PLAIN LOGIN\r\n

2020-09-21T12:23:16.771Z [1] [PROTOCOL] [outbound] C: RCPT TO:<destinationsmtp2route621172996@server-3.com>
2020-09-21T12:23:16.797Z [1] [PROTOCOL] [outbound] S: 250 sender <sourcesmtp2route621172996@server-1.com> OK\r\n

2020-09-21T12:23:16.797Z [1] [PROTOCOL] [outbound] C: DATA
2020-09-21T12:23:16.802Z [1] [PROTOCOL] [outbound] S: 250 recipient <destinationsmtp2route621172996@server-3.com> OK\r\n
```

I suspect that some node internals has changed. Anyways changing "on" to "once" at secure listener fix this.
