### PR TITLE
Implement forced TLS: outbound.force_tls_hosts[] in tls.ini

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,7 @@
 
 ### New features
 
-- 
+- tls: require secure and verified sockets for configured hosts/domains
 
 ### Fixes
 

--- a/docs/plugins/tls.md
+++ b/docs/plugins/tls.md
@@ -91,6 +91,20 @@ If needed, add this section to the `config/tls.ini` file and list any IP ranges 
 
 The [Node.js TLS](http://nodejs.org/api/tls.html) page has additional information about the following options.
 
+### force_tls_hosts
+
+For known good TLS hosts, it's possible to force that the outbound mailer will only connect via secure sockets. This makes Haraka use *forced TLS* instead of *opportunistic TLS*. For forced TLS, the STARTTLS upgrade must succeed with a valid certificate (overriding `rejectUnauthorized`). The list is matched both against the host (MX record or `nexthop` in `relay_dest_domains.ini`), and the domain name of the email address.
+
+Note: unlike `no_tls_hosts`, this feature is implemented as an array:
+
+```ini
+[outbound]
+force_tls_hosts[]=172.17.123.1
+force_tls_hosts[]=172.17.124.0/24
+force_tls_hosts[]=mx.example.org
+force_tls_hosts[]=example.com
+```
+
 ### ciphers
 
 A list of allowable ciphers to use. Example:

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -308,15 +308,11 @@ class HMailItem extends events.EventEmitter {
         let host = mx.exchange;
 
         self.force_tls = false;
-        const force_tls_hosts = {};  // ip_in_list doesn't take an array
-        for (const item of obtls.cfg.force_tls_hosts) {
-            force_tls_hosts[item] = 1;
-        }
-        if (net_utils.ip_in_list(force_tls_hosts, host)) {
+        if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, host)) {
             this.logdebug(`Forcing TLS for host ${host}`);
             self.force_tls = true;
         }
-        if (net_utils.ip_in_list(force_tls_hosts, self.todo.domain)) {
+        if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, self.todo.domain)) {
             this.logdebug(`Forcing TLS for domain ${self.todo.domain}`);
             self.force_tls = true;
         }

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -1535,7 +1535,7 @@ function sort_mx (mx_list) {
     return sorted;
 }
 
-const smtp_regexp = /^(\d{3})([ -])#?(?:(\d\.\d\.\d)\s)?(.*)/;
+const smtp_regexp = /^([2345]\d\d)([ -])#?(?:(\d\.\d\.\d)\s)?(.*)/;
 
 function cram_md5_response (username, password, challenge) {
     const crypto = require('crypto');

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -307,6 +307,20 @@ class HMailItem extends events.EventEmitter {
         const mx = this.mxlist.shift();
         let host = mx.exchange;
 
+        self.force_tls = false;
+        let force_tls_hosts = {};  // ip_in_list doesn't take an array
+        for (const host of obtls.cfg.force_tls_hosts) {
+            force_tls_hosts[host] = 1;
+        }
+        if (net_utils.ip_in_list(force_tls_hosts, host)) {
+            this.logdebug(`Forcing TLS for host ${host}`);
+            self.force_tls = true;
+        }
+        if (net_utils.ip_in_list(force_tls_hosts, self.todo.domain)) {
+            this.logdebug(`Forcing TLS for domain ${self.todo.domain}`);
+            self.force_tls = true;
+        }
+
         // IP or IP:port
         if (net.isIP(host)) {
             self.hostlist = [ host ];
@@ -456,6 +470,14 @@ class HMailItem extends events.EventEmitter {
                 }
                 return;
             }
+            if (self.force_tls && (cmd != 'EHLO' && cmd != 'STARTTLS') && !socket.isSecure()) {
+                // For safety against programming mistakes
+                self.logerror("Blocking attempt to send unencrypted data to forced TLS socket. This message indicates a programming error in the software.");
+                processing_mail = false;
+                client_pool.release_client(socket, port, host, mx.bind, true);
+                return;
+            }
+
             let line = `${cmd}${data ? ` ${data}` : ''}`;
             if (cmd === 'dot' || cmd === 'dot_lmtp') {
                 line = '.';
@@ -563,6 +585,27 @@ class HMailItem extends events.EventEmitter {
             set_ehlo_props();
 
             if (secured) return auth_and_mail_phase();              // TLS already negotiated
+
+            if (self.force_tls) {
+                self.logdebug(`Using TLS for domain: ${self.todo.domain}, host: ${host}`);
+
+                if (!obc.cfg.enable_tls || !smtp_properties.tls) {
+                    // Prevent further use of the non-securable socket
+                    processing_mail = false;
+                    socket.write("QUIT\r\n", "utf8");  // courtesy
+                    socket.end();
+                    client_pool.release_client(socket, port, host, mx.bind, true);
+                    return self.temp_fail(`No TLS available but required by configuration.`);
+                }
+
+                socket.once('secure', () => {
+                    // Set this flag so we don't try STARTTLS again if it
+                    // is incorrectly offered at EHLO once we are secured.
+                    secured = true;
+                    send_command(mx.using_lmtp ? 'LHLO' : 'EHLO', mx.bind_helo);
+                });
+                return send_command('STARTTLS');
+            }
             if (!obc.cfg.enable_tls) return auth_and_mail_phase();      // TLS not enabled
             if (!smtp_properties.tls) return auth_and_mail_phase(); // TLS not advertised by remote
 
@@ -595,7 +638,6 @@ class HMailItem extends events.EventEmitter {
                     return auth_and_mail_phase();
                 }
             );
-
         } // process_ehlo_data()
 
         let fp_called = false;
@@ -812,6 +854,7 @@ class HMailItem extends events.EventEmitter {
                     break;
                 case 'starttls': {
                     const tls_options = obtls.get_tls_options(mx);
+                    if (self.force_tls) tls_options.rejectUnauthorized = true;
 
                     smtp_properties = {};
                     socket.upgrade(tls_options, (authorized, verifyError, cert, cipher) => {
@@ -831,6 +874,13 @@ class HMailItem extends events.EventEmitter {
                         if (cert && cert.valid_to) loginfo.expires = cert.valid_to;
                         if (cert && cert.fingerprint) loginfo.fingerprint = cert.fingerprint;
                         self.loginfo('secured', loginfo);
+
+                        if (self.force_tls && !authorized) {
+                            processing_mail = false;
+                            socket.end();
+                            self.temp_fail('Host failed TLS verification required by configuration.');
+                            client_pool.release_client(socket, port, host, mx.bind, true);
+                        }
                     });
                     break;
                 }
@@ -908,6 +958,8 @@ class HMailItem extends events.EventEmitter {
 
         if (socket.__fromPool) {
             logger.logdebug('[outbound] got pooled socket, trying to deliver');
+            secured = socket.isEncrypted();
+            logger.logdebug(`[outbound] got pooled ${secured ? 'TLS ' : '' }socket, trying to deliver`);
             send_command('MAIL', `FROM:${self.todo.mail_from.format(!smtp_properties.smtp_utf8)}`);
         }
     }

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -308,9 +308,9 @@ class HMailItem extends events.EventEmitter {
         let host = mx.exchange;
 
         self.force_tls = false;
-        let force_tls_hosts = {};  // ip_in_list doesn't take an array
-        for (const host of obtls.cfg.force_tls_hosts) {
-            force_tls_hosts[host] = 1;
+        const force_tls_hosts = {};  // ip_in_list doesn't take an array
+        for (const item of obtls.cfg.force_tls_hosts) {
+            force_tls_hosts[item] = 1;
         }
         if (net_utils.ip_in_list(force_tls_hosts, host)) {
             this.logdebug(`Forcing TLS for host ${host}`);

--- a/outbound/tls.js
+++ b/outbound/tls.js
@@ -7,7 +7,8 @@ const hkredis      = require('haraka-plugin-redis');
 
 const inheritable_opts = [
     'key', 'cert', 'ciphers', 'minVersion', 'dhparam',
-    'requestCert', 'honorCipherOrder', 'rejectUnauthorized'
+    'requestCert', 'honorCipherOrder', 'rejectUnauthorized',
+    'force_tls_hosts'
 ];
 
 class OutboundTLS {
@@ -52,6 +53,7 @@ class OutboundTLS {
         }
 
         if (!cfg.no_tls_hosts) cfg.no_tls_hosts = [];
+        if (!cfg.force_tls_hosts) cfg.force_tls_hosts = [];
 
         this.cfg = cfg;
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "haraka-config"         : ">=1.0.15",
     "haraka-constants"      : ">=1.0.5",
     "haraka-dsn"            : "*",
-    "haraka-net-utils"      : ">=1.2.3",
+    "haraka-net-utils"      : ">=1.3.0",
     "haraka-notes"          : "*",
     "haraka-plugin-redis"   : "*",
     "haraka-results"        : "^2.0.3",

--- a/tests/config/tls.ini
+++ b/tests/config/tls.ini
@@ -38,3 +38,5 @@ minVersion = TLSv1
 rejectUnauthorized=false
 requestCert=false
 honorCipherOrder=false
+force_tls_hosts[]=first.example.com
+force_tls_hosts[]=second.example.net

--- a/tests/outbound/index.js
+++ b/tests/outbound/index.js
@@ -168,7 +168,8 @@ exports.get_tls_options = {
             requestCert: false,
             honorCipherOrder: false,
             redis: { disable_for_failed_hosts: false },
-            no_tls_hosts: []
+            no_tls_hosts: [],
+            force_tls_hosts: ['first.example.com', 'second.example.net']
         });
         test.done();
     },

--- a/tests/tls_socket.js
+++ b/tests/tls_socket.js
@@ -171,6 +171,7 @@ exports.load_tls_ini2 = {
                 rejectUnauthorized: false,
                 requestCert: false,
                 honorCipherOrder: false,
+                force_tls_hosts: ['first.example.com', 'second.example.net'],
             }
         });
         test.done();

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -153,6 +153,14 @@ class pluggableStream extends stream.Stream {
         this._timeout = timeout;
         return this.targetsocket.setTimeout(timeout);
     }
+
+    isEncrypted () {
+        return this.targetsocket.encrypted;
+    }
+
+    isSecure () {
+        return this.targetsocket.encrypted && this.targetsocket.authorized;
+    }
 }
 
 exports.parse_x509_names = string => {


### PR DESCRIPTION
Implemented using an ini array instead of like the [no_tls_hosts] section, so
that it can be different for outbound and inbound, for future use.

Currently does not accept wildcards like "*.example.org".

Also fixes a small bug in the "delivered" notice, where a previously TLS
upgraded socket from the pool would be logged as tls=N

Changes proposed in this pull request:
- New feature: forced TLS for selected hosts
- Configuration in tls.ini outbound.no_tls_hosts[], prepared for adding inbound.no_tls_hosts[] later (and both can then take from main.no_tls_hosts[] of course)
- Bug fix: tls=N in log should be tls=Y for re-used upgraded socket from pool
- Debug feature: indicate in debug log message that a re-used socket is a TLS socket
- Bug fix: invalid SMTP codes were not treated as fatal errors

Checklist:
- [X] docs updated
- [ ] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
