### PR TITLE
call cb without MX found

### DIFF
--- a/outbound/mx_lookup.js
+++ b/outbound/mx_lookup.js
@@ -51,7 +51,10 @@ exports.lookup_mx = async function lookup_mx (domain, cb) {
         mxs.push(wrap_mx(a));
     }
 
-    if (mxs.length) return mxs
+    if (mxs.length) {
+        if (cb) return cb(null, mxs)
+        return mxs
+    }
 
     const err = new Error("Found nowhere to deliver to");
     err.code = 'NOMX';


### PR DESCRIPTION
I'm running automated tests between two instances in docker - so far I've been running a custom version of mx_lookup which works as intended, trying to run the original version ends up with mails in limbo. So here is a simple fix

Checklist:
- [ ] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
