### PR TITLE
Reduced DNS timeout to prevent Haraka crash.

### DIFF
--- a/config/helo.checks.ini
+++ b/config/helo.checks.ini
@@ -1,6 +1,6 @@
 ; disable checks or reject for each test if you are worried about strictness
 
-;dns_timeout=30
+;dns_timeout=28
 
 [check]
 ; match_re=true

--- a/plugins/helo.checks.js
+++ b/plugins/helo.checks.js
@@ -499,7 +499,7 @@ exports.get_a_records = async function (host) {
         err.code = dns.TIMEOUT;
         this.logerror(err);
         throw err;
-    }, (this.cfg.main.dns_timeout || 30) * 1000);
+    }, (this.cfg.main.dns_timeout || 28) * 1000);
 
     // fully qualify, to ignore any search options in /etc/resolv.conf
     if (!/\.$/.test(host)) host = `${host}.`;


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- Reduced DNS timeout from 30 seconds to 28 seconds to prevent Haraka crash.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
