### PR TITLE
clone the header_list

### DIFF
--- a/mailheader.js
+++ b/mailheader.js
@@ -98,7 +98,7 @@ class Header {
     }
 
     get_all (key) {
-        return [].concat(this.headers[key.toLowerCase()] || []);
+        return Object.freeze([...(this.headers[key.toLowerCase()] || [])]);
     }
 
     get_decoded (key) {

--- a/mailheader.js
+++ b/mailheader.js
@@ -98,7 +98,7 @@ class Header {
     }
 
     get_all (key) {
-        return this.headers[key.toLowerCase()] || [];
+        return [].concat(this.headers[key.toLowerCase()] || []);
     }
 
     get_decoded (key) {
@@ -163,7 +163,7 @@ class Header {
     }
 
     lines () {
-        return this.header_list;
+        return [].concat(this.header_list);
     }
 
     toString () {

--- a/mailheader.js
+++ b/mailheader.js
@@ -163,7 +163,7 @@ class Header {
     }
 
     lines () {
-        return [].concat(this.header_list);
+        return Object.freeze([...this.header_list]);
     }
 
     toString () {


### PR DESCRIPTION
It's too dangerous to return the header_list object without cloning it, this object should never be modified outside of this class
we could even freeze it to make sure people know what they are doing wrong