### PR TITLE
outbound: pass the failed addresses and mx information to deferred hook

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - feat(rabbitmq_amqplib): configurable optional exchange arguments #3472
 - feat(rabbitmq_amqplib): configurable message priority #3472
 - add save-sent to Plugins.md
+- deferred hook is now passed the failed recips list and mx info
 
 ### [3.1.1] - 2025-05-19
 

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -174,7 +174,7 @@ These are the hook and their parameters (next excluded):
 * reset\_transaction - called before the transaction is reset (via RSET, or MAIL)
 * deny - called when a plugin returns DENY, DENYSOFT or DENYDISCONNECT
 * get\_mx (hmail, domain) - called by outbound to resolve the MX record
-* deferred (hmail, params) - called when an outbound message is deferred
+* deferred (hmail, {err, delay, fail_recips, mx} ) - called when an outbound message is deferred. `err` is an error message. `delay` is the seconds after which the delivery will be retried. `fail_recips` ([Address]) and `mx` are only present when the failure happenned during delivery of the addresses to `mx`.
 * bounce (hmail, err) - called when an outbound message bounces
 * delivered (hmail, [host, ip, response, delay, port, mode, ok_recips, secured, authenticated]) - called when outbound mail is delivered
 * send\_email (hmail) - called when outbound is about to be sent

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -1297,7 +1297,7 @@ class HMailItem extends events.EventEmitter {
 
         const delay = obc.cfg.temp_fail_intervals[this.num_failures-1];
 
-        plugins.run_hooks('deferred', this, {delay, err});
+        plugins.run_hooks('deferred', this, {delay, err, ...(extra || {})});
     }
 
     deferred_respond (retval, msg, params) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Pass fail_recips and mx info in deferred hook

Checklist:
- [X] docs updated
- [ ] tests updated
- [X] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
