### PR TITLE
tls: default to not sending TLS client cert

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,9 +3,11 @@
 
 ### Changes
 
+- tls: change default to NOT send TLS client certs #2902
+- dep: redis is now a dependency #2896
 - use address-rfc2821 2.0.0
-- drop support for node 10
-- http: use CDN for bootstrap/jquery, drop bower
+- http: use CDN for bootstrap/jquery, drop bower #2891
+- drop support for node 10  #2890
 
 ### New features
 
@@ -13,7 +15,9 @@
 
 ### Fixes
 
-- 
+- bounce: correctly set fail recipients #2901
+- bounce: correctly set bounce recipients #2899
+
 
 ## 2.8.27 - 2021-01-05
 

--- a/config/tls.ini
+++ b/config/tls.ini
@@ -26,6 +26,10 @@
 ; requireAuthorized[]=465
 ; requireAuthorized[]=587
 
+; send client certificate(s). If you use this setting and value it, report
+; your use case at https://github.com/haraka/Haraka/issues/2693
+; mutual_tls=false
+
 
 [redis]
 ; options in this block require redis to be enabled in config/plugins.
@@ -48,11 +52,24 @@
 ; TLS NO-GO Inbound expiry time in seconds
 ; disable_inbound_expiry = 3600
 
+
 ; no_tls_hosts - disable TLS for servers with broken TLS. (applies to inbound only)
 [no_tls_hosts]
 ; 127.0.0.1
 ; 192.168.1.1
 ; 172.16.0.0/16
+
+
+; hosts that require us to present a cert signed by a CA we both trust
+[mutual_auth_hosts]
+;travel.state.gov                     ; use default TLS cert
+;xo.huggable.gov=special.my-tld.com   ; specify cert by CN
+
+
+; these hosts request mutual TLS and reject our TLS certificate
+[mutual_auth_hosts_exclude]
+;bofh.no-such-agency.gov
+
 
 [outbound]
 ; key=tls_key.pem

--- a/tests/tls_socket.js
+++ b/tests/tls_socket.js
@@ -132,9 +132,12 @@ exports.load_tls_ini2 = {
                     requestOCSP: false,
                     // enableOCSPStapling: false,
                     requireAuthorized: [],
+                    mutual_tls: false,
                 },
                 redis: { disable_for_failed_hosts: false },
-                no_tls_hosts: {}
+                no_tls_hosts: {},
+                mutual_auth_hosts: {},
+                mutual_auth_hosts_exclude: {},
             });
         test.done();
     },
@@ -153,9 +156,12 @@ exports.load_tls_ini2 = {
                 ciphers: 'ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-SHA384',
                 minVersion: 'TLSv1',
                 requireAuthorized: [2465, 2587],
+                mutual_tls: false,
             },
             redis: { disable_for_failed_hosts: false },
             no_tls_hosts: {},
+            mutual_auth_hosts: {},
+            mutual_auth_hosts_exclude: {},
             outbound: {
                 key: 'outbound_tls_key.pem',
                 cert: 'outbound_tls_cert.pem',


### PR DESCRIPTION
fixes #2693
fixes #2893

Changes proposed in this pull request:
- turn off sending TLS client certificates (by default)
- add a config option to turn them back on
- add granular settings for [en|dis]abling client certs for particular hosts

Checklist:
- [ ] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated