### PR TITLE
tls: add no_tls_client_cert_hosts

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -8,7 +8,7 @@
 
 ### New features
 
-- 
+- tls: add no_tls_client_cert_hosts to exclude sending certs to specific hosts
 
 ### Fixes
 

--- a/docs/plugins/tls.md
+++ b/docs/plugins/tls.md
@@ -169,6 +169,20 @@ requires the OCSP responses to be fetched again upon the first client
 connection.
 
 
+## Outbound Specific Configuration
+
+### no_tls_client_cert_hosts
+
+By default, when Haraka is acting as a SMTP client, the server cert is sent as the SMTP client certificate.
+This can cause problems for some servers. To disable sending the cert for specific servers:
+
+    no_tls_client_cert_hosts[]=mx.example.com
+    no_tls_client_cert_hosts[]=mx.another.com
+
+You can also set it to `*`, to disable sending client certs to all servers:
+
+    no_tls_client_cert_hosts=*
+
 ## Inbound Specific Configuration
 
 By default the above options are shared with outbound mail (either

--- a/outbound/tls.js
+++ b/outbound/tls.js
@@ -7,7 +7,8 @@ const hkredis      = require('haraka-plugin-redis');
 
 const inheritable_opts = [
     'key', 'cert', 'ciphers', 'minVersion', 'dhparam',
-    'requestCert', 'honorCipherOrder', 'rejectUnauthorized'
+    'requestCert', 'honorCipherOrder', 'rejectUnauthorized',
+    'no_tls_client_cert_hosts'
 ];
 
 class OutboundTLS {

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -688,6 +688,15 @@ function createServer (cb) {
     return server;
 }
 
+function shouldSendClientCerts (options) {
+    const no_tls_client_cert_hosts = options.no_tls_client_cert_hosts;
+
+    if (no_tls_client_cert_hosts === '*') return false;
+    if (!Array.isArray(no_tls_client_cert_hosts)) return true;
+
+    return !no_tls_client_cert_hosts.some(h => h === options.servername || h === '*');
+}
+
 function connect (port, host, cb) {
     let conn_options = {};
     if (typeof port === 'object') {
@@ -707,7 +716,7 @@ function connect (port, host, cb) {
         socket.clean();
         cryptoSocket.removeAllListeners('data');
 
-        if (exports.tls_valid) {
+        if (exports.tls_valid && shouldSendClientCerts(options)) {
             options = Object.assign(options, certsByHost['*']);
         }
         options.socket = cryptoSocket;


### PR DESCRIPTION
This provides a way to disable sending client certs to specific hosts.

See the discussion in #2693

Checklist:
- [X] docs updated
- [ ] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
