### PR TITLE
Get local_ip from getsockname() instead of server properties

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -17,6 +17,7 @@
 
 - bounce: correctly set fail recipients #2901
 - bounce: correctly set bounce recipients #2899
+- Get local_ip from getsockname() instead of server properties #2914
 
 
 ## 2.8.27 - 2021-01-05

--- a/connection.js
+++ b/connection.js
@@ -145,12 +145,10 @@ class Connection {
             return;
         }
 
-        const local_addr = self.server.address();
-        if (local_addr && local_addr.address) {
-            self.set('local', 'ip', ipaddr.process(local_addr.address).toString());
-            self.set('local', 'port', local_addr.port);
-            self.results.add({name: 'local'}, self.local);
-        }
+        self.set('local', 'ip', ipaddr.process(self.client.localAddress).toString());
+        self.set('local', 'port', self.client.localPort);
+        self.results.add({name: 'local'}, self.local);
+
         self.set('remote', 'ip', ipaddr.process(ip).toString());
         self.set('remote', 'port', self.client.remotePort);
         self.results.add({name: 'remote'}, self.remote);

--- a/tests/connection.js
+++ b/tests/connection.js
@@ -186,6 +186,8 @@ exports.connectionPrivate = {
         const client = {
             remotePort: 2525,
             remoteAddress: '172.16.15.1',
+            localPort: 25,
+            localAddress: '172.16.15.254',
             destroy: () => { true; },
         };
         const server = {
@@ -212,6 +214,8 @@ exports.connectionLocal = {
         const client = {
             remotePort: 2525,
             remoteAddress: '127.0.0.2',
+            localPort: 25,
+            localAddress: '172.0.0.1',
             destroy: () => { true; },
         };
         const server = {

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -99,6 +99,12 @@ class pluggableStream extends stream.Stream {
         if (self.targetsocket.remoteAddress) {
             self.remoteAddress = self.targetsocket.remoteAddress;
         }
+        if (self.targetsocket.localPort) {
+            self.localPort = self.targetsocket.localPort;
+        }
+        if (self.targetsocket.localAddress) {
+            self.localAddress = self.targetsocket.localAddress;
+        }
     }
     clean (data) {
         if (this.targetsocket && this.targetsocket.removeAllListeners) {


### PR DESCRIPTION
Fixes #2914

In the case of binding to a specific existing address, client.localAddress
should be the same as the bind address and this commit doesn't change that.

In the case of binding to a non-existing address, no client will exist until
the address does exist, and this commit doesn't change that.

Finally, in the case of binding to INADDR_ANY, the bind address is useless
information (that is: I can't think of any use case where this fact would be
useful during handling an incoming connection), and this commit changes the
value from :: or 0.0.0.0 to a value that is actually useful: the IP address on
which the incoming connection was actually accepted.


Checklist:
- [ ] docs updated ← N/A
- [X] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
