### PR TITLE
add a default route for force_routing

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,7 +2,7 @@
 ## NEXT - 2020-MM-DD
 
 ### Changes
-
+- added ability to define a default relay in relay_dest_domains
 - connection error logging: use key-value paris #2921
 - tls: change default to NOT send TLS client certs #2902
 - dep: redis is now a dependency #2896
@@ -443,7 +443,7 @@
     * update js-yaml to version 3.10.0 #2097
     * repackage p0f plugin to NPM #2076
     * ES6: replace var with const or let  #2073
-    
+
 * New Features
     * Bounces can have an HTML part #2091
 * Fixes

--- a/docs/plugins/relay_force_routing.md
+++ b/docs/plugins/relay_force_routing.md
@@ -25,8 +25,9 @@ Configuration
     already defined.
 
     Example:
-
+```
     [domains]  
     test.com = { "action": "continue", "nexthop": "127.0.0.1:2525" }
     my.test.com = { "action": "continue", "nexthop": "127.0.0.1:2527" }
     any = { "action": "continue", "nexthop": "10.10.10.1:2525"}
+```

--- a/docs/plugins/relay_force_routing.md
+++ b/docs/plugins/relay_force_routing.md
@@ -20,3 +20,13 @@ Configuration
     [domains]  
     test.com = { "action": "continue", "nexthop": "127.0.0.1:2525" }
 
+    You can also define a default relay using the "any" domain, which will be
+    used if the message's destination domain doesn't match any of the domains
+    already defined.
+
+    Example:
+
+    [domains]  
+    test.com = { "action": "continue", "nexthop": "127.0.0.1:2525" }
+    my.test.com = { "action": "continue", "nexthop": "127.0.0.1:2527" }
+    any = { "action": "continue", "nexthop": "10.10.10.1:2525"}

--- a/plugins/relay.js
+++ b/plugins/relay.js
@@ -191,8 +191,6 @@ exports.force_routing = function (next, hmail, domain) {
 
     if (!route) {
         route = plugin.dest.domains["any"];
-        plugin.logdebug(plugin,"checking wildcard");
-        plugin.logdebug(plugin,plugin.dest.domains);
         if(!route){
             plugin.logdebug(plugin, `using normal MX lookup for: ${domain}`);
             return next();

--- a/plugins/relay.js
+++ b/plugins/relay.js
@@ -187,11 +187,16 @@ exports.force_routing = function (next, hmail, domain) {
     if (!plugin.cfg.relay.force_routing) { return next(); }
     if (!plugin.dest) { return next(); }
     if (!plugin.dest.domains) { return next(); }
-    const route = plugin.dest.domains[domain];
+    let route = plugin.dest.domains[domain];
 
     if (!route) {
-        plugin.logdebug(plugin, `using normal MX lookup for: ${domain}`);
-        return next();
+        route = plugin.dest.domains["any"];
+        plugin.logdebug(plugin,"checking wildcard");
+        plugin.logdebug(plugin,plugin.dest.domains);
+        if(!route){
+            plugin.logdebug(plugin, `using normal MX lookup for: ${domain}`);
+            return next();
+        }
     }
 
     const nexthop = JSON.parse(route).nexthop;

--- a/tests/plugins/relay.js
+++ b/tests/plugins/relay.js
@@ -290,6 +290,17 @@ exports.force_routing = {
         this.plugin.dest = { domains: { foo: '{"action":"blah blah","nexthop":"other-server"}' } };
         this.plugin.force_routing(next, this.connection, 'foo');
     },
+    'dest-domains, any' (test) {
+      test.expect(2);
+      function next (rc, nexthop) {
+          test.equal(OK, rc);
+          test.equal('any-server', nexthop);
+          test.done();
+      }
+      this.plugin.dest = { domains: { foo: '{"action":"blah blah","nexthop":"other-server"}',
+        any: '{"action":"blah blah","nexthop":"any-server"}'} };
+      this.plugin.force_routing(next, this.connection, 'not');
+    }
 }
 
 exports.all = {


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
add a default domain in relay_dest_domains to be used if the destination domain doesn't match any of the other domains

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
