### PR TITLE
docs(outbound): remove example of outbound_ip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 http/node_modules
 .coveralls.yml

--- a/Changes.md
+++ b/Changes.md
@@ -1,7 +1,15 @@
 
 ### Unreleased
 
-- dep(plugin-spf): bump version to 1.2.1
+- docs(outbound): remove example setting outbound_ip #3253
+- dep(plugin-es): bump version to 8.0.2 #3206
+- transaction: simplify else condition in add_data #3252
+- doc(Plugins.md): add pi-queue-kafka #3247
+- feat(rabbitmq_amqplib): configurable optional queue arguments #3239
+- fix(ob/hmail): bounce, add '' in .join() #3237
+- dep(pi-redis): bump version to 4.6.7 #3193
+- feat(clamd): add x-haraka-virus header #3207
+- dep(pi-spf): bump version to 1.2.1 #3214
 - feat(rabbitmq_amqplib): configurable optional queue arguments
 
 ### [3.0.2] - 2023-06-12

--- a/docs/Outbound.md
+++ b/docs/Outbound.md
@@ -117,7 +117,7 @@ you may be interested in are:
 * domain - the domain this mail is going to (see `always_split` above)
 * notes - the original transaction.notes for this mail, also contains the
   following useful keys:
-** outbound_ip - the IP address to bind to (note do not set this manually,
+** outbound_ip - the IP address to bind to (do not set manually,
   use the `get_mx` hook)
 ** outbound_helo - the EHLO domain to use (again, do not set manually)
 * queue_time - the epoch milliseconds time when this mail was queued
@@ -240,19 +240,10 @@ different IP addresses based on sender, domain or some other identifier.
 To do this, the IP address that you want to use *must* be bound to an 
 interface (or alias) on the local system.
 
-As described above the outbound IP can be set using the `bind` parameter
+As described above, the outbound IP can be set using the `bind` parameter
 and also the outbound helo for the IP can be set using the `bind_ehlo` 
-parameter returned by the `get_mx` hook or during the reception of the message 
-you can set a transaction note in a plugin to tell Haraka which outbound IP 
-address you would like it to use when it tries to deliver the message:
+parameter returned by the `get_mx` hook.
 
-`````
-connection.transaction.notes.outbound_ip = '1.2.3.4';
-connection.transaction.notes.outbound_helo = 'mail-2.example.com';
-`````
-
-Note: if the `get_mx` hook returns a `bind` and `bind_helo` parameter, then
-this will be used in preference to the transaction note.
 
 AUTH
 ----


### PR DESCRIPTION
The docs a few paragraphs above tell users NOT to set the note manually and to use `get_mx`.  Perfect. Don't follow that with an example of manually setting `outbound_ip`.

closes #2911

Checklist:
- [x] docs updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
