### PR TITLE
check for local_mx only when default route is used

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 #### Changed
 
+- check for local_mx only when default route is used #3307
 - deps: bump all versions to latest #3303
 - auth_base: enable disabling constrain_sender at runtime #3298
 - connection: support IPv6 when setting remote.is_private #3295


### PR DESCRIPTION
github somehow broke the #3300 PR - still showing me "processing updates" and refusing to accept changes, so this is a second attempt to update cfg.local_mx_ok functionality

It only checks local mx if it falls through to the default route - so any plugin's mx is excluded.