### PR TITLE
SA: stop processing when client is gone

### DIFF
--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -104,6 +104,7 @@ exports.hook_data_post = function (next, connection) {
     });
 
     socket.once('end', () => {
+        if (!conn.transaction) return next() // client gone
 
         if (spamd_response.headers && spamd_response.headers.Tests) {
             spamd_response.tests = spamd_response.headers.Tests.replace(/\s/g, '');


### PR DESCRIPTION
Fixes:
```
TypeError: Cannot read property 'results' of null
    at Plugin.exports.log_results (/code/nodejs/Haraka/plugins/spamassassin.js:353:22)
    at Socket.<anonymous> (/code/nodejs/Haraka/plugins/spamassassin.js:135:16)
    at Object.onceWrapper (events.js:420:28)
    at Socket.emit (events.js:326:22)
    at endReadableNT (_stream_readable.js:1223:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
