### PR TITLE
Fix crash when outbound connection fails

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix(outbound): in outbound, fix a crash when socket connection errors #3456
+
 ### [3.1.0] - 2025-01-30
 
 #### Changes

--- a/outbound/client_pool.js
+++ b/outbound/client_pool.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const util = require('node:util');
+
 const utils = require('haraka-utils');
 const net_utils = require('haraka-net-utils')
 
@@ -32,7 +34,12 @@ exports.get_client = function (mx, callback) {
         socket.end();
         socket.removeAllListeners();
         socket.destroy();
-        callback(err.message, null);
+        const errMsg = err.message ?
+            err.message :
+            err instanceof AggregateError ?
+                err.map(e => e.message).join(', ') :
+                util.inspect(err, { depth: 3 });
+        callback(errMsg, null);
     })
 
     socket.once('timeout', () => {


### PR DESCRIPTION
In node 22 atleast, network code has started returning AggregateError. This means that when socket connection fails, err.message is an empty string. The on('error') handler as a result invoked callback('', null) . Since error is falsy, code assumes socket is valid and crashes.

Code is changed to always return a error string.

Fixes #3455

Changes proposed in this pull request:

- Code is changed to always return a error string on a socket error

Checklist:

- [ ] docs updated
- [ ] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
