### PR TITLE
remove not-an-error error message

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -6,6 +6,7 @@
 - reformat dkim signature to multi-line #2991
 - add lots of `if (!transaction) return` in places #2732
 - use optional chaining when accessing transactions #2732
+- dkim_sign: remove spurious error logging #3034
 
 
 ## 2.8.28 - 2021-10-14

--- a/plugins/dkim_sign.js
+++ b/plugins/dkim_sign.js
@@ -187,10 +187,7 @@ exports.hook_queue_outbound = exports.hook_pre_send_trans_email = function (next
         // props: selector, domain, & private_key
         if (err) connection.logerror(plugin, `${err.message}`);
 
-        if (!plugin.has_key_data(connection, props)) {
-            connection.logerror(`missing key data for ${props.selector}.${props.domain}`)
-            return next();
-        }
+        if (!plugin.has_key_data(connection, props)) return next();
 
         connection.logdebug(plugin, `domain: ${props.domain}`);
 


### PR DESCRIPTION
Changes proposed in this pull request:
- don't emit an error after deciding not to skip signing a message and logging why

````
Apr  2 07:48:29 [INFO] [] [dkim_verify] identity="@online.costco.com" domain="online.costco.com" selector="key1" result=pass
Apr  2 07:48:29 [NOTICE] [-] [dkim_sign] skipped: no private key for online.costco.com
Apr  2 07:48:29 [ERROR] [-] [core] missing key data for undefined.online.costco.com
Apr  2 07:48:30 [NOTICE] [] [core] disconnect ip=67.90.142.249 rdns=mta16v7.online.costco.com helo=mta16v7.online.costco.com relay=N early=N esmtp=Y tls=Y pipe=N errors=0 txns=1 rcpts=1/0/0 msgs=1/0/0 bytes=211031 lr="" time=8.286
````

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
