### PR TITLE
outbound: chown queue dir after creation

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@
 #### Fixed
 
 - fix(outbound): allow LHLO over insecure socket if TLS is forced #3278
+- fix(outbound): chown queue dir after creation #3291
 
 ### [3.0.3] - 2024-02-07
 


### PR DESCRIPTION
if user/group specified in smtp.ini

Fixes #2773 

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
