### PR TITLE
fix: plugin names: removing 'haraka-plugin-' from plugin names breaks…

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -441,9 +441,10 @@ plugins.run_hooks = (hook, object, params) => {
     object.hooks_to_run = [];
 
     if (plugins.registered_hooks[hook]) {
+        const registered_plugins = Array.from(Object.values(plugins.registered_plugins).values());
         for (let i=0; i<plugins.registered_hooks[hook].length; i++) {
             const item = plugins.registered_hooks[hook][i];
-            const plugin = plugins.registered_plugins[item.plugin];
+            const plugin = registered_plugins.find(({name}) => name === item.plugin);
             object.hooks_to_run.push([plugin, item.method]);
         }
     }


### PR DESCRIPTION
… with plugins 'known-senders' and 'recipient-routes' enabled (at least, maybe more); look up plugin by actual name when running hooks
