### PR TITLE
plugin: strip haraka-plugin- prefix from entries in plugin config

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,11 +3,14 @@
 
 ### Changes
 
+- strip _haraka-plugin-_ prefixes off plugin names in config/plugins #2873
+
 ### New features
 
 - add ability to disable SMTPUTF8 advertisement #2866
 
 ### Fixes
+
 
 ## 2.8.26 - 2020-11-18
 

--- a/plugins.js
+++ b/plugins.js
@@ -58,7 +58,7 @@ class Plugin {
         */
 
         plugin.hasPackageJson = false;
-        const name = ('haraka-plugin-' === plugin.name.substr(0,14)) ? plugin.name.substr(14) : plugin.name;
+        const name = plugin.name.startsWith('haraka-plugin-') ? plugin.name.substr(14) : plugin.name;
         if (plugin.name !== name) plugin.name = name;
 
         let paths = [];

--- a/plugins.js
+++ b/plugins.js
@@ -58,11 +58,8 @@ class Plugin {
         */
 
         plugin.hasPackageJson = false;
-        let name = plugin.name;
-        if (/^haraka-plugin-/.test(name)) {
-            name = name.replace(/^haraka-plugin-/, '');
-            plugin.name = name;
-        }
+        const name = ('haraka-plugin-' === plugin.name.substr(0,14)) ? plugin.name.substr(14) : plugin.name;
+        if (plugin.name !== name) plugin.name = name;
 
         let paths = [];
         if (process.env.HARAKA) {
@@ -320,6 +317,7 @@ plugins.load_plugins = override => {
     }
 
     plugin_list.forEach(plugin => {
+        if (plugin.substr(0,14) === 'haraka-plugin-') plugin = plugin.substr(14)
         if (plugins.deprecated[plugin]) {
             logger.lognotice(`the plugin ${plugin} has been replaced by '${plugins.deprecated[plugin]}'. Please update config/plugins`)
             plugins.load_plugin(plugins.deprecated[plugin]);

--- a/plugins.js
+++ b/plugins.js
@@ -317,7 +317,7 @@ plugins.load_plugins = override => {
     }
 
     plugin_list.forEach(plugin => {
-        if (plugin.substr(0,14) === 'haraka-plugin-') plugin = plugin.substr(14)
+        if (plugin.startsWith('haraka-plugin-')) plugin = plugin.substr(14)
         if (plugins.deprecated[plugin]) {
             logger.lognotice(`the plugin ${plugin} has been replaced by '${plugins.deprecated[plugin]}'. Please update config/plugins`)
             plugins.load_plugin(plugins.deprecated[plugin]);


### PR DESCRIPTION
Fixes #2870
closes #2867
related to #2846

Changes proposed in this pull request:
- plugin: strip haraka-plugin- prefix from entries in plugin config

Checklist:
- [x] tests updated (n/a)
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
