### PR TITLE
allow disabling STARTTLS "TLS NO-GO" feature on specific ports

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -5,6 +5,7 @@
 
 - strip _haraka-plugin-_ prefixes off plugin names in config/plugins #2873
 - pass smtp.ini config from Server into connections & transactions #2872
+- constrain STARTTLS "TLS NO-GO" to port 25 (by default)
 
 ### New features
 

--- a/config/tls.ini
+++ b/config/tls.ini
@@ -48,6 +48,9 @@
 ; TLS NO-GO Inbound expiry time in seconds
 ; disable_inbound_expiry = 3600
 
+; TLS NO-GO Inbound engages on the following ports only
+; disable_inbound_on_ports[] = 25
+
 ; no_tls_hosts - disable TLS for servers with broken TLS. (applies to inbound only)
 [no_tls_hosts]
 ; 127.0.0.1

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -42,11 +42,12 @@ exports.advertise_starttls = function (next, connection) {
         next();
     }
 
-    if (!tls_socket.cfg.redis || !server.notes.redis) {
+    const redis = server.notes.redis;
+    const nogo_ports = tls_socket.cfg.redis.disable_inbound_on_ports || [25];
+    if (!tls_socket.cfg.redis || !redis || !nogo_ports.includes(connection.local.port)) {
         return enable_tls();
     }
 
-    const redis = server.notes.redis;
     const dbkey = `no_tls|${connection.remote.ip}`;
 
     redis.get(dbkey, (err, dbr) => {


### PR DESCRIPTION
This is related to #2792, #770,  and allows disabling the feature on specific ports.
Reasoning: STARTTLS sometimes gets disabled because MUA is misconfigured or too slow to set up a TLS session. MUAs should not be kicked out into insecure field, especially when they're set to use port 587 (vs. 25). Most modern MUAs are sane and refuse to AUTH when TLS checkbox is ticked in their settings.

This will disable TLS NO-GO mechanism on port 587 by default. 25 is unaffected.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
