### PR TITLE
auth_base: return if setting switches to false at runtime

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 #### Changed
 
+- auth_base: enable disabling constrain_sender at runtime #3298
 - connection: support IPv6 when setting remote.is_private #3295
 - outbound/mx_lookup: make it async/await
 - outbound: emit log message when ignoring local MX

--- a/plugins/auth/auth_base.js
+++ b/plugins/auth/auth_base.js
@@ -241,6 +241,8 @@ exports.auth_cram_md5 = function (next, connection, params) {
 exports.hexi = number => String(Math.abs(parseInt(number)).toString(16))
 
 exports.constrain_sender = function (next, connection, params) {
+    if (this?.cfg?.main?.constrain_sender === false) return next()
+
     const au = connection.results.get('auth')?.user
     if (!au) return next()
 


### PR DESCRIPTION
When an auth plugin is loaded, if `constrain_sender` is false, then the hook doesn't get registered and is never called. If `constrain_sender` is true, then the hook is registered and is called every time that hook is run. If the config file is then set to `false`, the hook is still run. This adds a run-time check.

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
