### PR TITLE
replace perl haraka_grep with shell version

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+* hgrep: replaced perl script with shell script #2842
 * outbound: add os.hostname() as default for outbound HELO #2813
 * use node v10's mkdir instead of mkdirp #2797
 * CI: drop appveyor and Travis #2784

--- a/bin/haraka_grep
+++ b/bin/haraka_grep
@@ -1,17 +1,32 @@
-#!/usr/bin/perl -w
- 
-use strict;
-open(my $grep, "-|", "grep", @ARGV) || die $!;
-my %uuids;
-while (<$grep>) {
-    if (/^[^\[]*\[(\w+)\]\s+\[([A-F0-9-]+)(?:\.\d+)?\]/) {
-        $uuids{$2}++;
-    }
-}
-if (! scalar(keys(%uuids))) {
-    print "Not found\n";
-    exit(-1);
-}
-print "Looking for UUIDs: ", join(', ',keys(%uuids)), "\n";
-exec 'grep', '-E', '('.join('|',keys(%uuids)).')', $ARGV[-1];
+#!/bin/sh
 
+if [ -z $1 ]; then
+	echo "$0 email@example.com"
+	exit
+fi
+
+LOG="/var/log/maillog"
+UUIDS=$(grep $1 $LOG | awk '{ print $7 }' | cut -d. -f1 | cut -f2 -d[ | sort -u)
+echo $UUIDS
+
+ARCHIVES=0
+if [ -z $UUIDS ]; then
+	echo "no recent matches, checking archives"
+	UUIDS=$(/usr/bin/bzgrep $1 $LOG.?.bz2 | awk '{ print $7 }' | cut -d. -f1 | cut -f2 -d[ | sort -u)
+	ARCHIVES=1
+	#echo "$UUIDS"
+fi
+
+show_uuids()
+{
+	for u in $UUIDS
+	do
+		echo; echo
+		echo $u
+		grep $u $LOG
+		if [ "$ARCHIVES" = "1" ]; then
+			bzgrep $u $LOG.0.bz2
+		fi
+	done
+}
+show_uuids


### PR DESCRIPTION
perl version in the repo has no help and I couldn't easily deduce what it's expecting. This handy shell version works with modern Haraka logs, especially syslog, and doesn't require perl