### PR TITLE
dep(haraka-email-message): 1.2.3 -> 1.2.4

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -3,7 +3,7 @@
 
 #### Changed
 
-- dep(haraka-email-message): 1.2.3 -> 1.2.4
+- dep(haraka-email-message): bump 1.2.3 -> 1.2.4
 - fix: revert a refactoring error in queue/lmtp, #3407
 - removed dependency on ldap plugins #3399
 - doc(tls.md): add note for no_tls_hosts for outbound

--- a/Changes.md
+++ b/Changes.md
@@ -3,6 +3,7 @@
 
 #### Changed
 
+- dep(haraka-email-message): 1.2.3 -> 1.2.4
 - fix: revert a refactoring error in queue/lmtp, #3407
 - removed dependency on ldap plugins #3399
 - doc(tls.md): add note for no_tls_hosts for outbound

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "haraka-config": "^1.4.0",
     "haraka-constants": "^1.0.7",
     "haraka-dsn": "^1.1.0",
-    "haraka-email-message": "^1.2.3",
+    "haraka-email-message": "^1.2.4",
     "haraka-message-stream": "^1.2.2",
     "haraka-net-utils": "^1.7.0",
     "haraka-notes": "^1.1.0",


### PR DESCRIPTION
Fixes https://github.com/haraka/email-message/issues/12.

Changes proposed in this pull request:

- Update haraka-email-message to 1.2.4, which correcly recognizes attachment filenames containing semicolons.

With this update, emails containing attachments named e.g. "aaa@bbb.com; ccc@ddd.com.zip" won't be rejected anymore due to the combination of the filename being incorrectly read as "aaa@bbb.com" and the [attachment](https://github.com/haraka/haraka-plugin-attachment) Haraka plugin rejecting the com extension.

Checklist:

- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated


To the maintainer: I'm not entirely sure I'm following the right contribution process here (https://github.com/haraka/email-message/pull/13 not being merged yet), feel free to discard this PR for another one if appropriate.