### PR TITLE
feat: if AUTH, assure Env From dom matches AUTH dom

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,7 @@
 
 ### Unreleased
 
+- feat(auth_vpopmaild): when outbound, assure the envelope domain matches AUTH domain #3265
 - docs(outbound): remove example setting outbound_ip #3253
 - dep(plugin-es): bump version to 8.0.2 #3206
 - transaction: simplify else condition in add_data #3252

--- a/config/auth_flat_file.ini
+++ b/config/auth_flat_file.ini
@@ -1,5 +1,6 @@
 [core]
 methods=CRAM-MD5
+; constrain_sender=true
 
 [users]
 ; matt=test

--- a/config/auth_vpopmaild.ini
+++ b/config/auth_vpopmaild.ini
@@ -1,6 +1,8 @@
+[main]
 host=127.0.0.6
 port=89
 ;sysadmin=postmaster@example.com:sekret
+constrain_sender=true
 
 [example.com]
 host=127.0.0.10

--- a/config/auth_vpopmaild.ini
+++ b/config/auth_vpopmaild.ini
@@ -1,9 +1,9 @@
 [main]
 host=127.0.0.6
 port=89
-;sysadmin=postmaster@example.com:sekret
-constrain_sender=true
+; sysadmin=postmaster@example.com:sekret
+; constrain_sender=true
 
 [example.com]
 host=127.0.0.10
-;sysadmin=postmaster@example.com:sekret
+; sysadmin=postmaster@example.com:sekret

--- a/docs/plugins/auth/auth_vpopmaild.md
+++ b/docs/plugins/auth/auth_vpopmaild.md
@@ -1,26 +1,20 @@
-auth/auth\_vpopmaild
-===============
+# auth/auth\_vpopmaild
 
-The `auth/vpopmaild` plugin allows you to authenticate against a vpopmaild
-daemon.
+The `auth/vpopmaild` plugin allows SMTP users to authenticate against a vpopmaild daemon.
 
 ## Configuration
 
-Configuration is stored in `config/auth_vpopmaild.ini` and uses INI
-style formatting.
+The configuration file is stored in `config/auth_vpopmaild.ini`.
 
-There are three configuration settings:
+### settings
 
 * host: The host/IP that vpopmaild is listening on (default: localhost).
 
 * port: The TCP port that vpopmaild is listening on (default: 89).
 
-* sysadmin: A colon separated username:password of a vpopmail user with
-    SYSADMIN privileges (see vpopmail/bin/vmoduser -S). This is **only**
-    necessary to support CRAM-MD5 which requires access to the clear text
-    password. On new installs, it's best not to use CRAM-MD5, as it requires
-    storing clear text passwords. Legacy clients with MUAs configured
-    to authenticate with CRAM-MD5 will need this enabled.
+* sysadmin: A colon separated username:password of a vpopmail user with SYSADMIN privileges (see vpopmail/bin/vmoduser -S). This is **only** necessary to support CRAM-MD5 which requires access to the clear text password. On new installs, it's best not to use CRAM-MD5, as it requires storing clear text passwords. Legacy clients with MUAs configured to authenticate with CRAM-MD5 will need this enabled.
+
+* constrain_sender: (default: true). For outbound messages (due to successful AUTH), constrain the envelope sender (MAIL FROM) to the same domain as the authenticated user. This setting, combined with `rate_rcpt_sender` in the [limit](https://github.com/haraka/haraka-plugin-limit) plugin can dramatically reduce the amount of backscatter and spam sent when an email account is compromised.
 
 
 ### Per-domain Configuration
@@ -29,10 +23,12 @@ Additionally, domains can each have their own configuration for connecting
 to vpopmaild. The defaults are the same, so only the differences needs to
 be declared. Example:
 
-    [example.com]
-    host=192.168.0.1
-    port=999
+```ini
+[example.com]
+host=192.168.0.1
+port=999
 
-    [example2.com]
-    host=192.168.0.2
-    sysadmin=postmaster@example2.com:sekret
+[example2.com]
+host=192.168.0.2
+sysadmin=postmaster@example2.com:sekret
+```

--- a/docs/plugins/auth/flat_file.md
+++ b/docs/plugins/auth/flat_file.md
@@ -1,47 +1,40 @@
-auth/flat\_file
-==============
+# auth/flat\_file
 
-The `auth/flat_file` plugin allows you to create a file containing username
-and password combinations, and have relaying users authenticate from that
-file.
+The `auth/flat_file` plugin allows you to create a file containing username and password combinations, and have relaying users authenticate from that file.
 
-Note that passwords are stored in clear-text, so this may not be a great idea
-for large scale systems. However the plugin would be a good start for someone
-looking to implement authentication using some other form of auth.
+Note that passwords are stored in clear-text, so this may not be a great idea for large scale systems. However the plugin would be a good start for someone looking to implement authentication using some other form of auth.
 
-**Security** - it is recommended to switch to [auth-encfile][url-authencflat]
-to protect your user credentials.
+**Security** - it is recommended to switch to [auth-encfile][url-authencflat] to protect your user credentials.
 
-**IMPORANT NOTE** - this plugin requires that STARTTLS be used via the tls plugin 
-before it will advertise AUTH capabilities by the EHLO command.  This is to 
-improve security out-of-the-box.   Localhost and any IP in RFC1918 ranges 
-are automatically exempt from this rule.
+**IMPORANT NOTE** - this plugin requires that STARTTLS be used via the tls plugin before it will advertise AUTH capabilities by the EHLO command.  Localhost and IPs in RFC1918 ranges 
+are exempt from this rule.
 
-Configuration
--------------
+## Configuration
 
-Configuration is stored in `config/auth_flat_file.ini` and uses the INI
-style formatting. 
+Configuration is stored in `config/auth_flat_file.ini`.
 
-Authentication methods are listed in the `[core]` section under `methods`
-parameter. Lists of authentification methods are comma separated. Currently
-supported methods are: `CRAM-MD5`, `PLAIN` and `LOGIN`. The `PLAIN` 
-and `LOGIN` methods are not secure. That is why TLS is required before AUTH is
-offered.
+* [core]methods
+
+Authentication methods are listed in the `[core]methods` parameter. Authentification methods are comma separated. Currently supported methods are: `CRAM-MD5`, `PLAIN` and `LOGIN`. The `PLAIN` and `LOGIN` methods are insecure and require TLS to be enabled.
+
+* [core]constrain_sender: (default: true). For outbound messages (due to successful AUTH), constrain the envelope sender (MAIL FROM) to the same domain as the authenticated user. This setting, combined with `rate_rcpt_sender` in the [limit](https://github.com/haraka/haraka-plugin-limit) plugin can dramatically reduce the amount of backscatter and spam sent when an email account is compromised.
 
 Example:
 
-    [core]
-    methods=PLAIN,LOGIN,CRAM-MD5
-
+```ini
+[core]
+methods=PLAIN,LOGIN,CRAM-MD5
+constrain_sender=true
+```
 
 Users are stored in the `[users]` section.
 
 Example:
 
-    [users]
-    user1=password1
-    user@domain.com=password2
-
+```ini
+[users]
+user1=password1
+user@domain.com=password2
+```
 
 [url-authencflat]: https://github.com/AuspeXeu/haraka-plugin-auth-enc-file

--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -229,7 +229,7 @@ exports.auth_cram_md5 = function (next, connection, params) {
         return this.check_user(next, connection, credentials, AUTH_METHOD_CRAM_MD5);
     }
 
-    const ticket = `<${this.hexi(Math.floor(Math.random() * 1000000))}. ${this.hexi(Date.now())}@${connection.local.host}>`;
+    const ticket = `<${this.hexi(Math.floor(Math.random() * 1000000))}.${this.hexi(Date.now())}@${connection.local.host}>`;
 
     connection.loginfo(this, `ticket: ${ticket}`);
     connection.respond(334, utils.base64(ticket), () => {

--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -15,7 +15,7 @@ const LOGIN_STRING2 = 'UGFzc3dvcmQ6'; //Password: base64 coded
 
 exports.hook_capabilities = (next, connection) => {
     // Don't offer AUTH capabilities unless session is encrypted
-    if (!connection.tls.enabled) { return next(); }
+    if (!connection.tls.enabled) return next();
 
     const methods = [ 'PLAIN', 'LOGIN', 'CRAM-MD5' ];
     connection.capabilities.push(`AUTH ${methods.join(' ')}`);
@@ -47,9 +47,8 @@ exports.hook_unrecognized_command = function (next, connection, params) {
 
 exports.check_plain_passwd = function (connection, user, passwd, cb) {
     function callback (plain_pw) {
-        if (plain_pw === null  ) return cb(false);
-        if (plain_pw !== passwd) return cb(false);
-        cb(true);
+        const result = plain_pw === null ? false : plain_pw === passwd
+        cb(result);
     }
     if (this.get_plain_passwd.length == 2) {
         this.get_plain_passwd(user, callback);
@@ -71,7 +70,7 @@ exports.check_cram_md5_passwd = function (connection, user, passwd, cb) {
 
         if (hmac.digest('hex') === passwd) return cb(true);
 
-        return cb(false);
+        cb(false);
     }
     if (this.get_plain_passwd.length == 2) {
         this.get_plain_passwd(user, callback);
@@ -117,7 +116,7 @@ exports.check_user = function (next, connection, credentials, method) {
                 connection.auth_results(`auth=pass (${method.toLowerCase()})`);
                 connection.notes.auth_user = credentials[0];
                 if (!plugin.blankout_password) connection.notes.auth_passwd = credentials[1];
-                return next(OK);
+                next(OK);
             });
             return;
         }


### PR DESCRIPTION
- auth_base (flat & vpopmaild): when user auths (outbound), assure the MAIL FROM (envelope) domain matches the domain of the email address they authenticated with.
- shed some useless returns

related to haraka/haraka-plugin-limit#28

Checklist:
- [x] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
