### PR TITLE
Update mail_from.is_resolvable.js

### DIFF
--- a/plugins/mail_from.is_resolvable.js
+++ b/plugins/mail_from.is_resolvable.js
@@ -122,7 +122,7 @@ exports.hook_mail = function (next, connection, params) {
                     }
 
                     mxDone(
-                        ((this.cfg.main.reject_no_mx) ? DENY : DENYSOFT),
+                        ((this.cfg.reject.no_mx) ? DENY : DENYSOFT),
                         'No valid MX for your FROM address'
                     );
                 })


### PR DESCRIPTION
One of the MX checks was still using old style config. When a From domain had no valid MX, a DENYSOFT was returned.  Updated to use new style config so now a DENY is returned.
