### PR TITLE
Allow spamassassin to return DENYSOFT on errors/timeouts

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -11,7 +11,7 @@
 - http: use CDN for bootstrap/jquery, drop bower #2891
 - drop support for node 10  #2890
 - outbound: disable outbound to localhost by default #2952
-- spamassassin: allow returning DENYSOFT on errors
+- spamassassin: allow returning DENYSOFT on errors #2967
 
 ### New features
 

--- a/Changes.md
+++ b/Changes.md
@@ -11,6 +11,7 @@
 - http: use CDN for bootstrap/jquery, drop bower #2891
 - drop support for node 10  #2890
 - outbound: disable outbound to localhost by default #2952
+- spamassassin: allow returning DENYSOFT on errors
 
 ### New features
 

--- a/config/spamassassin.ini
+++ b/config/spamassassin.ini
@@ -51,6 +51,6 @@ modern_status_syntax=1
 
 [reject]
 ; Set to true to return DENYSOFT on errors, connection timeouts, or scanning timeouts
-error=false
-connect_timeout=false
-scan_timeout=false
+;error=false
+;connect_timeout=false
+;scan_timeout=false

--- a/config/spamassassin.ini
+++ b/config/spamassassin.ini
@@ -44,7 +44,13 @@ modern_status_syntax=1
 ;spamc_auth_header = X-Haraka-Relay
 
 [check]
-;authenticated=false
-;private_ip=false
-;local_ip=false
-;relay=false
+;authenticated=true
+;private_ip=true
+;local_ip=true
+;relay=true
+
+[reject]
+; Set to true to return DENYSOFT on errors, connection timeouts, or scanning timeouts
+error=false
+connect_timeout=false
+scan_timeout=false

--- a/config/spamassassin.ini
+++ b/config/spamassassin.ini
@@ -49,7 +49,7 @@ modern_status_syntax=1
 ;local_ip=true
 ;relay=true
 
-[reject]
+[defer]
 ; Set to true to return DENYSOFT on errors, connection timeouts, or scanning timeouts
 ;error=false
 ;connect_timeout=false

--- a/docs/plugins/spamassassin.md
+++ b/docs/plugins/spamassassin.md
@@ -124,7 +124,7 @@ meeting following criteria.
 
     If true, messages that are to be relayed will be scored.
 
-[check]
+[reject]
 =======
 
 The optional reject section can allow returning a DENYSOFT status back to the

--- a/docs/plugins/spamassassin.md
+++ b/docs/plugins/spamassassin.md
@@ -124,6 +124,32 @@ meeting following criteria.
 
     If true, messages that are to be relayed will be scored.
 
+[check]
+=======
+
+The optional reject section can allow returning a DENYSOFT status back to the
+client.  Turns these on to force the client to retry later in cases where
+spamassassin is not responding properly.  If set to false, then the errors
+will be ignored and message processing will continue.
+
+- error
+
+    Default: false
+
+    If true, return DENYSOFT on socket errors
+
+- connect\_timeout
+
+    Default: false
+
+    If true, return DENYSOFT on socket connection timeouts
+
+- scan\_timeout
+
+    Default: false
+
+    If true, return DENYSOFT on scan timeouts
+
 Extras
 ======
 

--- a/docs/plugins/spamassassin.md
+++ b/docs/plugins/spamassassin.md
@@ -124,11 +124,11 @@ meeting following criteria.
 
     If true, messages that are to be relayed will be scored.
 
-[reject]
+[defer]
 =======
 
-The optional reject section can allow returning a DENYSOFT status back to the
-client.  Turns these on to force the client to retry later in cases where
+The optional defer section can allow returning a DENYSOFT status back to the
+client.  Setting these to true will force the client to retry later in cases where
 spamassassin is not responding properly.  If set to false, then the errors
 will be ignored and message processing will continue.
 

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -305,8 +305,8 @@ exports.get_spamd_socket = function (next, conn, headers) {
         socket.destroy();
         conn.logerror(plugin, `connection failed: ${err.message}`);
         if (txn) txn.results.add(plugin, {err: `socket error: ${err.message}` });
-        if (!plugin.cfg.reject.error) return next();
-        return next(DENYSOFT, 'Spam scan error');
+        if (plugin.cfg.reject.error) return next(DENYSOFT, 'Spam scan error');
+        return next();
     });
 
     socket.on('timeout', function () {

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -303,7 +303,6 @@ exports.get_spamd_socket = function (next, conn, headers) {
 
     socket.on('error', err => {
         socket.destroy();
-        conn.logerror(plugin, `connection failed: ${err.message}`);
         if (txn) txn.results.add(plugin, {err: `socket error: ${err.message}` });
         if (plugin.cfg.reject.error) return next(DENYSOFT, 'Spam scan error');
         return next();
@@ -312,13 +311,11 @@ exports.get_spamd_socket = function (next, conn, headers) {
     socket.on('timeout', function () {
         socket.destroy();
         if (!this.is_connected) {
-            conn.logerror(plugin, 'spamd connection timed out');
-            if (txn) txn.results.add(plugin, {err: `spamd socket connect timeout` });
+            if (txn) txn.results.add(plugin, {err: `socket connect timeout` });
             if (plugin.cfg.reject.connect_timeout) return next(DENYSOFT, 'Spam connect error');
         }
         else {
-            conn.logerror(plugin, 'timeout waiting for results');
-            if (txn) txn.results.add(plugin, {err: `spamd timeout waiting for results` });
+            if (txn) txn.results.add(plugin, {err: `timeout waiting for results` });
             if (plugin.cfg.reject.scan_timeout) return next(DENYSOFT, 'Spam timeout error');
         }
         return next();

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -18,7 +18,7 @@ exports.load_spamassassin_ini = function () {
             '+check.private_ip',
             '+check.local_ip',
             '+check.relay',
-            
+
             '-reject.error',
             '-reject.connect_timeout',
             '-reject.scan_timeout',
@@ -279,7 +279,7 @@ exports.get_spamd_headers = function (conn, username) {
 exports.get_spamd_socket = function (next, conn, headers) {
     const plugin = this;
     const txn = conn.transaction;
-    
+
     // TODO: support multiple spamd backends
 
     const socket = new sock.Socket();

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -19,9 +19,9 @@ exports.load_spamassassin_ini = function () {
             '+check.local_ip',
             '+check.relay',
 
-            '-reject.error',
-            '-reject.connect_timeout',
-            '-reject.scan_timeout',
+            '-defer.error',
+            '-defer.connect_timeout',
+            '-defer.scan_timeout',
         ],
     }, () => {
         plugin.load_spamassassin_ini();
@@ -304,7 +304,7 @@ exports.get_spamd_socket = function (next, conn, headers) {
     socket.on('error', err => {
         socket.destroy();
         if (txn) txn.results.add(plugin, {err: `socket error: ${err.message}` });
-        if (plugin.cfg.reject.error) return next(DENYSOFT, 'Spam scan error');
+        if (plugin.cfg.defer.error) return next(DENYSOFT, 'spamd scan error');
         return next();
     });
 
@@ -312,11 +312,11 @@ exports.get_spamd_socket = function (next, conn, headers) {
         socket.destroy();
         if (!this.is_connected) {
             if (txn) txn.results.add(plugin, {err: `socket connect timeout` });
-            if (plugin.cfg.reject.connect_timeout) return next(DENYSOFT, 'Spam connect error');
+            if (plugin.cfg.defer.connect_timeout) return next(DENYSOFT, 'spamd connect timeout');
         }
         else {
             if (txn) txn.results.add(plugin, {err: `timeout waiting for results` });
-            if (plugin.cfg.reject.scan_timeout) return next(DENYSOFT, 'Spam timeout error');
+            if (plugin.cfg.defer.scan_timeout) return next(DENYSOFT, 'spamd scan timeout');
         }
         return next();
     });


### PR DESCRIPTION
Changes proposed in this pull request:
- Allow spamassassin to return DENYSOFT on connection errors, connection timeouts, and scan timeouts
- New configuration options added for each scenario, defaulting to false (honoring existing behavior)

Checklist:
- [X] docs updated
- [ ] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
