### PR TITLE
don't leak addr parsing errors into SMTP conversation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 #### Fixed
 
+- parsing error leaking to SMTP communication #3176
 - rename redis command setex to setEx #3174
 
 #### Changed

--- a/connection.js
+++ b/connection.js
@@ -1358,7 +1358,6 @@ class Connection {
             from = new Address(results.shift());
         }
         catch (err) {
-            this.loginfo(`Invalid MAIL FROM address: ${err.message}`);
             return this.respond(501, `Invalid MAIL FROM address`);
         }
 
@@ -1423,7 +1422,6 @@ class Connection {
             recip = new Address(results.shift());
         }
         catch (err) {
-            this.loginfo(`Invalid RCPT TO address: ${err.message}`);
             return this.respond(501, `Invalid RCPT TO address`);
         }
 

--- a/connection.js
+++ b/connection.js
@@ -15,7 +15,7 @@ const constants   = require('haraka-constants');
 const net_utils   = require('haraka-net-utils');
 const Notes       = require('haraka-notes');
 const utils       = require('haraka-utils');
-const { Address }     = require('address-rfc2821');
+const { Address } = require('address-rfc2821');
 const ResultStore = require('haraka-results');
 
 // Haraka libs
@@ -1326,16 +1326,15 @@ class Connection {
             this.errors++;
             return this.respond(503, 'Use EHLO/HELO before MAIL');
         }
-        // Require authentication on connections to port 587 & 465
+        // Require authentication on ports 587 & 465
         if (!this.relaying && [587,465].includes(this.local.port)) {
             this.errors++;
             return this.respond(550, 'Authentication required');
         }
+
         let results;
-        let from;
         try {
             results = rfc1869.parse('mail', line, this.cfg.main.strict_rfc1869 && !this.relaying);
-            from    = new Address (results.shift());
         }
         catch (err) {
             this.errors++;
@@ -1350,9 +1349,19 @@ class Connection {
                 return this.respond(452, 'Internal Server Error');
             }
             else {
-                return this.respond(501, ["Command parsing failed", err]);
+                return this.respond(501, ['Command parsing failed', err]);
             }
         }
+
+        let from;
+        try {
+            from = new Address(results.shift());
+        }
+        catch (err) {
+            this.loginfo(`Invalid MAIL FROM address: ${err.message}`);
+            return this.respond(501, `Invalid MAIL FROM address`);
+        }
+
         // Get rest of key=value pairs
         const params = {};
         results.forEach(param => {
@@ -1389,10 +1398,8 @@ class Connection {
         }
 
         let results;
-        let recip;
         try {
             results = rfc1869.parse('rcpt', line, this.cfg.main.strict_rfc1869 && !this.relaying);
-            recip   = new Address(results.shift());
         }
         catch (err) {
             this.errors++;
@@ -1410,6 +1417,16 @@ class Connection {
                 return this.respond(501, ["Command parsing failed", err]);
             }
         }
+
+        let recip;
+        try {
+            recip = new Address(results.shift());
+        }
+        catch (err) {
+            this.loginfo(`Invalid RCPT TO address: ${err.message}`);
+            return this.respond(501, `Invalid RCPT TO address`);
+        }
+
         // Get rest of key=value pairs
         const params = {};
         results.forEach((param) => {


### PR DESCRIPTION
- fixes #3176
- closes #3177

Differences:
- don't return unsanitized network input (its a vulnerability vector)
- don't log unsanitized network input as it enables log injection vulnerabilities

Checklist:
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
