### PR TITLE
consolidate smtp.ini parsing to server.js

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,11 +3,14 @@
 
 ### Changes
 
+- pass smtp.ini config from Server into connections & transactions
+
 ### New features
 
 - add ability to disable SMTPUTF8 advertisement #2866
 
 ### Fixes
+
 
 ## 2.8.26 - 2020-11-18
 

--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,7 @@
 
 ### Changes
 
-- pass smtp.ini config from Server into connections & transactions
+- pass smtp.ini config from Server into connections & transactions #2872
 
 ### New features
 

--- a/config/smtp.ini
+++ b/config/smtp.ini
@@ -44,6 +44,9 @@
 ;   wait for outbound connections to finish.
 ;force_shutdown_timeout=30
 
+; SMTP service extensions: https://tools.ietf.org/html/rfc1869
+; strict_rfc1869 = false
+
 ; Advertise support for SMTPTUF8 (RFC-6531)
 ;smtputf8=true
 

--- a/connection.js
+++ b/connection.js
@@ -38,12 +38,10 @@ function loadHAProxyHosts () {
     for (let i=0; i<hosts.length; i++) {
         const host = hosts[i].split(/\//);
         if (net.isIPv6(host[0])) {
-            new_ipv6_hosts[i] =
-                [ipaddr.IPv6.parse(host[0]), parseInt(host[1] || 64)];
+            new_ipv6_hosts[i] = [ipaddr.IPv6.parse(host[0]), parseInt(host[1] || 64)];
         }
         else {
-            new_ipv4_hosts[i] =
-                [ipaddr.IPv4.parse(host[0]), parseInt(host[1] || 32)];
+            new_ipv4_hosts[i] = [ipaddr.IPv4.parse(host[0]), parseInt(host[1] || 32)];
         }
     }
     haproxy_hosts_ipv4 = new_ipv4_hosts;
@@ -1347,7 +1345,7 @@ class Connection {
         let results;
         let from;
         try {
-            results = rfc1869.parse("mail", line, config.get('strict_rfc1869') && !this.relaying);
+            results = rfc1869.parse('mail', line, this.cfg.main.strict_rfc1869 && !this.relaying);
             from    = new Address (results.shift());
         }
         catch (err) {
@@ -1405,7 +1403,7 @@ class Connection {
         let results;
         let recip;
         try {
-            results = rfc1869.parse("rcpt", line, config.get('strict_rfc1869') && !this.relaying);
+            results = rfc1869.parse('rcpt', line, this.cfg.main.strict_rfc1869 && !this.relaying);
             recip   = new Address(results.shift());
         }
         catch (err) {

--- a/docs/CoreConfig.md
+++ b/docs/CoreConfig.md
@@ -26,8 +26,7 @@ The list of plugins to load
   * listen\_host, port - the host and port to listen on (default: ::0 and 25)
   * listen - (default: [::0]:25) Comma separated IP:Port addresses to listen on
   * inactivity\_time - how long to let clients idle in seconds (default: 300)
-  * nodes - specifies how many processes to fork. The string "cpus" will fork as many
-    children as there are CPUs (default: 0, which disables cluster mode)
+  * nodes - specifies how many processes to fork. The string "cpus" will fork as many children as there are CPUs (default: 0, which disables cluster mode)
   * user - optionally a user to drop privileges to. Can be a string or UID.
   * group - optionally a group to drop privileges to. Can be a string or GID.
   * ignore\_bad\_plugins - If a plugin fails to compile by default Haraka will stop at load time.
@@ -42,6 +41,8 @@ The list of plugins to load
   * graceful\_shutdown - (default: false) enable this to wait for sockets on shutdown instead of closing them quickly
   * force_shutdown_timeout - (default: 30) number of seconds to wait for a graceful shutdown
   * smtputf8 - (default: true) advertise support for SMTPUTF8
+  * strict\_rfc1869 - (default: false) Requires senders to conform to RFC 1869 and RFC 821 when sending the MAIL FROM and RCPT TO commands. In particular,
+  the inclusion of spurious spaces or missing angle brackets will be rejected.
 
 * me
 
@@ -126,15 +127,6 @@ The list of plugins to load
 
   A list of HAProxy hosts that Haraka should enable the PROXY protocol from.
   See [HAProxy.md](HAProxy.md)
-
-* strict\_rfc1869
-
-  When enabled, this setting requires senders to conform to RFC 1869 and
-  RFC 821 when sending the MAIL FROM and RCPT TO commands. In particular,
-  the inclusion of spurious spaces or missing angle brackets will be rejected.
-
-  to enable:   `echo 1 > /path/to/haraka/config/strict_rfc1869`
-  to disable:  `echo 0 > /path/to/haraka/config/strict_rfc1869`
 
 * max_mime_parts
 

--- a/plugins/mail_from.is_resolvable.js
+++ b/plugins/mail_from.is_resolvable.js
@@ -175,13 +175,13 @@ exports.implicit_mx = function (connection, domain, mxDone) {
         for (let i=0; i < addresses.length; i++) {
             const addr = addresses[i];
             // Ignore anything obviously bogus
-            if (net.isIPv4(addr)){
+            if (net.isIPv4(addr)) {
                 if (plugin.re_bogus_ip.test(addr)) {
                     connection.logdebug(plugin, `${domain}: discarding ${addr}`);
                     continue;
                 }
             }
-            if (net.isIPv6(addr)){
+            if (net.isIPv6(addr)) {
                 if (net_utils.ipv6_bogus(addr)) {
                     connection.logdebug(plugin, `${domain}: discarding ${addr}`);
                     continue;

--- a/rfc1869.js
+++ b/rfc1869.js
@@ -25,11 +25,11 @@ const chew_regexp = /\s+([A-Za-z0-9][A-Za-z0-9-]*(?:=[^= \x00-\x1f]+)?)$/;
 exports.parse = (type, line, strict) => {
     let params = [];
     line = (new String(line)).replace(/\s*$/, '');
-    if (type === "mail") {
-        line = line.replace(strict ? /from:/i : /from:\s*/i, "");
+    if (type === 'mail') {
+        line = line.replace(strict ? /from:/i : /from:\s*/i, '');
     }
     else {
-        line = line.replace(strict ? /to:/i : /to:\s*/i, "");
+        line = line.replace(strict ? /to:/i : /to:\s*/i, '');
     }
 
     while (1) {
@@ -38,9 +38,7 @@ exports.parse = (type, line, strict) => {
             params.push(p1);
             return '';
         });
-        if (old_length === line.length) {
-            break;
-        }
+        if (old_length === line.length) break;
     }
 
     params = params.reverse();
@@ -68,30 +66,28 @@ exports.parse = (type, line, strict) => {
         }
     }
 
-    if (type === "mail") {
+    if (type === 'mail') {
         if (!line.length) {
             return ["<>"]; // 'MAIL FROM:' --> 'MAIL FROM:<>'
         }
         if (line.match(/@.*\s/)) {
-            throw new Error("Syntax error in parameters");
+            throw new Error('Syntax error in parameters');
         }
     }
     else {
-        // console.log("Looking at " + line);
+        // console.log(`Looking at ${line}``);
         if (line.match(/@.*\s/)) {
-            throw new Error("Syntax error in parameters");
+            throw new Error('Syntax error in parameters');
         }
         else {
             if (line.match(/\s/)) {
-                throw new Error("Syntax error in parameters");
+                throw new Error('Syntax error in parameters');
             }
             else if (line.match(/@/)) {
-                if (!line.match(/^<.*>$/)) {
-                    line = `<${line}>`;
-                }
+                if (!line.match(/^<.*>$/)) line = `<${line}>`;
             }
             else if (!line.match(/^(postmaster|abuse)$/i)) {
-                throw new Error("Syntax error in address");
+                throw new Error('Syntax error in address');
             }
         }
     }

--- a/server.js
+++ b/server.js
@@ -33,7 +33,11 @@ Server.load_smtp_ini = () => {
     Server.cfg = Server.config.get('smtp.ini', {
         booleans: [
             '-main.daemonize',
+            '+main.smtputf8',
             '-main.graceful_shutdown',
+            '+headers.add_received',
+            '+headers.show_version',
+            '+headers.clean_auth_results',
         ],
     }, () => {
         Server.load_smtp_ini();
@@ -51,6 +55,11 @@ Server.load_smtp_ini = () => {
         smtps_port: 465,
         nodes: 1,
     };
+
+    Server.cfg.headers.max_received = parseInt(Server.cfg.headers.max_received) || parseInt(Server.config.get('max_received_count')) || 100;
+
+    const hhv = Server.config.get('header_hide_version')  // backwards compat
+    if (hhv !== null && !hhv) Server.cfg.headers.show_version = false;
 
     for (const key in defaults) {
         if (Server.cfg.main[key] !== undefined) continue;
@@ -344,7 +353,7 @@ Server.get_smtp_server = (ep, inactivity_timeout, done) => {
 
     function onConnect (client) {
         client.setTimeout(inactivity_timeout);
-        const connection = conn.createConnection(client, server);
+        const connection = conn.createConnection(client, server, Server.cfg);
 
         if (!server.has_tls) return;
 

--- a/server.js
+++ b/server.js
@@ -22,7 +22,7 @@ Server.config     = require('haraka-config');
 Server.plugins    = require('./plugins');
 Server.notes      = {};
 
-const logger        = Server.logger;
+const logger      = Server.logger;
 
 // Need these here so we can run hooks
 logger.add_log_methods(Server, 'server');
@@ -33,6 +33,7 @@ Server.load_smtp_ini = () => {
     Server.cfg = Server.config.get('smtp.ini', {
         booleans: [
             '-main.daemonize',
+            '-main.strict_rfc1869',
             '+main.smtputf8',
             '-main.graceful_shutdown',
             '+headers.add_received',
@@ -57,6 +58,12 @@ Server.load_smtp_ini = () => {
     };
 
     Server.cfg.headers.max_received = parseInt(Server.cfg.headers.max_received) || parseInt(Server.config.get('max_received_count')) || 100;
+
+    const strict_ext = Server.config.get('strict_rfc1869');
+    if (Server.cfg.main.strict_rfc1869 === false && strict_ext) {
+        logger.logwarn(`legacy config config/strict_rfc1869 is overriding smtp.ini`)
+        Server.cfg.main.strict_rfc1869 = strict_ext;
+    }
 
     const hhv = Server.config.get('header_hide_version')  // backwards compat
     if (hhv !== null && !hhv) Server.cfg.headers.show_version = false;

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -2,6 +2,7 @@
 const constants    = require('haraka-constants');
 
 const connection   = require('../connection');
+const Server       = require('../server');
 
 // huge hack here, but plugin tests need constants
 constants.import(global);
@@ -19,7 +20,7 @@ function _set_up (done) {
             return this.ip_address;
         }
     }
-    this.connection = connection.createConnection(client, server);
+    this.connection = connection.createConnection(client, server, Server.cfg);
     done();
 }
 
@@ -193,7 +194,7 @@ exports.connectionPrivate = {
                 return this.ip_address;
             }
         }
-        this.connection = connection.createConnection(client, server);
+        this.connection = connection.createConnection(client, server, Server.cfg);
         done();
     },
     tearDown : _tear_down,
@@ -219,7 +220,7 @@ exports.connectionLocal = {
                 return this.ip_address;
             }
         };
-        this.connection = connection.createConnection(client, server);
+        this.connection = connection.createConnection(client, server, Server.cfg);
         done();
     },
     tearDown : _tear_down,

--- a/transaction.js
+++ b/transaction.js
@@ -5,7 +5,6 @@
 const util   = require('util');
 
 // haraka npm modules
-const config = require('haraka-config');
 const Notes  = require('haraka-notes');
 const utils  = require('haraka-utils');
 
@@ -13,11 +12,6 @@ const utils  = require('haraka-utils');
 const Header = require('./mailheader').Header;
 const body   = require('./mailbody');
 const MessageStream = require('./messagestream');
-
-const cfg = config.get('smtp.ini', { booleans: [ '+headers.add_received' ] });
-if (!cfg.headers.max_lines) {
-    cfg.headers.max_lines = config.get('max_header_lines') || 1000;
-}
 
 class Transaction {
     constructor () {
@@ -153,7 +147,7 @@ class Transaction {
         }
         else if (this.header_pos === 0) {
             // Build up headers
-            if (this.header_lines.length < cfg.headers.max_lines) {
+            if (this.header_lines.length < this.cfg.headers.max_lines) {
                 if (line[0] === 0x2E) line = line.slice(1); // Strip leading '.'
                 this.header_lines.push(line.toString(this.encoding).replace(/\r\n$/, '\n'));
             }
@@ -257,12 +251,24 @@ class Transaction {
 }
 
 exports.Transaction = Transaction;
-exports.MAX_HEADER_LINES = cfg.headers.max_lines;
 
-exports.createTransaction = uuid => {
+exports.createTransaction = (uuid, cfg) => {
     const t = new Transaction();
     t.uuid = uuid || utils.uuid();
+
+    if (!cfg) {
+        const config = require('haraka-config');
+        cfg = config.get('smtp.ini', { booleans: [ '+headers.add_received' ] });
+        if (!cfg.headers.max_lines) {
+            cfg.headers.max_lines = config.get('max_header_lines') || 1000;
+        }
+    }
+    t.cfg = cfg
+
     // Initialize MessageStream here to pass in the UUID
     t.message_stream = new MessageStream(cfg, t.uuid, t.header.header_list);
+
+    exports.MAX_HEADER_LINES = cfg.headers.max_lines;
+
     return t;
 }


### PR DESCRIPTION
Fixes #2871

Changes proposed in this pull request:
- consolidate smtp.ini parsing to server.js
- passes config into connections and transactions
- move strict_rfc1869 setting into smtp.ini

Checklist:
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
