### PR TITLE
Set connection.tls and connection.notes.tls properties

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -211,7 +211,6 @@ class Connection {
         this.set('hello', 'host', undefined);
         this.set('tls',   'enabled', true);
         for (const t of ['cipher','verified','verifyError','peerCertificate']) {
-            if (obj[t] === undefined) return;
             this.set('tls', t, obj[t]);
         }
         // prior to 2017-07, authorized and verified were both used. Verified


### PR DESCRIPTION
Is there a reason we're returning if it encounters undefined value?
It results in `peerCertificate` not being set because `verifyError` is undefined.