### PR TITLE
outbound: include SMTPUTF8 param in return path

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 #### Fixed
 
 - fix(outbound): allow LHLO over insecure socket if TLS is forced #3278
+- fix(outbound): include return path param SMTPUTF8 when required #3289
 
 ### [3.0.3] - 2024-02-07
 


### PR DESCRIPTION
when required. fixes #2711

### RFC 6531

[3.4](https://www.rfc-editor.org/rfc/rfc6531#section-3.4).  MAIL Command Parameter Usage

     If the envelope or message being sent requires the capabilities of
     the SMTPUTF8 extension, the SMTPUTF8-aware SMTP client MUST supply
     the SMTPUTF8 parameter with the MAIL command.  If this parameter is
     provided, it MUST not accept a value.  If the SMTPUTF8-aware SMTP
     client is aware that neither the envelope nor the message being sent
     requires any of the SMTPUTF8 extension capabilities, it SHOULD NOT
     supply the SMTPUTF8 parameter with the MAIL command.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
