### PR TITLE
fix(outbound): fix reading from null this.todo in temp fail bounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix(outbound): fix reading from null this.todo in temp fail bounce
 - fix(outbound): guard against error emit after listeners removed #3554
 - fix(outbound): yield before delivery attempts #3552
 - test(outbound,conn,endpoint,server,tls_socket): added tests #3552

--- a/outbound/hmail.js
+++ b/outbound/hmail.js
@@ -1321,12 +1321,14 @@ class HMailItem extends events.EventEmitter {
     }
 
     convert_temp_failed_to_bounce(err, extra) {
-        this.todo.rcpt_to.forEach((rcpt_to) => {
-            rcpt_to.dsn_action = 'failed'
-            if (rcpt_to.dsn_status) {
-                rcpt_to.dsn_status = `${rcpt_to.dsn_status}`.replace(/^4/, '5')
-            }
-        })
+        if (this.todo) {
+            this.todo.rcpt_to.forEach((rcpt_to) => {
+                rcpt_to.dsn_action = 'failed'
+                if (rcpt_to.dsn_status) {
+                    rcpt_to.dsn_status = `${rcpt_to.dsn_status}`.replace(/^4/, '5')
+                }
+            })
+        }
         return this.bounce(err, extra)
     }
 


### PR DESCRIPTION
Fixes this error I encountered in Haraka@3.1.5:

```
[CRIT] [-] [core] TypeError: Cannot read properties of null (reading 'rcpt_to')
[CRIT] [-] [core]     at HMailItem.convert_temp_failed_to_bounce (/path/to/Haraka/outbound/hmail.js:1324:19)
[CRIT] [-] [core]     at HMailItem.temp_fail (/path/to/Haraka/outbound/hmail.js:1339:25)
[CRIT] [-] [core]     at HMailItem.size_file (/path/to/Haraka/outbound/hmail.js:92:18)
[CRIT] [-] [core] TypeError: Cannot read properties of null (reading 'rcpt_to')
[CRIT] [-] [core]     at HMailItem.convert_temp_failed_to_bounce (/path/to/Haraka/outbound/hmail.js:1324:19)
[CRIT] [-] [core]     at HMailItem.temp_fail (/path/to/Haraka/outbound/hmail.js:1339:25)
[CRIT] [-] [core]     at HMailItem.size_file (/path/to/Haraka/outbound/hmail.js:92:18)
[CRIT] [-] [core] TypeError: Cannot read properties of null (reading 'rcpt_to')
[CRIT] [-] [core]     at HMailItem.convert_temp_failed_to_bounce (/path/to/Haraka/outbound/hmail.js:1324:19)
[CRIT] [-] [core]     at HMailItem.temp_fail (/path/to/Haraka/outbound/hmail.js:1339:25)
[CRIT] [-] [core]     at HMailItem.size_file (/path/to/Haraka/outbound/hmail.js:92:18)
```

I didn't spend much time trying to understand the root cause more deeply, but Claude says:

<img width="733" height="538" alt="image" src="https://github.com/user-attachments/assets/c63f1178-82bf-4438-9325-120979830a37" />

Checklist:

- [ ] docs updated
- [ ] tests updated
- [x] [Changes](https://github.com/haraka/Haraka/blob/master/Changes.md) updated
