### PR TITLE
q/smtp_forward: always register get_mx hook

### DIFF
--- a/docs/plugins/queue/smtp_forward.md
+++ b/docs/plugins/queue/smtp_forward.md
@@ -100,4 +100,4 @@ enable\_outbound can be set or unset on a per-domain level to enable or disable 
 
 # Split host forward routing
 
-When an incoming email transaction has multiple recipients with different forward routes,  recipients to subsequent forward routes are deferred. Example: an incoming email transaction has recipients user@example1.com, user@example2.com, and user@example3.com. The first two recipients will be accepted (they share the same forward destination) and the latter will be deferred. It will arrive in a future delivery attempt by the remote.
+When an incoming email transaction has multiple recipients with different forward routes, recipients to subsequent forward routes are deferred. Example: an incoming email transaction has recipients user@example1.com, user@example2.com, and user@example3.com. The first two recipients will be accepted (they share the same forward destination) and the latter will be deferred. It will arrive in a future delivery attempt by the remote.

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -28,10 +28,10 @@ exports.register = function () {
     if (this.cfg.main.enable_outbound) {
         // deliver local message via smtp forward when relaying=true
         this.register_hook('queue_outbound', 'queue_forward');
-
-        // may specify more specific routes for outbound
-        this.register_hook('get_mx', 'get_mx');
     }
+
+    // may specify more specific [per-domain] outbound routes
+    this.register_hook('get_mx', 'get_mx');
 }
 
 exports.load_smtp_forward_ini = function () {


### PR DESCRIPTION
- revert a portion of #3199 