### PR TITLE
assure cfg.headers section exists

### DIFF
--- a/transaction.js
+++ b/transaction.js
@@ -14,7 +14,7 @@ const Header = require('./mailheader').Header;
 const body   = require('./mailbody');
 const MessageStream = require('./messagestream');
 
-const cfg = config.get('smtp.ini');
+const cfg = config.get('smtp.ini', { booleans: [ '+headers.add_received' ] });
 if (!cfg.headers.max_lines) {
     cfg.headers.max_lines = config.get('max_header_lines') || 1000;
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- assure smtp.ini [headers] section exists for upgrades (legacy smtp.ini config w/o it). Goes with #2855