### PR TITLE
Update tls.js

### DIFF
--- a/plugins/tls.js
+++ b/plugins/tls.js
@@ -75,7 +75,7 @@ exports.set_notls = function (connection) {
 
     this.lognotice(connection, `STARTTLS failed. Marking ${connection.remote.ip} as non-TLS host for ${expiry} seconds`);
 
-    server.notes.redis.setex(`no_tls|${connection.remote.ip}`, expiry, (new Date()).toISOString());
+    server.notes.redis.setEx(`no_tls|${connection.remote.ip}`, expiry, (new Date()).toISOString());
 }
 
 exports.upgrade_connection = function (next, connection, params) {


### PR DESCRIPTION
Rename redis command setex to setEx

Fixes #3180

Changes proposed in this pull request:
- Rename redis command setex to setEx 

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
