### PR TITLE
Exlude non-SMTP services from local_mx_ok

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 #### Changed
 
+- outbound: exlude non-SMTP services from cfg.local_mx_ok
 - outbound/mx_lookup: make it async/await
 - outbound: emit log message when ignoring local MX
 

--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,7 @@
 
 #### Changed
 
-- outbound: exlude non-SMTP services from cfg.local_mx_ok #3300
+- outbound: include only default routes to cfg.local_mx_ok check #3300
 - auth_base: enable disabling constrain_sender at runtime #3298
 - connection: support IPv6 when setting remote.is_private #3295
 - outbound/mx_lookup: make it async/await

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -298,7 +298,7 @@ class HMailItem extends events.EventEmitter {
         const mx = this.mxlist.shift();
         const host = mx.exchange;
 
-        if (!obc.cfg.local_mx_ok) {
+        if (mx.port === 25 && !obc.cfg.local_mx_ok) {
             if (await net_utils.is_local_host(host)) {
                 this.loginfo(`MX ${host} is local, skipping since local_mx_ok=false`)
                 return this.try_deliver(); // try next MX

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -227,7 +227,11 @@ class HMailItem extends events.EventEmitter {
         }
 
         // if none of the above return codes, drop through to this...
-        mx_lookup.lookup_mx(this.todo.domain, this.found_mx)
+        mx_lookup.lookup_mx(this.todo.domain, (err, mxs) => {
+            if (mxs) mxs.forEach(mx => { mx.default = true; });
+
+            this.found_mx (err, mxs)
+        })
     }
 
     found_mx (err, mxs) {
@@ -272,8 +276,8 @@ class HMailItem extends events.EventEmitter {
                 }
                 else if (obc.cfg.ipv6_enabled) {
                     this.mxlist.push(
-                        { exchange: mxlist[mx].exchange, priority: mxlist[mx].priority, port: mxlist[mx].port, using_lmtp: mxlist[mx].using_lmtp, family: 'AAAA' },
-                        { exchange: mxlist[mx].exchange, priority: mxlist[mx].priority, port: mxlist[mx].port, using_lmtp: mxlist[mx].using_lmtp, family: 'A' }
+                        { default: mxlist[mx].default, exchange: mxlist[mx].exchange, priority: mxlist[mx].priority, port: mxlist[mx].port, using_lmtp: mxlist[mx].using_lmtp, family: 'AAAA' },
+                        { default: mxlist[mx].default, exchange: mxlist[mx].exchange, priority: mxlist[mx].priority, port: mxlist[mx].port, using_lmtp: mxlist[mx].using_lmtp, family: 'A' }
                     );
                 }
                 else {
@@ -298,7 +302,7 @@ class HMailItem extends events.EventEmitter {
         const mx = this.mxlist.shift();
         const host = mx.exchange;
 
-        if (mx.port === 25 && !obc.cfg.local_mx_ok) {
+        if (mx.default && !obc.cfg.local_mx_ok) {
             if (await net_utils.is_local_host(host)) {
                 this.loginfo(`MX ${host} is local, skipping since local_mx_ok=false`)
                 return this.try_deliver(); // try next MX
@@ -369,7 +373,7 @@ class HMailItem extends events.EventEmitter {
             host = mx.path;
         }
 
-        this.logdebug(`delivering from: ${mx.bind_helo} to: ${host}:${port}${mx.using_lmtp ? " using LMTP" : ""} (${delivery_queue.length()}) (${temp_fail_queue.length()})`)
+        this.logdebug(`delivering from: ${mx.bind_helo} to: ${host}:${port}${mx.using_lmtp ? " using LMTP" : ""}${mx.default ? " (default route)" : ""} (${delivery_queue.length()}) (${temp_fail_queue.length()})`)
         client_pool.get_client(port, host, mx.bind, !!mx.path, (err, socket) => {
             if (err) {
                 if (/connection timed out|connect ECONNREFUSED/.test(err)) {


### PR DESCRIPTION
The idea of cfg.local_mx_ok is ok, but with LMTP local delivery enabled this option makes no sense.

I've come up with a solution to "filter" only destinations with port 25, as other ports are AFAIK only used in a custom defined way and therefore wanted. The original purpose of this option should be preserved as these loops only happen with SMTP. Another way could be to just check using_lmtp, but maybe there are other protocols?

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
