### PR TITLE
put more data in AR header so that opendmarc check actually works

### DIFF
--- a/plugins/dkim_verify.js
+++ b/plugins/dkim_verify.js
@@ -28,7 +28,7 @@ exports.hook_data_post = function (next, connection) {
         results.forEach((res) => {
             let res_err = '';
             if (res.error) res_err = ` (${res.error})`;
-            connection.auth_results(`dkim=${res.result}${res_err} header.i=${res.identity}`);
+            connection.auth_results(`dkim=${res.result}${res_err} header.i=${res.identity} header.d=${res.domain} header.s=${res.selector}`);
             connection.loginfo(self, `identity="${res.identity}" domain="${res.domain}" selector="${res.selector}" result=${res.result} ${res_err}`);
 
             // save to ResultStore


### PR DESCRIPTION
Sadly, opendmarc can't decipher "header.i" and needs "header.d" in order to work. Make it so.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
