### PR TITLE
Removed AUTH PLAIN authorization identity

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -33,6 +33,7 @@
 - chore(test): restore CI tests to working order #3030
 - tls: add force_tls option to the ToDo object
 - fix(banner): banner was inserted erroneously into text attachments
+- outbound: remove hardcoded AUTH PLAIN authorization identity
 
 ## 2.8.28 - 2021-10-14
 

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -560,7 +560,7 @@ class HMailItem extends events.EventEmitter {
 
                 switch (mx.auth_type.toUpperCase()) {
                     case 'PLAIN':
-                        return send_command('AUTH', `PLAIN ${utils.base64(`${mx.auth_user}\0${mx.auth_user}\0${mx.auth_pass}`)}`);
+                        return send_command('AUTH', `PLAIN ${utils.base64(`\0${mx.auth_user}\0${mx.auth_pass}`)}`);
                     case 'LOGIN':
                         authenticating = true;
                         return send_command('AUTH', 'LOGIN');


### PR DESCRIPTION
Changes proposed in this pull request:
- do not assume authorization identity rather let destination server derive itself (see https://www.rfc-editor.org/rfc/rfc4616.html#section-2), smtp_forward.js works the same

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
