### PR TITLE
The space after "MAIL FROM:" and before "<" is not allowed

### DIFF
--- a/smtp_client.js
+++ b/smtp_client.js
@@ -458,7 +458,7 @@ exports.get_client_plugin = (plugin, connection, c, callback) => {
                 if (smtp_client.is_dead_sender(plugin, connection)) {
                     return;
                 }
-                smtp_client.send_command('MAIL', `FROM: ${connection.transaction.mail_from.format(!smtp_client.smtp_utf8)}`);
+                smtp_client.send_command('MAIL', `FROM:${connection.transaction.mail_from.format(!smtp_client.smtp_utf8)}`);
                 return;
             }
 


### PR DESCRIPTION
The space after "MAIL FROM:" and before "<" is not allowed by the syntax of RFC-5321.

Fixes #

Changes proposed in this pull request:
- 
- 

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
