### PR TITLE
Log connection errors with logfrmt key/value pairs

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 ### Changes
 
+- connection error logging: use key-value paris #2921
 - tls: change default to NOT send TLS client certs #2902
 - dep: redis is now a dependency #2896
 - use address-rfc2821 2.0.0


### PR DESCRIPTION
Fixes #2921

Changes proposed in this pull request:
- connection errors logged in `connection.js` should use key-value pairs rather than stringifying data into the message

Checklist:
- [ ] docs (I didn't see any)
- [ ] tests (I didn't see any)
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
