### PR TITLE
dns: add dns.ini config file to set the default dns server list

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,9 @@
 
 ## NEXT - 2020-MM-DD
 
+### New features
+
+* dns: add configurable dns servers using dns.ini config file
 
 ## 2.8.26 - 2020-11-18
 

--- a/config/dns.ini
+++ b/config/dns.ini
@@ -1,0 +1,4 @@
+; servers: a comma separated list of rfc5952 formatted addresses
+; servers=8.8.8.8
+; servers=4.4.4.4,[2001:4860:4860::8888],4.4.4.4:1053,[2001:4860:4860::8888]:1053
+

--- a/docs/CoreConfig.md
+++ b/docs/CoreConfig.md
@@ -144,3 +144,9 @@ The list of plugins to load
 * connection\_close\_message
   
   Defaults to `closing connection. Have a jolly good day.` can be overrridden with custom text
+
+* dns.ini
+
+  The `servers` key contains a comma separated list of [RFC 5952](https://tools.ietf.org/html/rfc5952#section-6)
+  formatted addresses.
+

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const fs          = require('fs');
 const os          = require('os');
 const path        = require('path');
 const tls         = require('tls');
+const dns         = require('dns');
 
 // let log = require('why-is-node-running');
 const tls_socket  = require('./tls_socket');
@@ -65,8 +66,23 @@ Server.load_http_ini = () => {
     }).main;
 }
 
+Server.load_dns_ini = () => {
+    const cfg = Server.config.get('dns.ini');
+    if (cfg && cfg.main.servers) {
+        const servers = cfg.main.servers.split(',');
+        try {
+            dns.setServers(servers);
+        }
+        catch (err) {
+            logger.logerror(`Invalid DNS servers: ${err.message}`);
+        }
+    }
+}
+
 Server.load_smtp_ini();
 Server.load_http_ini();
+// set default dns servers on startup since setServers() must not be called when a DNS query is in progress
+Server.load_dns_ini();
 
 Server.daemonize = function () {
     const c = this.cfg.main;


### PR DESCRIPTION
This feature is useful if you have dns servers running on a non-standard port. This is useful when running haraka in Docker. The base OS usually has systemd-resolved or equivalent which is a forwarding name server. In contrast, haraka ideally requires a recursive nameserver (for dnsbl to work, many OS default to google nameservers which zen spamhaus does not respond to). Unfortunately, one cannot set the default name server in the container's /etc/resolv.conf because that file does not support custom ports.


Changes proposed in this pull request:
- This calls dns.setServers() on startup. Both master and child workers in a cluster will get the setting
- [node docs](https://nodejs.org/docs/v10.0.0/api/dns.html#dns_dns_setservers_servers)

Checklist:
- [X] docs updated
- [ ] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
