### PR TITLE
headers.max_lines: init as integer at startup

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -13,7 +13,9 @@
 
 ### Fixes
 
+- assure headers.max_lines is initialized as integer #2878
 - require haraka-net-utils >= 1.2.2  #2876
+
 
 ## 2.8.26 - 2020-11-18
 

--- a/connection.js
+++ b/connection.js
@@ -131,7 +131,7 @@ class Connection {
         this.errors = 0;
         this.last_rcpt_msg = null;
         this.hook = null;
-        if (cfg.headers.show_version) {
+        if (this.cfg.headers.show_version) {
             const hpj = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json')));
             this.local.info += `/${hpj.version}`;
         }
@@ -1638,8 +1638,8 @@ class Connection {
         }
 
         // Warn if we hit the maximum parsed header lines limit
-        if (this.transaction.header_lines.length >= trans.MAX_HEADER_LINES) {
-            this.logwarn(`Incoming message reached maximum parsing limit of ${trans.MAX_HEADER_LINES} header lines`);
+        if (this.transaction.header_lines.length >= this.cfg.headers.max_lines) {
+            this.logwarn(`Incoming message reached maximum parsing limit of ${this.cfg.headers.max_lines} header lines`);
         }
 
         if (this.cfg.headers.clean_auth_results) {
@@ -1922,7 +1922,7 @@ exports.createConnection = (client, server, cfg) => {
     return new Connection(client, server, cfg);
 }
 
-// copy logger methods into Connection:
+// add logger methods to Connection:
 for (const key in logger) {
     if (!/^log\w/.test(key)) continue;
     Connection.prototype[key] = (function (level) {

--- a/server.js
+++ b/server.js
@@ -58,6 +58,7 @@ Server.load_smtp_ini = () => {
     };
 
     Server.cfg.headers.max_received = parseInt(Server.cfg.headers.max_received) || parseInt(Server.config.get('max_received_count')) || 100;
+    Server.cfg.headers.max_lines    = parseInt(Server.cfg.headers.max_lines) || parseInt(Server.config.get('max_header_lines')) || 1000;
 
     const strict_ext = Server.config.get('strict_rfc1869');
     if (Server.cfg.main.strict_rfc1869 === false && strict_ext) {

--- a/transaction.js
+++ b/transaction.js
@@ -256,19 +256,10 @@ exports.createTransaction = (uuid, cfg) => {
     const t = new Transaction();
     t.uuid = uuid || utils.uuid();
 
-    if (!cfg) {
-        const config = require('haraka-config');
-        cfg = config.get('smtp.ini', { booleans: [ '+headers.add_received' ] });
-        if (!cfg.headers.max_lines) {
-            cfg.headers.max_lines = config.get('max_header_lines') || 1000;
-        }
-    }
     t.cfg = cfg
 
     // Initialize MessageStream here to pass in the UUID
     t.message_stream = new MessageStream(cfg, t.uuid, t.header.header_list);
-
-    exports.MAX_HEADER_LINES = cfg.headers.max_lines;
 
     return t;
 }


### PR DESCRIPTION
continues #2872

Changes proposed in this pull request:
- assure config setting parses as integer
- reference the config setting consistently in conn & txn
- shed MAX_HEADER_LINES because identical config is now available in conn & txn

Checklist:
- [ ] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
