### PR TITLE
smtp_forward: restore queue_outbound when config asks for it

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 ### Changes
 
+- smtp_forward: restored ability to enable queue_outbound #3119
 - dep(generic-pool): remove pooling from outbound #3115
 - smtp_client: disable pooling in get_client_plugin, #3113
 - fix(smtp_client): add missing `$` char in front of interpolated string

--- a/config/smtp_forward.ini
+++ b/config/smtp_forward.ini
@@ -17,5 +17,5 @@ port=2555
 ;auth_pass=
 
 ; should outbound messages be delivered by smtp_forward?
-; see https://github.com/haraka/Haraka/issues/1472
-; enable_outbound=true
+; see #1472 and #2795
+; enable_outbound=false

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -26,6 +26,10 @@ exports.register = function () {
 
     plugin.register_hook('queue', 'queue_forward');
 
+    if (plugin.cfg.main.enable_outbound) {
+        plugin.register_hook('queue_outbound', 'queue_forward');
+    }
+
     plugin.register_hook('get_mx', 'get_mx'); // for relaying outbound messages
 }
 
@@ -35,7 +39,7 @@ exports.load_smtp_forward_ini = function () {
     plugin.cfg = plugin.config.get('smtp_forward.ini', {
         booleans: [
             '-main.enable_tls',
-            '+main.enable_outbound',
+            '-main.enable_outbound',
             'main.one_message_per_rcpt',
             '-main.check_sender',
             '-main.check_recipient',
@@ -46,10 +50,6 @@ exports.load_smtp_forward_ini = function () {
     () => {
         plugin.load_smtp_forward_ini();
     });
-
-    if (plugin.cfg.main.enable_outbound) {
-        plugin.lognotice('outbound enabled, will default to disabled in Haraka v3 (see #1472)');
-    }
 }
 
 exports.get_config = function (conn) {

--- a/tests/plugins/queue/smtp_forward.js
+++ b/tests/plugins/queue/smtp_forward.js
@@ -160,33 +160,33 @@ exports.get_mx = {
 
 exports.is_outbound_enabled = {
     setUp : _setup,
-    'enable_outbound is true by default' (test) {
+    'enable_outbound is false by default' (test) {
         test.expect(1);
-        test.equal(this.plugin.is_outbound_enabled(this.plugin.cfg), true);
+        test.equal(this.plugin.is_outbound_enabled(this.plugin.cfg), false);
         test.done();
     },
-    'per-domain enable_outbound is true by default' (test) {
+    'per-domain enable_outbound is false by default' (test) {
         test.expect(1);
-        this.connection.transaction.rcpt_to = [ new Address('<postmaster@test.com>') ];
-        const cfg = this.plugin.get_config(this.connection);
-        test.equal(this.plugin.is_outbound_enabled(cfg), true);
-        test.done();
-    },
-    'per-domain enable_outbound can be set to false' (test) {
-        test.expect(1);
-        this.plugin.cfg['test.com'].enable_outbound = false;
         this.connection.transaction.rcpt_to = [ new Address('<postmaster@test.com>') ];
         const cfg = this.plugin.get_config(this.connection);
         test.equal(this.plugin.is_outbound_enabled(cfg), false);
         test.done();
     },
-    'per-domain enable_outbound is true even if top level is false' (test) {
+    'per-domain enable_outbound can be set to true' (test) {
         test.expect(1);
-        this.plugin.cfg.main.enable_outbound = false; // this will be ignored
         this.plugin.cfg['test.com'].enable_outbound = true;
         this.connection.transaction.rcpt_to = [ new Address('<postmaster@test.com>') ];
         const cfg = this.plugin.get_config(this.connection);
         test.equal(this.plugin.is_outbound_enabled(cfg), true);
+        test.done();
+    },
+    'per-domain enable_outbound is false even if top level is false' (test) {
+        test.expect(1);
+        this.plugin.cfg.main.enable_outbound = false; // this will be ignored
+        this.plugin.cfg['test.com'].enable_outbound = false;
+        this.connection.transaction.rcpt_to = [ new Address('<postmaster@test.com>') ];
+        const cfg = this.plugin.get_config(this.connection);
+        test.equal(this.plugin.is_outbound_enabled(cfg), false);
         test.done();
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- partly reverts #2795. See also #1472

switches smtp_forward on outbound to off-by-default. Enabled only when asked for in config file.

Checklist:
- [ ] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
