### PR TITLE
Add force_tls option to ToDo object to require outbound TLS

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -31,6 +31,7 @@
 - chore: add lots of `if (!transaction) return` in places #2732
 - chore(test): build shims for windows-2022 & node on windows #3052
 - chore(test): restore CI tests to working order #3030
+- tls: add force_tls option to the ToDo object
 
 
 ## 2.8.28 - 2021-10-14

--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -157,6 +157,8 @@ you may be interested in are:
 ** outbound_helo - the EHLO domain to use (again, do not set manually)
 * queue_time - the epoch milliseconds time when this mail was queued
 * uuid - the original transaction.uuid
+* force_tls - if true, this mail will be sent over TLS or defer
+
 
 Outbound Mail Hooks
 -------------------

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -308,20 +308,20 @@ class HMailItem extends events.EventEmitter {
 
         self.force_tls = this.todo.force_tls;
         if (!self.force_tls) {
-          if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, host)) {
-              this.logdebug(`Forcing TLS for host ${host}`);
-              self.force_tls = true;
-          }
-          if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, self.todo.domain)) {
-              this.logdebug(`Forcing TLS for domain ${self.todo.domain}`);
-              self.force_tls = true;
-          }
+            if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, host)) {
+                this.logdebug(`Forcing TLS for host ${host}`);
+                self.force_tls = true;
+            }
+            if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, self.todo.domain)) {
+                this.logdebug(`Forcing TLS for domain ${self.todo.domain}`);
+                self.force_tls = true;
+            }
 
-          // IP or IP:port
-          if (net.isIP(host)) {
-              self.hostlist = [ host ];
-              return self.try_deliver_host(mx);
-          }
+            // IP or IP:port
+            if (net.isIP(host)) {
+                self.hostlist = [ host ];
+                return self.try_deliver_host(mx);
+            }
         }
 
         host   = mx.exchange;

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -306,20 +306,22 @@ class HMailItem extends events.EventEmitter {
         const mx = this.mxlist.shift();
         let host = mx.exchange;
 
-        self.force_tls = false;
-        if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, host)) {
-            this.logdebug(`Forcing TLS for host ${host}`);
-            self.force_tls = true;
-        }
-        if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, self.todo.domain)) {
-            this.logdebug(`Forcing TLS for domain ${self.todo.domain}`);
-            self.force_tls = true;
-        }
+        self.force_tls = this.todo.force_tls;
+        if (!self.force_tls) {
+          if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, host)) {
+              this.logdebug(`Forcing TLS for host ${host}`);
+              self.force_tls = true;
+          }
+          if (net_utils.ip_in_list(obtls.cfg.force_tls_hosts, self.todo.domain)) {
+              this.logdebug(`Forcing TLS for domain ${self.todo.domain}`);
+              self.force_tls = true;
+          }
 
-        // IP or IP:port
-        if (net.isIP(host)) {
-            self.hostlist = [ host ];
-            return self.try_deliver_host(mx);
+          // IP or IP:port
+          if (net.isIP(host)) {
+              self.hostlist = [ host ];
+              return self.try_deliver_host(mx);
+          }
         }
 
         host   = mx.exchange;

--- a/outbound/todo.js
+++ b/outbound/todo.js
@@ -10,6 +10,7 @@ class TODOItem {
         this.message_stream = transaction.message_stream;
         this.notes = transaction.notes;
         this.uuid = transaction.uuid;
+        this.force_tls = false;
     }
 }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a force_tls option to the ToDo object to allow forcing TLS for outbound from a hook

Checklist:
- [x] docs updated
- [-] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
