### PR TITLE
messagestream header skip

### DIFF
--- a/messagestream.js
+++ b/messagestream.js
@@ -334,7 +334,7 @@ class MessageStream extends Stream {
         this.in_pipe = true;
         this.readable = true;
         this.paused = false;
-        this.headers_done = false;
+        this.headers_done = (options && options.skip_headers);
         this.headers_found_eoh = false;
         this.rs = null;
         this.read_ce = new ChunkEmitter(this.buffer_size);


### PR DESCRIPTION
Add a `skip_headers` option to output message body only.
This is needed for [my milter plugin](https://github.com/celesteking/haraka-plugin-milter) to work correctly without additional hacks.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
