### PR TITLE
User configurable temporary fail delay times

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,6 +18,7 @@
 - tls: add `no_starttls_ports` - an array of incoming ports where STARTTLS is not advertised
 - outbound: add local_mx_ok config #2952
 - skip plugins at runtime by pushing name into transaction.skip_plugins #2966
+- outbound: add ability to specify delay times for temporary fails in `temp_fail_intervals` #2969
 
 ### Fixes
 

--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -101,6 +101,18 @@ Default: false. By default, outbound to a local IP is disabled, to avoid creatin
 outbound loops. Set this to true if you want to allow outbound to local IPs. 
 This could be useful if you want to deliver mail to localhost on another port.
 
+* `temp_fail_intervals`
+
+Set this to specify the delay intervals to use between trying to re-send an email
+that has a temporary failure condition.  The setting is a comma separated list of
+time spans and multipliers.  The time span is a number followed by `s`, `m`, `h`, or `d`
+to represent seconds, minutes, hours, and days, respectively.  The multiplier is an
+asterisk followed by an integer representing the number of times to repeat the interval.
+For example, the entry `1m, 5m*2, 1h*3` results in an array of delay times of
+`[60,300,300,3600,3600,3600]` in seconds.  The email will be bounced when the array
+runs out of intervals (the 7th failure in this case).  Set this to `none` to bounce the
+email on the first temporary failure.
+
 ### outbound.bounce\_message
 
 See "Bounce Messages" below for details.

--- a/outbound/config.js
+++ b/outbound/config.js
@@ -51,7 +51,7 @@ function load_config () {
     set_temp_fail_intervals(cfg);
 }
 
-function set_temp_fail_intervals(cfg) {
+function set_temp_fail_intervals (cfg) {
     // Set the outbound temp fail intervals (retry times) using the following rules:
     //   1) temp_fail_intervals takes precedence over maxTempFailures if both are specified
     //   2) if temp_fail_intervals is not specified or is illegaly specified, then initialize
@@ -60,7 +60,7 @@ function set_temp_fail_intervals(cfg) {
     //      equivalent behavior of specifying maxTempFailures=1
 
     // Fallback function to create an array of the original retry times
-    function set_old_defaults() {
+    function set_old_defaults () {
         cfg.temp_fail_intervals = [];
         for (let i=1; i<cfg.maxTempFailures; i++) {
             cfg.temp_fail_intervals.push(Math.pow(2, (i + 5)));
@@ -68,7 +68,7 @@ function set_temp_fail_intervals(cfg) {
     }
 
     // Helpful error function in case of parsing failure
-    function error(i, msg) {
+    function error (i, msg) {
         logger.logerror(`outbound temp_fail_intervals syntax error parsing element ${i}: ${msg}`);
         logger.logwarn('Setting outbound temp_fail_intervals to old defaults because of previous error');
         set_old_defaults();
@@ -82,7 +82,7 @@ function set_temp_fail_intervals(cfg) {
     // If here then turn the text input into an expanded array of intervals (in seconds)
     // i.e, turn "1m,5m*2,1h*3" into [60,300,300,3600,3600,3600]
     // Parse manually to do better syntax checking and provide better failure messages
-    let times = [];
+    const times = [];
     let input = cfg.temp_fail_intervals.replace(/\s+/g, '').toLowerCase();
     if (input.length === 0) return error(0, 'nothing specified');
     if (input === 'none') {

--- a/outbound/config.js
+++ b/outbound/config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const config = require('haraka-config');
+const logger = require('../logger');
 
 function load_config () {
     const cfg = exports.cfg = config.get('outbound.ini', {
@@ -21,6 +22,9 @@ function load_config () {
     }
     if (!cfg.enable_tls && config.get('outbound.enable_tls')) {
         cfg.enable_tls = true;
+    }
+    if (!cfg.temp_fail_intervals) {
+        cfg.temp_fail_intervals = config.get('outbound.temp_fail_intervals');
     }
     if (!cfg.maxTempFailures) {
         cfg.maxTempFailures = config.get('outbound.maxTempFailures') || 13;
@@ -43,6 +47,90 @@ function load_config () {
     if (!cfg.received_header) {
         cfg.received_header = config.get('outbound.received_header') || 'Haraka outbound';
     }
+
+    set_temp_fail_intervals(cfg);
+}
+
+function set_temp_fail_intervals(cfg) {
+    // Set the outbound temp fail intervals (retry times) using the following rules:
+    //   1) temp_fail_intervals takes precedence over maxTempFailures if both are specified
+    //   2) if temp_fail_intervals is not specified or is illegaly specified, then initialize
+    //      it with the equivalent times of maxTempFailures using the original 2^N formula
+    //   3) the word "none" can be specified if you do not want to retry a temp failure,
+    //      equivalent behavior of specifying maxTempFailures=1
+
+    // Fallback function to create an array of the original retry times
+    function set_old_defaults() {
+        cfg.temp_fail_intervals = [];
+        for (let i=1; i<cfg.maxTempFailures; i++) {
+            cfg.temp_fail_intervals.push(Math.pow(2, (i + 5)));
+        }
+    }
+
+    // Helpful error function in case of parsing failure
+    function error(i, msg) {
+        logger.logerror(`outbound temp_fail_intervals syntax error parsing element ${i}: ${msg}`);
+        logger.logwarn('Setting outbound temp_fail_intervals to old defaults because of previous error');
+        set_old_defaults();
+    }
+
+    // If the new value isn't specified, then create the old defaults
+    if (!cfg.temp_fail_intervals) {
+        return set_old_defaults();
+    }
+
+    // If here then turn the text input into an expanded array of intervals (in seconds)
+    // i.e, turn "1m,5m*2,1h*3" into [60,300,300,3600,3600,3600]
+    // Parse manually to do better syntax checking and provide better failure messages
+    let times = [];
+    let input = cfg.temp_fail_intervals.replace(/\s+/g, '').toLowerCase();
+    if (input.length === 0) return error(0, 'nothing specified');
+    if (input === 'none') {
+        cfg.temp_fail_intervals = [];
+        return;
+    }
+    input = input.split(',')
+
+    for (let i=0; i<input.length; i++) {
+        const delay = input[i].split('*');
+        if (delay.length === 1) delay.push(1);
+        else if (delay.length === 2) delay[1] = Number(delay[1]);
+        else return error(i, 'too many *');
+        if (!Number.isInteger(delay[1])) return error(i, 'multiplier is not an integer');
+
+        if (delay[0].length < 2) error(i, 'invalid time span');
+        const symbol = delay[0].charAt(delay[0].length - 1);
+        let num = Number(delay[0].slice(0, -1));
+        if (isNaN(num)) return error(i, 'invalid number or symbol');
+
+        switch (symbol) {
+            case 's':
+                // do nothing, this is the base unit
+                break;
+            case 'm':
+                num = num * 60;
+                break;
+            case 'h':
+                num = num * 3600;
+                break;
+            case 'd':
+                num = num * 86400;
+                break;
+            default:
+                return error(i, 'invalid time span symbol');
+        }
+        // Sanity check (what should this number be?)
+        if (num < 5) return error(i, 'delay time too small, should be >=5 seconds')
+        for (let j = 0; j < delay[1]; j++) {
+            times.push(num);
+        }
+    }
+
+    // One last check, just in case...should never be true
+    if (times.length === 0) return error(0, 'unexpected parsing result');
+
+    // If here, success, so actually store the calculated array in the config
+    cfg.temp_fail_intervals = times;
 }
 
 load_config();

--- a/outbound/config.js
+++ b/outbound/config.js
@@ -48,16 +48,17 @@ function load_config () {
         cfg.received_header = config.get('outbound.received_header') || 'Haraka outbound';
     }
 
-    set_temp_fail_intervals(cfg);
+    exports.set_temp_fail_intervals();
 }
 
-function set_temp_fail_intervals (cfg) {
+exports.set_temp_fail_intervals = function () {
     // Set the outbound temp fail intervals (retry times) using the following rules:
     //   1) temp_fail_intervals takes precedence over maxTempFailures if both are specified
-    //   2) if temp_fail_intervals is not specified or is illegaly specified, then initialize
+    //   2) if temp_fail_intervals is not specified or is illegally specified, then initialize
     //      it with the equivalent times of maxTempFailures using the original 2^N formula
     //   3) the word "none" can be specified if you do not want to retry a temp failure,
     //      equivalent behavior of specifying maxTempFailures=1
+    const cfg = this.cfg;
 
     // Fallback function to create an array of the original retry times
     function set_old_defaults () {

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -1368,19 +1368,11 @@ class HMailItem extends events.EventEmitter {
         this.num_failures++;
 
         // Test for max failures which is configurable.
-        if (this.num_failures >= (obc.cfg.maxTempFailures)) {
+        if (this.num_failures > (obc.cfg.temp_fail_intervals.length)) {
             return this.convert_temp_failed_to_bounce(`Too many failures (${err})`, extra);
         }
 
-        // basic strategy is we exponentially grow the delay to the power
-        // two each time, starting at 2 ** 6 seconds
-
-        // Note: More advanced options should be explored in the future as the
-        // last delay is 2**17 secs (1.5 days), which is a bit long... Exim has a max delay of
-        // 6 hours (configurable) and the expire time is also configurable... But
-        // this is good enough for now.
-
-        const delay = Math.pow(2, (this.num_failures + 5));
+        const delay = obc.cfg.temp_fail_intervals[this.num_failures-1];
 
         plugins.run_hooks('deferred', this, {delay, err});
     }

--- a/tests/outbound/index.js
+++ b/tests/outbound/index.js
@@ -52,7 +52,7 @@ exports.outbound = {
         });
         test.done();
     },
-	'set_temp_fail_intervals coverage': test => {
+    'set_temp_fail_intervals coverage': test => {
         test.expect(5);
 
         const config = require('../../outbound/config');
@@ -75,7 +75,7 @@ exports.outbound = {
         config.set_temp_fail_intervals();
         test.deepEqual(config.cfg.temp_fail_intervals, [64,128,256,512,1024,2048,4096,8192,16384,32768,65536,131072]);
         test.done();
-	}
+    }
 }
 
 exports.qfile = {

--- a/tests/outbound/index.js
+++ b/tests/outbound/index.js
@@ -51,7 +51,31 @@ exports.outbound = {
             test.ok(HMailItem.prototype[`log${level.toLowerCase()}`], `Log method for level: ${level}`);
         });
         test.done();
-    }
+    },
+	'set_temp_fail_intervals coverage': test => {
+        test.expect(5);
+
+        const config = require('../../outbound/config');
+        // Test default configuration
+        test.deepEqual(config.cfg.temp_fail_intervals, [64,128,256,512,1024,2048,4096,8192,16384,32768,65536,131072]);
+        // Test a simple configuration
+        config.cfg.temp_fail_intervals = '10s, 1m*2';
+        config.set_temp_fail_intervals();
+        test.deepEqual(config.cfg.temp_fail_intervals, [10, 60, 60]);
+        // Test a complex configuration
+        config.cfg.temp_fail_intervals = '30s, 1m, 5m, 9m, 15m*3, 30m*2, 1h*3, 2h*3, 1d';
+        config.set_temp_fail_intervals();
+        test.deepEqual(config.cfg.temp_fail_intervals, [30,60,300,540,900,900,900,1800,1800,3600,3600,3600,7200,7200,7200,86400]);
+        // Test the "none" configuration
+        config.cfg.temp_fail_intervals = 'none';
+        config.set_temp_fail_intervals();
+        test.deepEqual(config.cfg.temp_fail_intervals, []);
+        // Test bad config (should revert to default)
+        config.cfg.temp_fail_intervals = '60 min';
+        config.set_temp_fail_intervals();
+        test.deepEqual(config.cfg.temp_fail_intervals, [64,128,256,512,1024,2048,4096,8192,16384,32768,65536,131072]);
+        test.done();
+	}
 }
 
 exports.qfile = {


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a new config option in outbound to allow configuration of delay times
- The configuration would look something like (see the docs for specifics):
   `temp_fail_intervals` = `1m, 5m, 9m, 15m*3, 30m*10, 1h*6, 2h*6` 

Checklist:
- [x] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
