### PR TITLE
Update transaction.js

### DIFF
--- a/transaction.js
+++ b/transaction.js
@@ -152,7 +152,7 @@ class Transaction {
                 this.header_lines.push(line.toString(this.encoding).replace(/\r\n$/, '\n'));
             }
         }
-        else if (this.header_pos && this.parse_body) {
+        else if (this.parse_body) {
             let new_line = line;
             if (new_line[0] === 0x2E) new_line = new_line.slice(1); // Strip leading "."
 


### PR DESCRIPTION
`this.header_pos` was tested for zero on the previous line (148) so at this point (155), it would contain a number greater than zero and doesn't need to be tested again..

Changes proposed in this pull request:
- remove redundant check of `this.header_pos`
