### PR TITLE
dependencies: bump versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
       interval: "monthly"
     allow:
       - dependency-type: production
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
 
   - package-ecosystem: "docker"
     # Look for a `Dockerfile` in the `root` directory

--- a/Changes.md
+++ b/Changes.md
@@ -23,7 +23,6 @@
 #### Added
 
 - feat(auth_vpopmaild): when outbound, assure the envelope domain matches AUTH domain #3265
-- docs(outbound): remove example setting outbound_ip #3253
 - doc(Plugins.md): add pi-queue-kafka #3247
 - feat(rabbitmq_amqplib): configurable optional queue arguments #3239
 - feat(clamd): add x-haraka-virus header #3207

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 #### Changed
 
+- deps: bump all versions to latest #3303
 - auth_base: enable disabling constrain_sender at runtime #3298
 - connection: support IPv6 when setting remote.is_private #3295
 - outbound/mx_lookup: make it async/await

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -227,7 +227,9 @@ class HMailItem extends events.EventEmitter {
         }
 
         // if none of the above return codes, drop through to this...
-        mx_lookup.lookup_mx(this.todo.domain, this.found_mx)
+        mx_lookup.lookup_mx(this.todo.domain, (err, mxs) => {
+            this.found_mx(err, mxs);
+        });
     }
 
     found_mx (err, mxs) {

--- a/outbound/mx_lookup.js
+++ b/outbound/mx_lookup.js
@@ -38,7 +38,8 @@ exports.lookup_mx = async function lookup_mx (domain, cb) {
                 // likely a hostname with no MX record, drop through
                 break
             default:
-                throw err(err)
+                if (cb) return cb(err, mxs)
+                throw err
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "^3.2.5",
     "daemon": "~1.1.0",
     "ipaddr.js": "~2.1.0",
-    "node-gyp": "^10.0.1",
+    "node-gyp": "^10.1.0",
     "nopt": "~7.2.0",
     "npid": "~0.4.0",
     "semver": "~7.6.0",
@@ -33,18 +33,18 @@
     "haraka-config": "^1.1.0",
     "haraka-constants": "^1.0.6",
     "haraka-dsn": "^1.0.4",
-    "haraka-email-message": "^1.2.0",
-    "haraka-message-stream": "^1.2.0",
-    "haraka-net-utils": "^1.5.3",
+    "haraka-email-message": "^1.2.1",
+    "haraka-message-stream": "^1.2.1",
+    "haraka-net-utils": "^1.5.4",
     "haraka-notes": "^1.0.6",
-    "haraka-plugin-attachment": "^1.0.7",
+    "haraka-plugin-attachment": "^1.1.0",
     "haraka-plugin-spf": "1.2.4",
     "haraka-plugin-redis": "^2.0.6",
     "haraka-results": "^2.2.3",
-    "haraka-tld": "^1.2.0",
+    "haraka-tld": "^1.2.1",
     "haraka-utils": "^1.0.3",
     "openssl-wrapper": "^0.3.4",
-    "redis": "~4.6.11",
+    "redis": "~4.6.13",
     "sockaddr": "^1.0.1"
   },
   "optionalDependencies": {
@@ -56,29 +56,28 @@
     "haraka-plugin-elasticsearch": "^8.0.2",
     "haraka-plugin-fcrdns": "^1.1.0",
     "haraka-plugin-graph": "^1.0.5",
-    "haraka-plugin-geoip": "^1.0.17",
-    "haraka-plugin-headers": "^1.0.3",
-    "haraka-plugin-karma": "^2.1.2",
-    "haraka-plugin-limit": "^1.1.1",
+    "haraka-plugin-geoip": "^1.1.0",
+    "haraka-plugin-headers": "^1.0.4",
+    "haraka-plugin-karma": "^2.1.3",
+    "haraka-plugin-limit": "^1.2.1",
     "haraka-plugin-p0f": "^1.0.9",
     "haraka-plugin-qmail-deliverable": "^1.2.1",
-    "haraka-plugin-known-senders": "^1.0.9",
+    "haraka-plugin-known-senders": "^1.1.0",
     "haraka-plugin-rcpt-ldap": "^1.1.0",
     "haraka-plugin-recipient-routes": "^1.2.0",
     "haraka-plugin-rspamd": "^1.3.1",
-    "haraka-plugin-syslog": "^1.0.5",
+    "haraka-plugin-syslog": "^1.0.6",
     "haraka-plugin-uribl": "^1.0.8",
-    "haraka-plugin-watch": "^2.0.2",
+    "haraka-plugin-watch": "^2.0.4",
     "ocsp": "~1.2.0",
-    "tmp": "~0.2.1"
+    "tmp": "~0.2.3"
   },
   "devDependencies": {
     "nodeunit-x": "^0.16.0",
     "haraka-test-fixtures": "^1.3.3",
     "mock-require": "^3.0.3",
-    "eslint": "^8.56.0",
     "eslint-plugin-haraka": "^1.0.15",
-    "nodemailer": "^6.9.9"
+    "nodemailer": "^6.9.13"
   },
   "bugs": {
     "mail": "haraka.mail@gmail.com",
@@ -91,8 +90,8 @@
   },
   "scripts": {
     "test": "node run_tests",
-    "lint": "npx eslint *.js outbound plugins plugins/*/*.js tests tests/*/*.js tests/*/*/*.js bin/haraka bin/dkimverify",
-    "lintfix": "npx eslint --fix *.js outbound plugins plugins/*/*.js tests tests/*/*.js tests/*/*/*.js bin/haraka bin/dkimverify",
+    "lint": "npx eslint@^8 *.js outbound plugins plugins/*/*.js tests tests/*/*.js tests/*/*/*.js bin/haraka bin/dkimverify",
+    "lintfix": "npx eslint@^8 --fix *.js outbound plugins plugins/*/*.js tests tests/*/*.js tests/*/*/*.js bin/haraka bin/dkimverify",
     "versions": "npx dependency-version-checker check"
   }
 }


### PR DESCRIPTION
Fixes #3299

Changes proposed in this pull request:
- bump version of all deps to latest
- remove eslint from devDeps (installs if/when needed via npx)
- outbound: fix error handling in mx_lookup

Checklist:
- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
