### PR TITLE
fix: prevent outbound loop when target mx is self host, not just local host

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,9 @@
 
 ### Unreleased
 
+#### Fixed
+
+- fix(outbound/mx_lookup): prevent outbound loop when target mx is self host
 
 ### [3.0.1] - 2023-01-19
 

--- a/outbound/mx_lookup.js
+++ b/outbound/mx_lookup.js
@@ -37,7 +37,7 @@ exports.lookup_mx = function lookup_mx (domain, cb) {
             for (let i=0,l=addresses.length; i < l; i++) {
                 if (
                     obc.cfg.local_mx_ok ||
-                    await net_utils.is_local_host(addresses[i].exchange).catch(() => null) === false
+                    await net_utils.is_self_host(addresses[i].exchange).catch(() => null) === false
                 ) {
                     const mx = wrap_mx(addresses[i]);
                     mxs.push(mx);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "haraka-dsn": "^1.0.4",
     "haraka-email-message": "^1.2.0",
     "haraka-message-stream": "^1.2.0",
-    "haraka-net-utils": "^1.5.0",
+    "haraka-net-utils": "^1.6.0",
     "haraka-notes": "^1.0.6",
     "haraka-plugin-attachment": "^1.0.7",
     "haraka-plugin-spf": "1.2.0",


### PR DESCRIPTION
Fixes outbound loops when target mx is self host (i.e. domain-of-the-current-server.com, ip.ofthe.curr.srv), not just local (loopback) host (e.g. localhost, 0.0.0.0, ...).

Potentially fixes https://github.com/haraka/Haraka/issues/3065, not sure about that one.

Changes proposed in this pull request:
- call to `is_local_host` is replaced with `is_self_host` in mx_lookup.js, a new function introduced in https://github.com/haraka/haraka-net-utils/pull/76.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
