### PR TITLE
Extend rabbitmq_amqplib plugin options

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- feat(rabbitmq_amqplib): configurable optional exchange arguments #3468
+- feat(rabbitmq_amqplib): configurable message priority #3468
+
 ### [3.1.1] - 2025-05-19
 
 - Fix: install connection.ini with base configuration on install #3458

--- a/docs/plugins/queue/rabbitmq_amqplib.md
+++ b/docs/plugins/queue/rabbitmq_amqplib.md
@@ -31,17 +31,24 @@ Configuration
 		exchangeType = direct
 		; Queue
 		queueName = emails
-		deliveryMode = 2
 		confirm = true
 		durable = true
 		autoDelete = false
+		; Message
+		deliveryMode = 2
+		priority = 1
 
-        ; Optional queue arguments
-		; More information about x-arguments can be found at https://www.rabbitmq.com/queues.html#optional-arguments
-        [queue_args]
-        x-dead-letter-exchange =
-        x-dead-letter-routing-key = emails_dlq
-        x-overflow = reject-publish
-        x-queue-type = quorum
+		; Optional exchange arguments
+		; More information about exchange x-arguments can be found at https://www.rabbitmq.com/docs/exchanges#optional-arguments
+		[exchange_args]
+		alternate-exchange =
+
+		; Optional queue arguments
+		; More information about queue x-arguments can be found at https://www.rabbitmq.com/queues.html#optional-arguments
+		[queue_args]
+		x-dead-letter-exchange =
+		x-dead-letter-routing-key = emails_dlq
+		x-overflow = reject-publish
+		x-queue-type = quorum
     
  More information about RabbitMQ can be found at https://www.rabbitmq.com/

--- a/plugins/queue/rabbitmq_amqplib.js
+++ b/plugins/queue/rabbitmq_amqplib.js
@@ -17,7 +17,7 @@ exports.rabbitmq_queue = function (next, connection) {
     connection.transaction.message_stream.get_data(str => {
         const sendOptions = {deliveryMode};
         if (priority != null) {
-        sendOptions.priority = priority;
+            sendOptions.priority = priority;
         }
         if (channel?.sendToQueue(queue, str, sendOptions)) {
             return next(OK);

--- a/plugins/queue/rabbitmq_amqplib.js
+++ b/plugins/queue/rabbitmq_amqplib.js
@@ -58,7 +58,7 @@ exports.init_amqp_connection = function () {
                 this.logerror(`Error creating rabbitmq channel: ${err2}`);
                 return conn.close();
             }
-            ch.assertExchange(exchangeName, exchangeType, {durable}, (err3, ok) => {
+            ch.assertExchange(exchangeName, exchangeType, {durable, arguments: this.config.get('rabbitmq.ini').exchange_args}, (err3, ok) => {
                 if (err3) {
                     this.logerror(`Error asserting rabbitmq exchange: ${err3}`);
                     return conn.close();

--- a/plugins/queue/rabbitmq_amqplib.js
+++ b/plugins/queue/rabbitmq_amqplib.js
@@ -5,6 +5,7 @@ const amqp = require("amqplib/callback_api");
 let channel;
 let queue;
 let deliveryMode;
+let priority;
 
 exports.register = function () {
     this.init_amqp_connection();
@@ -14,7 +15,11 @@ exports.rabbitmq_queue = function (next, connection) {
     if (!connection?.transaction) return next();
 
     connection.transaction.message_stream.get_data(str => {
-        if (channel?.sendToQueue(queue, str, {deliveryMode})) {
+        const sendOptions = {deliveryMode};
+        if (priority != null) {
+        sendOptions.priority = priority;
+        }
+        if (channel?.sendToQueue(queue, str, sendOptions)) {
             return next(OK);
         }
         else {
@@ -40,6 +45,7 @@ exports.init_amqp_connection = function () {
     // var confirm = cfg.confirm === "true" || true;
     const autoDelete = cfg.autoDelete === "true" || false;
     deliveryMode = cfg.deliveryMode || 2;
+    priority = cfg.priority;
 
     amqp.connect(`${protocol}://${encodeURIComponent(user)}:${encodeURIComponent(password)}@${host}:${port}${vhost}`, (err, conn) => {
         if (err) {


### PR DESCRIPTION
A proposal to extend available configuration options of rabbitmq_amqplib plugin. Since amqplib supports all these options there 

Changes proposed in this pull request:
- Add option to set message priority, so if it is send to a priority queue, the priority of Haraka messages can be configured.
- Add option to set exchange args (for example `alternate-exchange`).

Checklist:

- [x] docs updated
- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
