### PR TITLE
Fix cumulative greeting message for custom greetings

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -25,8 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - fix(outbound): in outbound hook_delivered, when mx.exchange contains
   an IP, use mx.from_dns
 - fix(bin/haraka): fix for finding path to config/docs/Plugins.md
-- fix(connections): fix for infinitely expanding greeting when using a custom greeting
-  in connections.ini
+- fix(connections): fix for infinitely expanding custom greeting #3446
 
 ### [3.0.5] - 2024-09-27
 

--- a/Changes.md
+++ b/Changes.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - fix(outbound): in outbound hook_delivered, when mx.exchange contains
   an IP, use mx.from_dns
 - fix(bin/haraka): fix for finding path to config/docs/Plugins.md
+- fix(connections): fix for infinitely expanding greeting when using a custom greeting
+  in connections.ini
 
 ### [3.0.5] - 2024-09-27
 

--- a/connection.js
+++ b/connection.js
@@ -783,10 +783,11 @@ class Connection {
                 });
                 break;
             default: {
-                let greeting = cfg.message.greeting;
-                if (greeting?.length) {
+                let greeting;
+                if (cfg.message.greeting?.length) {
                     // RFC5321 section 4.2
                     // Hostname/domain should appear after the 220
+                    greeting = [...cfg.message.greeting];
                     greeting[0] = `${this.local.host} ESMTP ${greeting[0]}`;
                     if (cfg.uuid.banner_chars) {
                         greeting[0] += ` (${this.uuid.substr(0, cfg.uuid.banner_chars)})`;


### PR DESCRIPTION
Fixes #3445

Changed logic for the initial greeting to use a copy of the custom greeting array in connections.ini to build the greeting message so that it doesn't keep infinitely expanding for every connection.  The fix is slightly different than that discussed in #3445 to properly handle cases when the custom greeting is not set in connections.ini.

Checklist:
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
