### PR TITLE
prevent local delivery loop when target exchange resolves to a local hostname

### DIFF
--- a/outbound/mx_lookup.js
+++ b/outbound/mx_lookup.js
@@ -35,7 +35,7 @@ exports.lookup_mx = function lookup_mx (domain, cb) {
         }
         else if (addresses && addresses.length) {
             for (let i=0,l=addresses.length; i < l; i++) {
-                if (obc.cfg.local_mx_ok || !net_utils.is_local_ip(addresses[i].exchange)) {
+                if (obc.cfg.local_mx_ok || !net_utils.is_local_host(addresses[i].exchange)) {
                     const mx = wrap_mx(addresses[i]);
                     mxs.push(mx);
                 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "haraka-config"         : "^1.0.20",
     "haraka-constants"      : "^1.0.5",
     "haraka-dsn"            : "^1.0.3",
-    "haraka-net-utils"      : "^1.3.1",
+    "haraka-net-utils"      : "^1.3.2",
     "haraka-notes"          : "^1.0.4",
     "haraka-plugin-redis"   : "^1.0.12",
     "haraka-results"        : "^2.0.3",


### PR DESCRIPTION
Fixes #2809 also for host names (#2952 solved it for IPs only). Requires merge of [haraka-net-utils#63](https://github.com/haraka/haraka-net-utils/pull/63) first.

Changes proposed in this pull request:
- new function `net_utils.is_local_host` is used instead of `net_utils.is_local_ip` to check if the exchange is localhost.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
