### PR TITLE
require newer h-net-utils

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- require haraka-net-utils >= 1.2.2
 
 ## 2.8.26 - 2020-11-18
 

--- a/Changes.md
+++ b/Changes.md
@@ -12,7 +12,7 @@
 
 ### Fixes
 
-- require haraka-net-utils >= 1.2.2
+- require haraka-net-utils >= 1.2.2  #2876
 
 ## 2.8.26 - 2020-11-18
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "haraka-config"         : ">=1.0.15",
     "haraka-constants"      : ">=1.0.5",
     "haraka-dsn"            : "*",
-    "haraka-net-utils"      : ">=1.2.0",
+    "haraka-net-utils"      : ">=1.2.2",
     "haraka-notes"          : "*",
     "haraka-results"        : "^2.0.3",
     "haraka-tld"            : "*",


### PR DESCRIPTION
related to #2861

Changes proposed in this pull request:
- require h-net-utils >= 1.2.2 with updated get_mx that doesn't return implicit MXes
- the calling functions already have handling for implicit MXes

### ToDo
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
