### PR TITLE
bugfix queue/dilivery with latest generic-pool

### DIFF
--- a/config/outbound.ini
+++ b/config/outbound.ini
@@ -28,3 +28,7 @@
 ; pool_concurrency_max: default: 10
 ; set to zero to disable pools
 ; pool_concurrency_max=0
+
+; pool_waiting_queue_max: default: 20
+; set to zero to disable queue length restrictions
+; pool_waiting_queue_max=0

--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -95,6 +95,13 @@ Set this to `0` to completely disable the pooling code.
 This value determines how many concurrent connections can be made to a single
 IP address (destination) in the pool. Default: 10 connections.
 
+* `pool_waiting_queue_max`
+
+Set this to `0` to disable queue length restrictions.
+
+This value determines max amount of connections waited to be processed in pool
+of connections to single IP address (destination). Default: 20 connections.
+
 * `local_mx_ok`
 
 Default: false. By default, outbound to a local IP is disabled, to avoid creating 

--- a/outbound/client_pool.js
+++ b/outbound/client_pool.js
@@ -55,7 +55,7 @@ function get_pool (port, host, local_addr, is_unix_socket, max) {
 
         create () {
             return new Promise(function (resolve, reject) {
-                _create_socket(this.name, port, host, local_addr, is_unix_socket, (err, socket) => {
+                _create_socket(name, port, host, local_addr, is_unix_socket, (err, socket) => {
                     if (err) return reject(err)
                     resolve(socket)
                 })
@@ -111,7 +111,7 @@ exports.get_client = (port, host, local_addr, is_unix_socket, callback) => {
     }
 
     const pool = get_pool(port, host, local_addr, is_unix_socket, obc.cfg.pool_concurrency_max);
-    if (pool.waitingClientsCount() >= obc.cfg.pool_concurrency_max) {
+    if (pool.borrowed >= obc.cfg.pool_concurrency_max) {
         return callback("Too many waiting clients for pool", null);
     }
     pool.acquire().then(socket => {

--- a/outbound/client_pool.js
+++ b/outbound/client_pool.js
@@ -111,9 +111,10 @@ exports.get_client = (port, host, local_addr, is_unix_socket, callback) => {
     }
 
     const pool = get_pool(port, host, local_addr, is_unix_socket, obc.cfg.pool_concurrency_max);
-    if (pool.borrowed >= obc.cfg.pool_concurrency_max) {
+    if (obc.cfg.pool_waiting_queue_max != 0 && pool.pending >= obc.cfg.pool_waiting_queue_max) {
         return callback("Too many waiting clients for pool", null);
     }
+
     pool.acquire().then(socket => {
         socket.__acquired = true;
         logger.loginfo(`[outbound] acquired socket ${socket.__uuid} for ${socket.__pool_name}`);

--- a/outbound/config.js
+++ b/outbound/config.js
@@ -41,6 +41,9 @@ function load_config () {
     if (cfg.pool_concurrency_max === undefined) {
         cfg.pool_concurrency_max = 10;
     }
+    if (cfg.pool_waiting_queue_max === undefined) {
+        cfg.pool_waiting_queue_max = 20;
+    }
     if (!cfg.ipv6_enabled && config.get('outbound.ipv6_enabled')) {
         cfg.ipv6_enabled = true;
     }


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
With the lates generic-pool (version 3.8.2 at package.json) doesn't work simple queue delivery
It is repeatedly creating new pool entry until JavaScript heap is over and process is terminated by low memory reason


Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
