### PR TITLE
fix(outbound): allow LHLO over insecure socket if TLS is forced (#3278)

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,6 +1,10 @@
 
 ### Unreleased
 
+#### Fixed
+
+- fix(outbound): allow LHLO over insecure socket if TLS is forced #3278
+
 ### [3.0.3] - 2024-02-07
 
 #### Added

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -455,7 +455,7 @@ class HMailItem extends events.EventEmitter {
                 }
                 return;
             }
-            if (self.force_tls && (cmd != 'EHLO' && cmd != 'STARTTLS') && !socket.isSecure()) {
+            if (self.force_tls && !['EHLO', 'LHLO', 'STARTTLS'].includes(cmd.toUpperCase()) && !socket.isSecure()) {
                 // For safety against programming mistakes
                 self.logerror("Blocking attempt to send unencrypted data to forced TLS socket. This message indicates a programming error in the software.");
                 processing_mail = false;


### PR DESCRIPTION
Fixes #3278 

Changes proposed in this pull request:

- add `LHLO` to the allowed commands if TLS is enforced

Checklist:
- [x] docs updated (not affected)
- [x] tests updated (not affected)
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
