### PR TITLE
allow configuring optional queue arguments

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -2,6 +2,7 @@
 ### Unreleased
 
 - dep(plugin-spf): bump version to 1.2.1
+- feat(rabbitmq_amqplib): configurable optional queue arguments
 
 ### [3.0.2] - 2023-06-12
 

--- a/config/rabbitmq_amqplib.ini
+++ b/config/rabbitmq_amqplib.ini
@@ -10,3 +10,10 @@ deliveryMode = 2
 confirm = true
 durable = true
 autoDelete = false
+
+; Optional queue arguments
+; [queue_args]
+; x-dead-letter-exchange =
+; x-dead-letter-routing-key = emails_dlq
+; x-overflow = reject-publish
+; x-queue-type = quorum

--- a/docs/plugins/queue/rabbitmq_amqplib.md
+++ b/docs/plugins/queue/rabbitmq_amqplib.md
@@ -37,6 +37,7 @@ Configuration
 		autoDelete = false
 
         ; Optional queue arguments
+		; More information about x-arguments can be found at https://www.rabbitmq.com/queues.html#optional-arguments
         [queue_args]
         x-dead-letter-exchange =
         x-dead-letter-routing-key = emails_dlq

--- a/docs/plugins/queue/rabbitmq_amqplib.md
+++ b/docs/plugins/queue/rabbitmq_amqplib.md
@@ -36,5 +36,11 @@ Configuration
 		durable = true
 		autoDelete = false
 
+        ; Optional queue arguments
+        [queue_args]
+        x-dead-letter-exchange =
+        x-dead-letter-routing-key = emails_dlq
+        x-overflow = reject-publish
+        x-queue-type = quorum
     
  More information about RabbitMQ can be found at https://www.rabbitmq.com/

--- a/plugins/queue/rabbitmq_amqplib.js
+++ b/plugins/queue/rabbitmq_amqplib.js
@@ -26,6 +26,7 @@ exports.rabbitmq_queue = function (next, connection) {
 
 exports.init_amqp_connection = function () {
     const cfg = this.config.get("rabbitmq.ini").rabbitmq;
+    const queueArgs = this.config.get("rabbitmq.ini").queue_args;
 
     const protocol = cfg.protocol || "amqp";
     const host = cfg.host || "127.0.0.1";
@@ -58,7 +59,7 @@ exports.init_amqp_connection = function () {
                     return conn.close();
                 }
                 ch.assertQueue(queueName,
-                    {durable, autoDelete},
+                    {durable, autoDelete, arguments: queueArgs},
                     (err4, ok2) => {
                         if (err4) {
                             this.logerror(`Error asserting rabbitmq queue: ${err4}`);

--- a/plugins/queue/rabbitmq_amqplib.js
+++ b/plugins/queue/rabbitmq_amqplib.js
@@ -26,7 +26,6 @@ exports.rabbitmq_queue = function (next, connection) {
 
 exports.init_amqp_connection = function () {
     const cfg = this.config.get("rabbitmq.ini").rabbitmq;
-    const queueArgs = this.config.get("rabbitmq.ini").queue_args;
 
     const protocol = cfg.protocol || "amqp";
     const host = cfg.host || "127.0.0.1";
@@ -59,7 +58,7 @@ exports.init_amqp_connection = function () {
                     return conn.close();
                 }
                 ch.assertQueue(queueName,
-                    {durable, autoDelete, arguments: queueArgs},
+                    {durable, autoDelete, arguments: this.config.get("rabbitmq.ini").queue_args},
                     (err4, ok2) => {
                         if (err4) {
                             this.logerror(`Error asserting rabbitmq queue: ${err4}`);


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- Allow configuring optional queue arguments in queue/rabbitmq_amqplib plugin

Checklist:
- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
