### PR TITLE
Feature/temp UUID docs

### DIFF
--- a/docs/plugins/queue/test.md
+++ b/docs/plugins/queue/test.md
@@ -1,0 +1,9 @@
+queue/test
+==========
+
+This plugin saves incoming E-Mail to your temporary directory, as `mail_{message_id}.eml`, where message_id is a UUID.
+
+This plugin can be useful to quickly test if you're able to receive incoming E-Mail and just dump them to disk.
+
+The temporary directory is determined using Node's [`os.tmpdir()`](https://nodejs.org/api/os.html#ostmpdir), which respects standard platform configurations.
+

--- a/plugins/queue/test.js
+++ b/plugins/queue/test.js
@@ -4,10 +4,12 @@ const os = require('node:os');
 const tempDir = os.tmpdir();
 
 exports.hook_queue = function (next, connection) {
-    if (!connection?.transaction) return next();
+    const txn = connection?.transaction;
+    if (!txn) return next();
 
-    const ws = fs.createWriteStream(`${tempDir}/mail.eml`);
-    connection.logdebug(this, `Saving to ${tempDir}/mail.eml`);
+    const file_path = `${tempDir}/mail_${txn.uuid}.eml`
+    const ws = fs.createWriteStream(file_path);
+    connection.logdebug(this, `Saving to ${file_path}`);
     ws.once('close', () => next(OK));
     connection.transaction.message_stream.pipe(ws);
 }


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

- Save the email to temp with UUID suffix (Message ID)
- Add docs about test queue (it's quite useful! I wanted to test Haraka quickly but didnt know about this till I went to the source)

Checklist:

- [x] docs updated
- [ ] tests updated
- [ ] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated

Fixes #3448 

* Haven't found relevant test to update
* Not sure what's the best thing to put in Changes, maybe: `feat(queue/test): add uuid suffix`

# Other Considerations

This could be a breaking change, if some automated tests / setups using this queue expect `/tmp/mail.eml` to exist.
