### PR TITLE
Fix util.isFunction deprecation warning

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -32,6 +32,11 @@ function stringify (obj) {
     return str.trim();
 }
 
+function isFunction (functionToCheck) {
+    const getType = {};
+    return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+};
+
 const logger = exports;
 
 logger.levels = {
@@ -116,16 +121,9 @@ logger.dump_logs = cb => {
     return true;
 }
 
-if (!util.isFunction) {
-    util.isFunction = functionToCheck => {
-        const getType = {};
-        return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
-    };
-}
-
 logger.dump_and_exit = function (code) {
     this.dump_logs(() => {
-        if (util.isFunction(code)) return code();
+        if (isFunction(code)) return code();
         process.exit(code);
     });
 }

--- a/logger.js
+++ b/logger.js
@@ -32,11 +32,6 @@ function stringify (obj) {
     return str.trim();
 }
 
-function isFunction (functionToCheck) {
-    const getType = {};
-    return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
-};
-
 const logger = exports;
 
 logger.levels = {
@@ -123,7 +118,7 @@ logger.dump_logs = cb => {
 
 logger.dump_and_exit = function (code) {
     this.dump_logs(() => {
-        if (isFunction(code)) return code();
+        if (typeof code === 'function') return code();
         process.exit(code);
     });
 }


### PR DESCRIPTION
When stopping the server, I'm getting the following deprecation warning
```
^C(node:69460) [DEP0049] DeprecationWarning: The `util.isFunction` API is deprecated.  Please use `typeof arg === "function"` instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

https://nodejs.org/api/deprecations.html#DEP0049