### PR TITLE
outbound: set acquireTimeoutMillis

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -34,6 +34,7 @@
 - tls: add force_tls option to the ToDo object
 - fix(banner): banner was inserted erroneously into text attachments
 - outbound: remove hardcoded AUTH PLAIN authorization identity
+- outbound: set acquireTimeoutMillis to prevent constant reconnect to unreachable servers
 
 ## 2.8.28 - 2021-10-14
 

--- a/outbound/client_pool.js
+++ b/outbound/client_pool.js
@@ -89,6 +89,7 @@ function get_pool (port, host, local_addr, is_unix_socket, max) {
     const opts = {
         max: max || 10,
         idleTimeoutMillis: obc.cfg.pool_timeout * 1000,
+        acquireTimeoutMillis: 10000 // temporary fix for #3100
     }
     const pool = generic_pool.createPool(factory, opts);
     server.notes.pool[name] = pool;


### PR DESCRIPTION
...to prevent constant reconnect to unreachable servers

The generic-pool module is built on the assumption that acquire always succeeds. It is implemented as a busy loop of calling create() non-stop and there is no way to make acquire() return an error.

As a mitigation error, we make acquire() fail after 10 seconds. Note that it will still busy loop for 10 seconds. We have to fix upstream module or replace generic-pool to really fix the problem.

see #3100

Fixes #

Checklist:
- [ ] docs updated
- [ ] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
