### PR TITLE
smtp_proxy: handle dead sender more gracefully

### DIFF
--- a/docs/plugins/queue/smtp_proxy.md
+++ b/docs/plugins/queue/smtp_proxy.md
@@ -1,16 +1,11 @@
 # queue/smtp\_proxy
 ================
 
-This plugin delivers to another mail server. This is a common setup when you
-want to have a mail server with a solid pedigree of outbound delivery to
-other hosts, and inbound delivery to users.
+This plugin delivers to another mail server. This is a common setup when you want to have a mail server with a solid pedigree of outbound delivery to other hosts, and inbound delivery to users.
 
-In comparison to `queue/smtp_forward`, this plugin makes a connection at
-MAIL FROM time to the ongoing SMTP server. This can be a benefit in that
-you get any SMTP-time filtering that the ongoing server provides, in
-particular one important facility to some setups is recipient filtering.
-However be aware that other than connect and HELO-time filtering, you will
-have as many connections to your ongoing SMTP server as you have to Haraka.
+In comparison to `queue/smtp_forward`, this plugin makes a connection at MAIL FROM time to the ongoing SMTP server. This can be a benefit in that you get any SMTP-time filtering that the ongoing server provides, in particular one important facility to some setups is recipient filtering.
+
+Be aware that other than connect and HELO-time filtering, you will have as many connections to your ongoing SMTP server as you have to Haraka.
 
 ## Configuration
 -------------

--- a/plugins/queue/smtp_forward.js
+++ b/plugins/queue/smtp_forward.js
@@ -247,8 +247,7 @@ exports.queue_forward = function (next, connection) {
         );
 
         function get_rs () {
-            if (txn) return txn.results;
-            return connection.results;
+            return connection?.transaction?.results ? connection.transaction.results : connection.results
         }
 
         function dead_sender () {


### PR DESCRIPTION
This might fix #3023

Changes proposed in this pull request:
- q/proxy: check client is alive b4 sending cmd

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
