### PR TITLE
connections: grab a ref, to assure it still exists later

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+* smtp_forward/spamssassin: grab refs of conn/txn to avoid crashing later due
+  to lack of existence. #2847
 * outbound: add os.hostname() as default for outbound HELO #2813
 * use node v10's mkdir instead of mkdirp #2797
 * CI: drop appveyor and Travis #2784

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -47,14 +47,17 @@ exports.load_spamassassin_ini = function () {
 
 exports.hook_data_post = function (next, connection) {
     const plugin = this;
-    if (plugin.msg_too_big(connection)) return next();
-    if (!plugin.should_check(connection)) return next();
+    const conn = connection;
+    const txn  = connection.transaction;
 
-    connection.transaction.remove_header(plugin.cfg.main.spamc_auth_header); // just to be safe
+    if (plugin.msg_too_big(conn)) return next();
+    if (!plugin.should_check(conn)) return next();
 
-    const username        = plugin.get_spamd_username(connection);
-    const headers         = plugin.get_spamd_headers(connection, username);
-    const socket          = plugin.get_spamd_socket(next, connection, headers);
+    txn.remove_header(plugin.cfg.main.spamc_auth_header); // just to be safe
+
+    const username        = plugin.get_spamd_username(conn);
+    const headers         = plugin.get_spamd_headers(conn, username);
+    const socket          = plugin.get_spamd_socket(next, conn, headers);
 
     const spamd_response = { headers: {} };
     let state = 'line0';
@@ -62,7 +65,7 @@ exports.hook_data_post = function (next, connection) {
     const start = Date.now();
 
     socket.on('line', line => {
-        connection.logprotocol(plugin, `Spamd C: ${line} state=${state}`);
+        conn.logprotocol(plugin, `Spamd C: ${line} state=${state}`);
         line = line.replace(/\r?\n/, '');
         if (state === 'line0') {
             spamd_response.line0 = line;
@@ -86,7 +89,7 @@ exports.hook_data_post = function (next, connection) {
         else if (state === 'headers') {
             const m = line.match(/^X-Spam-([\x21-\x39\x3B-\x7E]+):\s*(.*)/);
             if (m) {
-                connection.logdebug(plugin, `header: ${line}`);
+                conn.logdebug(plugin, `header: ${line}`);
                 last_header = m[1];
                 spamd_response.headers[m[1]] = m[2];
                 return;
@@ -101,8 +104,6 @@ exports.hook_data_post = function (next, connection) {
     });
 
     socket.once('end', () => {
-        // Abort if the transaction is gone
-        if (!connection.transaction) return next();
 
         if (spamd_response.headers && spamd_response.headers.Tests) {
             spamd_response.tests = spamd_response.headers.Tests.replace(/\s/g, '');
@@ -121,30 +122,30 @@ exports.hook_data_post = function (next, connection) {
         }
 
         // do stuff with the results...
-        connection.transaction.notes.spamassassin = spamd_response;
-        connection.results.add(plugin, {
+        txn.notes.spamassassin = spamd_response;
+        conn.results.add(plugin, {
             time: (Date.now() - start)/1000,
             hits: spamd_response.hits,
             flag: spamd_response.flag,
         });
 
-        plugin.fixup_old_headers(connection.transaction);
-        plugin.do_header_updates(connection, spamd_response);
-        plugin.log_results(connection, spamd_response);
+        plugin.fixup_old_headers(txn);
+        plugin.do_header_updates(conn, spamd_response);
+        plugin.log_results(conn, spamd_response);
 
-        const exceeds_err = plugin.score_too_high(connection, spamd_response);
+        const exceeds_err = plugin.score_too_high(conn, spamd_response);
         if (exceeds_err) return next(DENY, exceeds_err);
 
-        plugin.munge_subject(connection, spamd_response.score);
+        plugin.munge_subject(conn, spamd_response.score);
 
         next();
     });
 }
 
-exports.fixup_old_headers = function (transaction) {
+exports.fixup_old_headers = function (txn) {
     const plugin = this;
     const action = plugin.cfg.main.old_headers_action;
-    const headers = transaction.notes.spamassassin.headers;
+    const headers = txn.notes.spamassassin.headers;
 
     let key;
     switch (action) {
@@ -153,7 +154,7 @@ exports.fixup_old_headers = function (transaction) {
         case "drop":
             for (key in headers) {
                 if (!key) continue;
-                transaction.remove_header(`X-Spam-${key}`);
+                txn.remove_header(`X-Spam-${key}`);
             }
             break;
         // case 'rename':
@@ -161,37 +162,37 @@ exports.fixup_old_headers = function (transaction) {
             for (key in headers) {
                 if (!key) continue;
                 key = `X-Spam-${key}`;
-                const old_val = transaction.header.get(key);
-                transaction.remove_header(key);
+                const old_val = txn.header.get(key);
+                txn.remove_header(key);
                 if (old_val) {
                     // plugin.logdebug(plugin, `header: ${key}, ${old_val}`);
-                    transaction.add_header(key.replace(/^X-/, 'X-Old-'), old_val);
+                    txn.add_header(key.replace(/^X-/, 'X-Old-'), old_val);
                 }
             }
             break;
     }
 }
 
-exports.munge_subject = function (connection, score) {
+exports.munge_subject = function (conn, score) {
     const plugin = this;
     const munge = plugin.cfg.main.munge_subject_threshold;
     if (!munge) return;
     if (parseFloat(score) < parseFloat(munge)) return;
 
-    const subj = connection.transaction.header.get('Subject');
+    const subj = conn.transaction.header.get('Subject');
     const subject_re = new RegExp(`^${utils.regexp_escape(plugin.cfg.main.subject_prefix)}`);
     if (subject_re.test(subj)) return;    // prevent double munge
 
-    connection.transaction.remove_header('Subject');
-    connection.transaction.add_header('Subject', `${plugin.cfg.main.subject_prefix} ${subj}`);
+    conn.transaction.remove_header('Subject');
+    conn.transaction.add_header('Subject', `${plugin.cfg.main.subject_prefix} ${subj}`);
 }
 
-exports.do_header_updates = function (connection, spamd_response) {
+exports.do_header_updates = function (conn, spamd_response) {
     const plugin = this;
     if (spamd_response.flag === 'Yes') {
         // X-Spam-Flag is added by SpamAssassin
-        connection.transaction.remove_header('precedence');
-        connection.transaction.add_header('Precedence', 'junk');
+        conn.transaction.remove_header('precedence');
+        conn.transaction.add_header('Precedence', 'junk');
     }
 
     const modern = plugin.cfg.main.modern_status_syntax;
@@ -204,18 +205,18 @@ exports.do_header_updates = function (connection, spamd_response) {
 
         if (key === 'Status' && !modern) {
             const legacy = spamd_response.headers[key].replace(/ score=/,' hits=');
-            connection.transaction.add_header('X-Spam-Status', legacy);
+            conn.transaction.add_header('X-Spam-Status', legacy);
             continue;
         }
         if (val === '') continue;
-        connection.transaction.add_header(`X-Spam-${key}`, val);
+        conn.transaction.add_header(`X-Spam-${key}`, val);
     }
 }
 
-exports.score_too_high = function (connection, spamd_response) {
+exports.score_too_high = function (conn, spamd_response) {
     const plugin = this;
     const score = spamd_response.score;
-    if (connection.relaying) {
+    if (conn.relaying) {
         const rmax = plugin.cfg.main.relay_reject_threshold;
         if (rmax && (score >= rmax)) {
             return "spam score exceeded relay threshold";
@@ -230,10 +231,10 @@ exports.score_too_high = function (connection, spamd_response) {
     return false;
 }
 
-exports.get_spamd_username = function (connection) {
+exports.get_spamd_username = function (conn) {
     const plugin = this;
 
-    let user = connection.transaction.notes.spamd_user;  // 1st priority
+    let user = conn.transaction.notes.spamd_user;  // 1st priority
     if (user && user !== undefined) return user;
 
     if (!plugin.cfg.main.spamd_user) return 'default';   // when not defined
@@ -241,7 +242,7 @@ exports.get_spamd_username = function (connection) {
 
     // Enable per-user SA prefs
     if (user === 'first-recipient') {                // special cases
-        return connection.transaction.rcpt_to[0].address();
+        return conn.transaction.rcpt_to[0].address();
     }
     if (user === 'all-recipients') {
         throw "Unimplemented";
@@ -253,24 +254,24 @@ exports.get_spamd_username = function (connection) {
     return user;
 }
 
-exports.get_spamd_headers = function (connection, username) {
+exports.get_spamd_headers = function (conn, username) {
     const plugin = this;
     // http://svn.apache.org/repos/asf/spamassassin/trunk/spamd/PROTOCOL
     const headers = [
         'HEADERS SPAMC/1.4',
         `User: ${username}`,
         '',
-        `X-Envelope-From: ${connection.transaction.mail_from.address()}`,
-        `X-Haraka-UUID: ${connection.transaction.uuid}`,
+        `X-Envelope-From: ${conn.transaction.mail_from.address()}`,
+        `X-Haraka-UUID: ${conn.transaction.uuid}`,
     ];
-    if (connection.relaying) {
+    if (conn.relaying) {
         headers.push(`${plugin.cfg.main.spamc_auth_header}: true`);
     }
 
     return headers;
 }
 
-exports.get_spamd_socket = function (next, connection, headers) {
+exports.get_spamd_socket = function (next, conn, headers) {
     const plugin = this;
     // TODO: support multiple spamd backends
 
@@ -280,8 +281,8 @@ exports.get_spamd_socket = function (next, connection, headers) {
 
     socket.on('connect', function () {
         // Abort if the transaction is gone
-        if (!connection.transaction) {
-            plugin.logwarn(connection, 'Transaction gone, cancelling SPAMD connection');
+        if (!conn.transaction) {
+            plugin.logwarn(conn, 'Transaction gone, cancelling SPAMD connection');
             socket.end();
             return;
         }
@@ -290,11 +291,11 @@ exports.get_spamd_socket = function (next, connection, headers) {
         // Reset timeout
         this.setTimeout(results_timeout * 1000);
         socket.write(`${headers.join("\r\n")}\r\n`);
-        connection.transaction.message_stream.pipe(socket);
+        conn.transaction.message_stream.pipe(socket);
     });
 
     socket.on('error', err => {
-        connection.logerror(plugin, `connection failed: ${err}`);
+        conn.logerror(plugin, `connection failed: ${err}`);
         // TODO: optionally DENYSOFT
         // TODO: add a transaction note
         return next();
@@ -302,10 +303,10 @@ exports.get_spamd_socket = function (next, connection, headers) {
 
     socket.on('timeout', function () {
         if (!this.is_connected) {
-            connection.logerror(plugin, 'spamd connection timed out');
+            conn.logerror(plugin, 'spamd connection timed out');
         }
         else {
-            connection.logerror(plugin, 'timeout waiting for results');
+            conn.logerror(plugin, 'timeout waiting for results');
         }
         socket.end();
         return next();
@@ -325,22 +326,22 @@ exports.get_spamd_socket = function (next, connection, headers) {
     return socket;
 }
 
-exports.msg_too_big = function (connection) {
+exports.msg_too_big = function (conn) {
     const plugin = this;
     if (!plugin.cfg.main.max_size) return false;
 
-    const size = connection.transaction.data_bytes;
+    const size = conn.transaction.data_bytes;
 
     const max = plugin.cfg.main.max_size;
     if (size <= max) { return false; }
-    connection.loginfo(plugin, `skipping, size ${utils.prettySize(size)} exceeds max: ${utils.prettySize(max)}`);
+    conn.loginfo(plugin, `skipping, size ${utils.prettySize(size)} exceeds max: ${utils.prettySize(max)}`);
     return true;
 }
 
-exports.log_results = function (connection, spamd_response) {
+exports.log_results = function (conn, spamd_response) {
     const plugin = this;
     const cfg = plugin.cfg.main;
-    const reject_threshold = (connection.relaying) ? (cfg.relay_reject_threshold || cfg.reject_threshold) : cfg.reject_threshold;
+    const reject_threshold = (conn.relaying) ? (cfg.relay_reject_threshold || cfg.reject_threshold) : cfg.reject_threshold;
 
     const human_text = `status=${spamd_response.flag}` +
               `, score=${spamd_response.score}` +
@@ -348,39 +349,39 @@ exports.log_results = function (connection, spamd_response) {
               `, reject=${reject_threshold}` +
               `, tests="${spamd_response.tests}"`;
 
-    connection.transaction.results.add(plugin, {
+    conn.transaction.results.add(plugin, {
         human: human_text,
         status: spamd_response.flag, score: parseFloat(spamd_response.score),
         required: parseFloat(spamd_response.reqd), reject: reject_threshold, tests: spamd_response.tests,
         emit: true});
 }
 
-exports.should_check = function (connection) {
+exports.should_check = function (conn) {
     const plugin = this;
 
     let result = true;  // default
 
-    if (plugin.cfg.check.authenticated == false && connection.notes.auth_user) {
-        connection.transaction.results.add(plugin, { skip: 'authed'});
+    if (plugin.cfg.check.authenticated == false && conn.notes.auth_user) {
+        conn.transaction.results.add(plugin, { skip: 'authed'});
         result = false;
     }
 
-    if (plugin.cfg.check.relay == false && connection.relaying) {
-        connection.transaction.results.add(plugin, { skip: 'relay'});
+    if (plugin.cfg.check.relay == false && conn.relaying) {
+        conn.transaction.results.add(plugin, { skip: 'relay'});
         result = false;
     }
 
-    if (plugin.cfg.check.local_ip == false && connection.remote.is_local) {
-        connection.transaction.results.add(plugin, { skip: 'local_ip'});
+    if (plugin.cfg.check.local_ip == false && conn.remote.is_local) {
+        conn.transaction.results.add(plugin, { skip: 'local_ip'});
         result = false;
     }
 
-    if (plugin.cfg.check.private_ip == false && connection.remote.is_private) {
-        if (plugin.cfg.check.local_ip == true && connection.remote.is_local) {
+    if (plugin.cfg.check.private_ip == false && conn.remote.is_private) {
+        if (plugin.cfg.check.local_ip == true && conn.remote.is_local) {
             // local IPs are included in private IPs
         }
         else {
-            connection.transaction.results.add(plugin, { skip: 'private_ip'});
+            conn.transaction.results.add(plugin, { skip: 'private_ip'});
             result = false;
         }
     }


### PR DESCRIPTION
In two places it has been seen frequently, grab a ref to the connection and/or transaction, to assure it'll still be there when the plugin continues later.

Use shortened names (conn/txn) to distinguish between local ref and source (connection/connection.transaction).

Related to #2732 

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
