### PR TITLE
client_pool: fix debug message

### DIFF
--- a/outbound/client_pool.js
+++ b/outbound/client_pool.js
@@ -15,15 +15,7 @@ function _create_socket (pool_name, port, host, local_addr, is_unix_socket, call
     socket.__pool_name = pool_name;
     socket.__uuid = utils.uuid();
     socket.setTimeout(obc.cfg.connect_timeout * 1000);
-    logger.logdebug(
-        '[outbound] created',
-        {
-            uuid: socket.__uuid,
-            host,
-            port,
-            pool_timeout: obc.cfg.pool_timeout
-        }
-    );
+    logger.logdebug(`[outbound] created. host: ${host} port: ${port} pool_timeout: ${obc.cfg.pool_timeout}`, { uuid: socket.__uuid });
     socket.once('connect', () => {
         socket.removeAllListeners('error'); // these get added after callback
         socket.removeAllListeners('timeout');


### PR DESCRIPTION
Currently, the messages look like this:

```
[DEBUG] [02189A5C-54DC-4B51-AEB1-C3BE81488DB0] [core] [outbound] created
[DEBUG] [ED283FFA-B342-4F14-9976-64AA653F6CF9] [core] [outbound] created
[DEBUG] [CD8A5DD9-ECF1-47B4-9909-ACC0C986BB7D] [core] [outbound] created
[DEBUG] [771DEF11-85D6-4B4A-9850-23AF523DA624] [core] [outbound] created
```
