### PR TITLE
drop node 10 support

### DIFF
--- a/.github/workflows/ci-test-win.yml
+++ b/.github/workflows/ci-test-win.yml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest ]
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [12.x, 14.x]
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       name: Checkout Haraka
       with:
         fetch-depth: 1
@@ -28,10 +28,11 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: npm install and test
-      run: |
-        npm install
-        npm run test
+    - name: Install
+      run: npm install
+
+    - name: Test
+      run: npm run test
 
       env:
         CI: true

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,11 +18,11 @@ jobs:
         # node 6, maint. ended 2018-04
         # node 8, maint. ended 2019-12
         # node 10, maint. ends 2021-04
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [12.x, 14.x]
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       name: Checkout Haraka
       with:
         fetch-depth: 1
@@ -32,10 +32,10 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: npm install
+    - name: Install
       run: npm install
 
-    - name: Run test suite
+    - name: Test
       run: npm run test
 
       env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-!tests/node_modules
 .coveralls.yml
 Haraka-*.gz
 *~
@@ -7,6 +6,8 @@ bower_components
 coverage
 .nyc_output
 .idea
+tests/node_modules
 tests/queue/plain
 tests/queue/multibyte
+tests/test-queue
 package-lock.json

--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,18 @@
 
 ## NEXT - 2020-MM-DD
 
+### Changes
+
+- use address-rfc2821 2.0.0
+- drop support for node 10
+
+### New features
+
+- 
+
+### Fixes
+
+- 
 
 ## 2.8.27 - 2021-01-05
 

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "main": "haraka.js",
   "engines": {
-    "node": ">= v10.23.1"
+    "node": ">=12.20.1"
   },
   "dependencies": {
-    "address-rfc2821"       : "^1.2.3",
+    "address-rfc2821"       : "^2.0.0",
     "address-rfc2822"       : "^2.0.5",
     "async"                 : "~3.2.0",
     "daemon"                : "~1.1.0",


### PR DESCRIPTION
Changes proposed in this pull request:
- drop support for node.js 10
- use address-rfc2821 2.0.0

Checklist:
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
