### PR TITLE
add guard for 2nd error emit

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix(outbound): guard against error emit after listeners removed #3554
 - fix(outbound): yield before delivery attempts #3552
 - test(outbound,conn,endpoint,server,tls_socket): added tests #3552
 - deps(various): updated to latest

--- a/test/tls_socket.js
+++ b/test/tls_socket.js
@@ -96,6 +96,49 @@ test('tls_socket', async (t) => {
                 await new Promise((resolve) => server.close(resolve))
             }
         })
+
+        await t.test('second error handler does not crash when first handler removes all listeners', () => {
+            // Regression test for issue #3553
+            const originalNetConnect = net.connect
+            const originalTlsConnect = tls.connect
+            const originalTlsValid = tls_socket.tls_valid
+
+            const fakeCrypto = new EventEmitter()
+            fakeCrypto.writable = true
+            fakeCrypto.removeAllListeners = EventEmitter.prototype.removeAllListeners
+            fakeCrypto.setTimeout = () => {}
+            fakeCrypto.setKeepAlive = () => {}
+
+            let capturedCleartext
+            net.connect = () => fakeCrypto
+            tls.connect = () => {
+                capturedCleartext = new EventEmitter()
+                capturedCleartext.writable = true
+                capturedCleartext.setTimeout = () => {}
+                capturedCleartext.setKeepAlive = () => {}
+                return capturedCleartext
+            }
+            tls_socket.tls_valid = false
+
+            try {
+                const socket = tls_socket.connect({ host: 'bad-tls.example.com', port: 25 })
+
+                // Simulate what release_client does: strip all listeners on first error
+                socket.once('error', () => socket.removeAllListeners())
+
+                socket.upgrade({}, () => {})
+
+                // capturedCleartext now has two 'error' handlers (on from upgrade, once from attach).
+                // Emitting error must NOT throw even though the first handler removes all
+                // listeners from the outer socket before the second fires.
+                const tlsError = new Error('dh key too small')
+                assert.doesNotThrow(() => capturedCleartext.emit('error', tlsError))
+            } finally {
+                net.connect = originalNetConnect
+                tls.connect = originalTlsConnect
+                tls_socket.tls_valid = originalTlsValid
+            }
+        })
     })
 
     await t.test('getSocketOpts', async (t) => {

--- a/tls_socket.js
+++ b/tls_socket.js
@@ -76,7 +76,7 @@ class pluggableStream extends stream.Stream {
         this.targetsocket.once('error', (exception) => {
             this.writable = this.targetsocket.writable
             exception.source = 'tls'
-            this.emit('error', exception)
+            if (this.listenerCount('error') > 0) this.emit('error', exception)
         })
         this.targetsocket.on('timeout', () => {
             this.emit('timeout')


### PR DESCRIPTION
Fixes #3553

Root cause: pluggableStream.attach() registers cleartext.once('error', ...). The upgrade() function also registers cleartext.on('error', ...). On TLS handshake failure, both fire synchronously. The first handler causes release_client → socket.removeAllListeners(). The second handler then calls socket.emit('error') on a socket with zero listeners → Node.js throws → worker crash.

- [x] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
