### PR TITLE
exclude port 587 from TLS no-go

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,7 @@
 
 ### Changes
 
-- constrain TLS NO-GO feature to port 25 #2875
+- exclude port 587 from TLS NO-GO feature #2875
 - strip _haraka-plugin-_ prefixes off plugin names in config/plugins #2873
 - pass smtp.ini config from Server into connections & transactions #2872
 

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 ### Changes
 
+- constrain TLS NO-GO feature to port 25 #2875
 - strip _haraka-plugin-_ prefixes off plugin names in config/plugins #2873
 - pass smtp.ini config from Server into connections & transactions #2872
 

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -42,8 +42,8 @@ exports.advertise_starttls = function (next, connection) {
         next();
     }
 
-    // limit NO-GO to port 25
-    if (connection.local.port !== 25) return enable_tls();
+    // exclude port 587 from NO-GO
+    if (connection.local.port === 587) return enable_tls();
 
     if (!tls_socket.cfg.redis || !server.notes.redis) {
         return enable_tls();

--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -42,6 +42,9 @@ exports.advertise_starttls = function (next, connection) {
         next();
     }
 
+    // limit NO-GO to port 25
+    if (connection.local.port !== 25) return enable_tls();
+
     if (!tls_socket.cfg.redis || !server.notes.redis) {
         return enable_tls();
     }


### PR DESCRIPTION
Fixes #2874

Changes proposed in this pull request:
- constrain TLS no-go to port 25

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
