### PR TITLE
Fixed incorrect use of .join() on bounce.

### DIFF
--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -1062,7 +1062,7 @@ class HMailItem extends events.EventEmitter {
             "\r": '#10',
             "\n": '#13'
         };
-        const escape_pattern = new RegExp(`[${Object.keys(escaped_chars).join()}]`, 'g');
+        const escape_pattern = new RegExp(`[${Object.keys(escaped_chars).join('')}]`, 'g');
 
         bounce_msg_html_.forEach(line => {
             line = line.replace(/\{(\w+)\}/g, (i, word) => {


### PR DESCRIPTION
Fixes #3236

Changes proposed in this pull request:
- Added empty string as a parameter of .join().

Checklist:
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
