### PR TITLE
lint changes, cherry picked from #3135

### DIFF
--- a/dkim.js
+++ b/dkim.js
@@ -302,11 +302,7 @@ class DKIMObject {
                 }
             }
             if (!res) return this.result('no key for signature', 'invalid');
-            for (let record of res) {
-                // Node 0.11.x compatibility
-                if (Array.isArray(record)) {
-                    record = record.join('');
-                }
+            for (const record of res) {
                 if (!record.includes('p=')) {
                     this.debug(`${this.identity}: ignoring TXT record: ${record}`);
                     continue;

--- a/plugins/auth/auth_proxy.js
+++ b/plugins/auth/auth_proxy.js
@@ -1,7 +1,9 @@
 // Proxy AUTH requests selectively by domain
+
 const sock  = require('./line_socket');
 const utils = require('haraka-utils');
-const smtp_regexp = /^([0-9]{3})([ -])(.*)/;
+
+const smtp_regexp = /^(\d{3})([ -])(.*)/;
 
 exports.register = function () {
     this.inherits('auth/auth_base');
@@ -25,8 +27,8 @@ exports.hook_capabilities = (next, connection) => {
 }
 
 exports.check_plain_passwd = function (connection, user, passwd, cb) {
-    let domain;
-    if ((domain = /@([^@]+)$/.exec(user))) {
+    let domain = /@([^@]+)$/.exec(user);
+    if (domain) {
         domain = domain[1].toLowerCase();
     }
     else {
@@ -82,7 +84,6 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
     socket.on('error', err => {
         connection.logerror(self, `connection failed to host ${host}: ${err}`);
         socket.end();
-        return;
     });
     socket.send_command = function (cmd, data) {
         let line = cmd + (data ? (` ${data}`) : '');
@@ -175,8 +176,8 @@ exports.try_auth_proxy = function (connection, hosts, user, passwd, cb) {
             }
             if (code.startsWith('5')) {
                 // Initial attempt failed; strip domain and retry.
-                let u;
-                if ((u = /^([^@]+)@.+$/.exec(user))) {
+                const u = /^([^@]+)@.+$/.exec(user)
+                if (u) {
                     user = u[1];
                     if (methods.includes('PLAIN')) {
                         socket.send_command('AUTH', `PLAIN ${utils.base64(`\0${user}\0${passwd}`)}`);

--- a/plugins/avg.js
+++ b/plugins/avg.js
@@ -7,7 +7,8 @@ const fs   = require('fs');
 const path = require('path');
 
 const sock = require('./line_socket');
-const smtp_regexp = /^([0-9]{3})([ -])(.*)/;
+
+const smtp_regexp = /^(\d{3})([ -])(.*)/;
 
 exports.register = function () {
 

--- a/plugins/clamd.js
+++ b/plugins/clamd.js
@@ -363,18 +363,19 @@ exports.send_clamd_predata = (socket, cb) => {
 }
 
 function clamd_connect (socket, host) {
-    let match;
+
     if (host.match(/^\//)) {
-        // assume unix socket
-        socket.connect(host);
+        socket.connect(host); // starts with /, unix socket
+        return
     }
-    else if ((match = /^\[([^\] ]+)\](?::(\d+))?/.exec(host))) {
-        // IPv6 literal
-        socket.connect((match[2] || 3310), match[1]);
+
+    const match = /^\[([^\] ]+)\](?::(\d+))?/.exec(host);
+    if (match) {
+        socket.connect((match[2] || 3310), match[1]); // IPv6 literal
+        return
     }
-    else {
-        // IP:port, hostname:port or hostname
-        const hostport = host.split(/:/);
-        socket.connect((hostport[1] || 3310), hostport[0]);
-    }
+
+    // IP:port, hostname:port or hostname
+    const hostport = host.split(/:/);
+    socket.connect((hostport[1] || 3310), hostport[0]);
 }

--- a/plugins/delay_deny.js
+++ b/plugins/delay_deny.js
@@ -93,7 +93,7 @@ exports.hook_deny = function (next, connection, params) {
             // fall through
         default:
             // No delays
-            return next();
+            next();
     }
 }
 
@@ -128,7 +128,7 @@ exports.hook_rcpt_ok = function (next, connection, rcpt) {
             return next(params[0], params[1]);
         }
     }
-    return next();
+    next();
 }
 
 exports.hook_data = (next, connection) => {
@@ -145,5 +145,5 @@ exports.hook_data = (next, connection) => {
     }
     if (fails.length) transaction.add_header('X-Haraka-Fail-Pre', fails.join(' '));
 
-    return next();
+    next();
 }

--- a/plugins/greylist.js
+++ b/plugins/greylist.js
@@ -342,7 +342,7 @@ exports.process_skip_rules = function (connection) {
         }
     }
 
-    return false;
+    return '';
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/plugins/messagesniffer.js
+++ b/plugins/messagesniffer.js
@@ -89,11 +89,11 @@ exports.hook_connect = function (next, connection) {
                 default:
                     // Unknown
                     connection.logerror(this, `Unknown GBUdb range: ${gbudb.range}`);
-                    return next();
+                    next();
             }
         }
         else {
-            return next();
+            next();
         }
     });
 }
@@ -136,7 +136,7 @@ exports.hook_data_post = function (next, connection) {
 
     ws.once('error', err => {
         connection.logerror(this, `Error writing temporary file: ${err.message}`);
-        return next();
+        next();
     });
 
     ws.once('close', () => {
@@ -338,11 +338,11 @@ exports.hook_disconnect = function (next, connection) {
             else {
                 connection.logdebug(this, `GBUdb bad encounter added for ${connection.remote.ip}`);
             }
-            return next();
+            next();
         });
     }
     else {
-        return next();
+        next();
     }
 }
 
@@ -367,16 +367,14 @@ function SNFClient (req, cb) {
     });
     sock.once('end', () => {
         // Check for result
+        if (/<result /.exec(result)) return cb(null, result);
+
         let match;
-        if (/<result /.exec(result)) {
-            return cb(null, result);
-        }
-        else if ((match = /<error message='([^']+)'/.exec(result))) {
+        if ((match = /<error message='([^']+)'/.exec(result))) {
             return cb(new Error(match[1]));
         }
-        else {
-            return cb(new Error(`unexpected result: ${result}`));
-        }
+
+        return cb(new Error(`unexpected result: ${result}`));
     });
     // Start the sequence
     sock.connect(port);

--- a/plugins/messagesniffer.js
+++ b/plugins/messagesniffer.js
@@ -352,7 +352,7 @@ function SNFClient (req, cb) {
     sock.setTimeout(30 * 1000); // Connection timeout
     sock.once('timeout', function () {
         this.destroy();
-        return cb(new Error('connection timed out'));
+        cb(new Error('connection timed out'));
     });
     sock.once('error', err => cb(err));
     sock.once('connect', function () {
@@ -374,7 +374,7 @@ function SNFClient (req, cb) {
             return cb(new Error(match[1]));
         }
 
-        return cb(new Error(`unexpected result: ${result}`));
+        cb(new Error(`unexpected result: ${result}`));
     });
     // Start the sequence
     sock.connect(port);

--- a/plugins/prevent_credential_leaks.js
+++ b/plugins/prevent_credential_leaks.js
@@ -21,8 +21,8 @@ exports.hook_data_post = (next, connection) => {
 
     let user = connection.notes.auth_user;
     let domain;
-    let idx;
-    if ((idx = user.indexOf('@'))) {
+    const idx = user.indexOf('@')
+    if (idx) {
         // If the username is qualified (e.g. user@domain.com)
         // then we make the @domain.com part optional in the regexp.
         domain = user.substr(idx);

--- a/plugins/process_title.js
+++ b/plugins/process_title.js
@@ -120,7 +120,7 @@ exports.hook_init_master = function (next, server) {
         });
     }
     this._interval = setupInterval(title, server);
-    return next();
+    next();
 }
 
 exports.hook_init_child = function (next, server) {
@@ -134,10 +134,9 @@ exports.hook_init_child = function (next, server) {
     server.notes.pt_messages = 0;
     server.notes.pt_mps_diff = 0;
     server.notes.pt_mps_max = 0;
-    const title = 'Haraka (worker)';
-    process.title = title;
-    this._interval = setupInterval(title, server);
-    return next();
+    process.title = 'Haraka (worker)';
+    this._interval = setupInterval(process.title, server);
+    next();
 }
 
 exports.shutdown = function () {
@@ -154,7 +153,7 @@ exports.hook_connect_init = (next, connection) => {
     }
     server.notes.pt_connections++;
     server.notes.pt_concurrent++;
-    return next();
+    next();
 }
 
 exports.hook_disconnect = (next, connection) => {
@@ -177,7 +176,7 @@ exports.hook_disconnect = (next, connection) => {
         worker.send({event: 'process_title.disconnect', wid: worker.id});
     }
     server.notes.pt_concurrent--;
-    return next();
+    next();
 }
 
 exports.hook_rcpt = (next, connection) => {
@@ -187,7 +186,7 @@ exports.hook_rcpt = (next, connection) => {
         worker.send({event: 'process_title.recipient'});
     }
     server.notes.pt_recipients++;
-    return next();
+    next();
 }
 
 exports.hook_data = (next, connection) => {
@@ -197,5 +196,5 @@ exports.hook_data = (next, connection) => {
         worker.send({event: 'process_title.message'});
     }
     server.notes.pt_messages++;
-    return next();
+    next();
 }

--- a/plugins/queue/quarantine.js
+++ b/plugins/queue/quarantine.js
@@ -51,9 +51,7 @@ function wants_quarantine (connection) {
 
     if (transaction.notes.quarantine) return transaction.notes.quarantine;
 
-    if (transaction.notes.get('queue.wants') === 'quarantine') return true;
-
-    return false;
+    return transaction.notes.get('queue.wants') === 'quarantine';
 }
 
 exports.get_base_dir = function () {

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -189,16 +189,17 @@ exports.auth = function (cfg, connection, smtp_client) {
         if (cfg.auth_type === 'plain') {
             connection.loginfo(this, `Authenticating with AUTH PLAIN ${cfg.auth_user}`);
             smtp_client.send_command('AUTH', `PLAIN ${base64(`\0${cfg.auth_user}\0${cfg.auth_pass}`)}`);
+            return
         }
-        else if (cfg.auth_type === 'login') {
+
+        if (cfg.auth_type === 'login') {
             smtp_client.authenticating = true;
             smtp_client.authenticated = false;
 
             connection.loginfo(this, `Authenticating with AUTH LOGIN ${cfg.auth_user}`);
             smtp_client.send_command('AUTH', 'LOGIN');
             smtp_client.on('auth', () => {
-                //TODO: nothing?
-
+                // do nothing
             });
             smtp_client.on('auth_username', () => {
                 smtp_client.send_command(base64(cfg.auth_user));

--- a/plugins/rcpt_to.host_list_base.js
+++ b/plugins/rcpt_to.host_list_base.js
@@ -23,9 +23,7 @@ exports.load_host_list_regex = function () {
         () => { this.load_host_list_regex(); }
     );
 
-    this.hl_re = new RegExp (`^(?:${
-
-        this.host_list_regex.join('|')})$`, 'i');
+    this.hl_re = new RegExp (`^(?:${this.host_list_regex.join('|')})$`, 'i');
 }
 
 exports.hook_mail = function (next, connection, params) {

--- a/plugins/rcpt_to.host_list_base.js
+++ b/plugins/rcpt_to.host_list_base.js
@@ -58,10 +58,7 @@ exports.hook_mail = function (next, connection, params) {
 
 exports.in_host_list = function (domain) {
     this.logdebug(`checking ${domain} in config/host_list`);
-    if (this.host_list[domain]) {
-        return true;
-    }
-    return false;
+    return !!(this.host_list[domain]);
 }
 
 exports.in_host_regex = function (domain) {
@@ -70,6 +67,5 @@ exports.in_host_regex = function (domain) {
 
     this.logdebug(`checking ${domain} against config/host_list_regex `);
 
-    if (this.hl_re.test(domain)) { return true; }
-    return false;
+    return !!(this.hl_re.test(domain));
 }

--- a/plugins/spamassassin.js
+++ b/plugins/spamassassin.js
@@ -220,11 +220,9 @@ exports.score_too_high = function (conn, spamd_response) {
     }
 
     const max = this.cfg.main.reject_threshold;
-    if (max && (score >= max)) {
-        return "spam score exceeded threshold";
-    }
+    if (max && (score >= max)) return "spam score exceeded threshold";
 
-    return false;
+    return '';
 }
 
 exports.get_spamd_username = function (conn) {

--- a/plugins/xclient.js
+++ b/plugins/xclient.js
@@ -22,10 +22,7 @@ exports.load_xclient_hosts = function () {
 }
 
 function xclient_allowed (ip) {
-    if (ip === '127.0.0.1' || ip === '::1' || allowed_hosts[ip]) {
-        return true;
-    }
-    return false;
+    return !!(ip === '127.0.0.1' || ip === '::1' || allowed_hosts[ip]);
 }
 
 exports.hook_capabilities = (next, connection) => {

--- a/smtp_client.js
+++ b/smtp_client.js
@@ -20,7 +20,7 @@ const line_socket = require('./line_socket');
 const logger      = require('./logger');
 const HostPool    = require('./host_pool');
 
-const smtp_regexp = /^([0-9]{3})([ -])(.*)/;
+const smtp_regexp = /^(\d{3})([ -])(.*)/;
 const STATE = {
     IDLE: 1,
     ACTIVE: 2,

--- a/tests/plugins/dns_list_base.js
+++ b/tests/plugins/dns_list_base.js
@@ -93,7 +93,7 @@ exports.multi = {
                 test.done();
             }
         }
-        this.plugin.multi('127.0.0.2', 'cbl.abuseat.org', cb);
+        this.plugin.multi('127.0.0.2', 'xbl.spamhaus.org', cb);
     },
     'Spamcop + CBL' (test) {
         test.expect(12);
@@ -111,7 +111,7 @@ exports.multi = {
                 test.done();
             }
         }
-        const dnsbls = ['bl.spamcop.net','cbl.abuseat.org'];
+        const dnsbls = ['bl.spamcop.net','xbl.spamhaus.org'];
         this.plugin.multi('127.0.0.2', dnsbls, cb);
     },
     'Spamcop + CBL + negative result' (test) {
@@ -129,7 +129,7 @@ exports.multi = {
                 test.done();
             }
         }
-        const dnsbls = ['bl.spamcop.net','cbl.abuseat.org'];
+        const dnsbls = ['bl.spamcop.net','xbl.spamhaus.org'];
         this.plugin.multi('127.0.0.1', dnsbls, cb);
     },
     'IPv6 addresses supported' (test) {
@@ -148,7 +148,7 @@ exports.multi = {
                 test.done();
             }
         }
-        const dnsbls = ['bl.spamcop.net','cbl.abuseat.org'];
+        const dnsbls = ['bl.spamcop.net','xbl.spamhaus.org'];
         this.plugin.multi('::1', dnsbls, cb);
     }
 }
@@ -163,7 +163,7 @@ exports.first = {
             test.ok((Array.isArray(a) && a.length > 0));
             test.done();
         }
-        const dnsbls = [ 'cbl.abuseat.org', 'bl.spamcop.net' ];
+        const dnsbls = [ 'xbl.spamhaus.org', 'bl.spamcop.net' ];
         this.plugin.first('127.0.0.2', dnsbls , cb);
     },
     'negative result' (test) {
@@ -174,12 +174,12 @@ exports.first = {
             test.equal(null, a);
             test.done();
         }
-        const dnsbls = [ 'cbl.abuseat.org', 'bl.spamcop.net' ];
+        const dnsbls = [ 'xbl.spamhaus.org', 'bl.spamcop.net' ];
         this.plugin.first('127.0.0.1', dnsbls, cb);
     },
     'each_cb' (test) {
         test.expect(7);
-        const dnsbls = [ 'cbl.abuseat.org', 'bl.spamcop.net' ];
+        const dnsbls = [ 'xbl.spamhaus.org', 'bl.spamcop.net' ];
         let pending = dnsbls.length;
         function cb () {
             test.ok(pending);

--- a/tests/plugins/spamassassin.js
+++ b/tests/plugins/spamassassin.js
@@ -158,7 +158,7 @@ exports.score_too_high = {
         test.expect(1);
         this.connection.relaying = true;
         this.plugin.cfg.main.relay_reject_threshold = 7;
-        test.equal(false, this.plugin.score_too_high(this.connection, {score: 6}));
+        test.equal('', this.plugin.score_too_high(this.connection, {score: 6}));
         test.done();
     },
     'too high score with relaying is too high' (test) {

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -629,9 +629,7 @@ exports.get_rejectUnauthorized = (rejectUnauthorized, port, port_list) => {
 
     if (rejectUnauthorized) return true;
 
-    if (port_list.includes(port)) return true;
-
-    return false;
+    return !!(port_list.includes(port));
 }
 
 function createServer (cb) {


### PR DESCRIPTION
- coerce some results to boolean with not not (!!) operator
- remove useless returns
- more early returns
- test: cbl.abuseat.org -> xbl.spamhaus.org
- use empty string instead of false to type consistency
- regex: replace `[0-9]` with `\d`
- shed a few indirect variables
- refactor: do assignments outside of conditional test