### PR TITLE
Implicit TLS with Proxy Protocol

### DIFF
--- a/config/connection.ini
+++ b/config/connection.ini
@@ -19,6 +19,9 @@
 
 
 [haproxy]
+; Bool: enable HAProxy PROXY protocol support and SMTPS pre-parsing.
+; enabled=true
+
 ; Array: hosts or CIDRs that Haraka should enable the PROXY protocol from. See docs/HAProxy for format
 hosts[] =
 ; hosts[] = 192.0.2.4

--- a/connection.js
+++ b/connection.js
@@ -31,31 +31,38 @@ const cfg = config.get('connection.ini', {
         '+headers.add_received',
         '+headers.show_version',
         '+headers.clean_auth_results',
+        '+haproxy.enabled',
     ],
 })
 
+const haproxy_enabled = cfg.haproxy.enabled !== false
 const haproxy_hosts_ipv4 = []
 const haproxy_hosts_ipv6 = []
 
-for (const ip of cfg.haproxy.hosts) {
-    if (!ip) continue
-    if (net.isIPv6(ip.split('/')[0])) {
-        haproxy_hosts_ipv6.push([ipaddr.IPv6.parse(ip.split('/')[0]), parseInt(ip.split('/')[1] || 64)])
-    } else {
-        haproxy_hosts_ipv4.push([ipaddr.IPv4.parse(ip.split('/')[0]), parseInt(ip.split('/')[1] || 32)])
+if (haproxy_enabled) {
+    for (const ip of cfg.haproxy.hosts) {
+        if (!ip) continue
+        if (net.isIPv6(ip.split('/')[0])) {
+            haproxy_hosts_ipv6.push([ipaddr.IPv6.parse(ip.split('/')[0]), parseInt(ip.split('/')[1] || 64)])
+        } else {
+            haproxy_hosts_ipv4.push([ipaddr.IPv4.parse(ip.split('/')[0]), parseInt(ip.split('/')[1] || 32)])
+        }
     }
 }
 
+// TODO: Move these three functions to net_utils
 function normalize_ip(ip) {
     if (!net.isIP(ip)) return null
     return ipaddr.process(ip).toString()
 }
 
-function is_haproxy_allowed(ip) {
+function is_haproxy_allowed(ip, enabled, ipv6_hosts, ipv4_hosts) {
+    if (!enabled) return false
+
     const normalized_ip = normalize_ip(ip)
     if (!normalized_ip) return false
 
-    const ha_list = net.isIPv6(normalized_ip) ? haproxy_hosts_ipv6 : haproxy_hosts_ipv4
+    const ha_list = net.isIPv6(normalized_ip) ? ipv6_hosts : ipv4_hosts
     return ha_list.some((element) => ipaddr.parse(normalized_ip).match(element[0], element[1]))
 }
 
@@ -225,19 +232,20 @@ class Connection {
             self.process_data(data)
         })
 
-        // SMTPS pre-parses PROXY before TLS; don't wait for a second PROXY line here.
-        if (self.client.haraka_proxy) {
+        // SMTPS pre-parser state: proxy means the PROXY line was already consumed;
+        // peer_allowed means a trusted PROXY peer sent direct TLS instead.
+        const smtps = self.client.haraka_smtps
+        if (smtps?.proxy) {
             self.proxy.allowed = true
             return
         }
 
-        // SMTPS pre-parser already checked this allowed peer and found direct TLS.
-        if (self.client.haraka_proxy_checked) {
+        if (smtps?.peer_allowed) {
             plugins.run_hooks('connect_init', self)
             return
         }
 
-        if (is_haproxy_allowed(self.remote.ip)) {
+        if (is_haproxy_allowed(self.remote.ip, haproxy_enabled, haproxy_hosts_ipv6, haproxy_hosts_ipv4)) {
             self.proxy.allowed = true
             // Wait for PROXY command
             self.proxy.timer = setTimeout(() => {
@@ -1894,6 +1902,8 @@ class Connection {
 }
 
 exports.Connection = Connection
+exports.is_haproxy_enabled = () => haproxy_enabled
+// TODO: Move these three functions to net_utils
 exports.is_haproxy_allowed = is_haproxy_allowed
 exports.normalize_ip = normalize_ip
 exports.parse_proxy_line = parse_proxy_line

--- a/connection.js
+++ b/connection.js
@@ -31,62 +31,8 @@ const cfg = config.get('connection.ini', {
         '+headers.add_received',
         '+headers.show_version',
         '+headers.clean_auth_results',
-        '+haproxy.enabled',
     ],
 })
-
-const haproxy_enabled = cfg.haproxy.enabled !== false
-const haproxy_hosts_ipv4 = []
-const haproxy_hosts_ipv6 = []
-
-if (haproxy_enabled) {
-    for (const ip of cfg.haproxy.hosts) {
-        if (!ip) continue
-        if (net.isIPv6(ip.split('/')[0])) {
-            haproxy_hosts_ipv6.push([ipaddr.IPv6.parse(ip.split('/')[0]), parseInt(ip.split('/')[1] || 64)])
-        } else {
-            haproxy_hosts_ipv4.push([ipaddr.IPv4.parse(ip.split('/')[0]), parseInt(ip.split('/')[1] || 32)])
-        }
-    }
-}
-
-// TODO: Move these three functions to net_utils
-function normalize_ip(ip) {
-    if (!net.isIP(ip)) return null
-    return ipaddr.process(ip).toString()
-}
-
-function is_haproxy_allowed(ip, enabled, ipv6_hosts, ipv4_hosts) {
-    if (!enabled) return false
-
-    const normalized_ip = normalize_ip(ip)
-    if (!normalized_ip) return false
-
-    const ha_list = net.isIPv6(normalized_ip) ? ipv6_hosts : ipv4_hosts
-    return ha_list.some((element) => ipaddr.parse(normalized_ip).match(element[0], element[1]))
-}
-
-function parse_proxy_line(line) {
-    const proxyLine = line.toString().replace(/\r?\n$/, '')
-    const match = /^(?:PROXY )?(TCP4|TCP6|UNKNOWN) (\S+) (\S+) (\d+) (\d+)$/.exec(proxyLine)
-    if (!match) return null
-
-    const proto = match[1]
-    const src_ip = match[2]
-    const dst_ip = match[3]
-    const src_port = match[4]
-    const dst_port = match[5]
-
-    if (proto === 'TCP4' && ipaddr.IPv4.isValid(src_ip) && ipaddr.IPv4.isValid(dst_ip)) {
-        return { type: 'haproxy', proto, src_ip, src_port, dst_ip, dst_port }
-    }
-
-    if (proto === 'TCP6' && ipaddr.IPv6.isValid(src_ip) && ipaddr.IPv6.isValid(dst_ip)) {
-        return { type: 'haproxy', proto, src_ip, src_port, dst_ip, dst_port }
-    }
-
-    return null
-}
 
 class Connection {
     constructor(client, server, smtp_cfg) {
@@ -245,7 +191,7 @@ class Connection {
             return
         }
 
-        if (is_haproxy_allowed(self.remote.ip, haproxy_enabled, haproxy_hosts_ipv6, haproxy_hosts_ipv4)) {
+        if (net_utils.is_haproxy_allowed(self.remote.ip)) {
             self.proxy.allowed = true
             // Wait for PROXY command
             self.proxy.timer = setTimeout(() => {
@@ -1237,7 +1183,7 @@ class Connection {
             return this.disconnect()
         }
 
-        const proxy = parse_proxy_line(line)
+        const proxy = net_utils.parse_proxy_line(line)
         if (!proxy) {
             this.respond(421, 'Invalid PROXY format')
             return this.disconnect()
@@ -1902,11 +1848,6 @@ class Connection {
 }
 
 exports.Connection = Connection
-exports.is_haproxy_enabled = () => haproxy_enabled
-// TODO: Move these three functions to net_utils
-exports.is_haproxy_allowed = is_haproxy_allowed
-exports.normalize_ip = normalize_ip
-exports.parse_proxy_line = parse_proxy_line
 
 exports.createConnection = (client, server, cfg) => {
     return new Connection(client, server, cfg)

--- a/connection.js
+++ b/connection.js
@@ -46,6 +46,41 @@ for (const ip of cfg.haproxy.hosts) {
     }
 }
 
+function normalize_ip(ip) {
+    if (!net.isIP(ip)) return null
+    return ipaddr.process(ip).toString()
+}
+
+function is_haproxy_allowed(ip) {
+    const normalized_ip = normalize_ip(ip)
+    if (!normalized_ip) return false
+
+    const ha_list = net.isIPv6(normalized_ip) ? haproxy_hosts_ipv6 : haproxy_hosts_ipv4
+    return ha_list.some((element) => ipaddr.parse(normalized_ip).match(element[0], element[1]))
+}
+
+function parse_proxy_line(line) {
+    const proxyLine = line.toString().replace(/\r?\n$/, '')
+    const match = /^(?:PROXY )?(TCP4|TCP6|UNKNOWN) (\S+) (\S+) (\d+) (\d+)$/.exec(proxyLine)
+    if (!match) return null
+
+    const proto = match[1]
+    const src_ip = match[2]
+    const dst_ip = match[3]
+    const src_port = match[4]
+    const dst_port = match[5]
+
+    if (proto === 'TCP4' && ipaddr.IPv4.isValid(src_ip) && ipaddr.IPv4.isValid(dst_ip)) {
+        return { type: 'haproxy', proto, src_ip, src_port, dst_ip, dst_port }
+    }
+
+    if (proto === 'TCP6' && ipaddr.IPv6.isValid(src_ip) && ipaddr.IPv6.isValid(dst_ip)) {
+        return { type: 'haproxy', proto, src_ip, src_port, dst_ip, dst_port }
+    }
+
+    return null
+}
+
 class Connection {
     constructor(client, server, smtp_cfg) {
         this.client = client
@@ -190,8 +225,19 @@ class Connection {
             self.process_data(data)
         })
 
-        const ha_list = net.isIPv6(self.remote.ip) ? haproxy_hosts_ipv6 : haproxy_hosts_ipv4
-        if (ha_list.some((element) => ipaddr.parse(self.remote.ip).match(element[0], element[1]))) {
+        // SMTPS pre-parses PROXY before TLS; don't wait for a second PROXY line here.
+        if (self.client.haraka_proxy) {
+            self.proxy.allowed = true
+            return
+        }
+
+        // SMTPS pre-parser already checked this allowed peer and found direct TLS.
+        if (self.client.haraka_proxy_checked) {
+            plugins.run_hooks('connect_init', self)
+            return
+        }
+
+        if (is_haproxy_allowed(self.remote.ip)) {
             self.proxy.allowed = true
             // Wait for PROXY command
             self.proxy.timer = setTimeout(() => {
@@ -1137,39 +1183,14 @@ class Connection {
     /////////////////////////////////////////////////////////////////////////////
     // HAProxy support
 
-    cmd_proxy(line) {
-        if (!this.proxy.allowed) {
-            this.respond(421, `PROXY not allowed from ${this.remote.ip}`)
-            return this.disconnect()
+    apply_proxy(proxy) {
+        if (this.proxy.timer) {
+            clearTimeout(this.proxy.timer)
+            this.proxy.timer = null
         }
 
-        const match = /(TCP4|TCP6|UNKNOWN) (\S+) (\S+) (\d+) (\d+)$/.exec(line)
-        if (!match) {
-            this.respond(421, 'Invalid PROXY format')
-            return this.disconnect()
-        }
-        const proto = match[1]
-        const src_ip = match[2]
-        const dst_ip = match[3]
-        const src_port = match[4]
-        const dst_port = match[5]
-
-        // Validate source/destination IP
-        /*eslint no-fallthrough: 0 */
-        switch (proto) {
-            case 'TCP4':
-                if (ipaddr.IPv4.isValid(src_ip) && ipaddr.IPv4.isValid(dst_ip)) {
-                    break
-                }
-            case 'TCP6':
-                if (ipaddr.IPv6.isValid(src_ip) && ipaddr.IPv6.isValid(dst_ip)) {
-                    break
-                }
-            // case 'UNKNOWN':
-            default:
-                this.respond(421, 'Invalid PROXY format')
-                return this.disconnect()
-        }
+        const { proto, src_ip, src_port, dst_ip, dst_port } = proxy
+        const proxy_ip = proxy.proxy_ip || this.remote.ip
 
         // Apply changes
         this.loginfo('HAProxy', {
@@ -1185,11 +1206,11 @@ class Connection {
             src_port,
             dst_ip,
             dst_port,
-            proxy_ip: this.remote.ip,
+            proxy_ip,
         }
 
         this.reset_transaction(() => {
-            this.set('proxy.ip', this.remote.ip)
+            this.set('proxy.ip', proxy_ip)
             this.set('proxy.type', 'haproxy')
             this.relaying = false
             this.set('local.ip', dst_ip)
@@ -1200,6 +1221,21 @@ class Connection {
             this.set('hello.host', null)
             plugins.run_hooks('connect_init', this)
         })
+    }
+
+    cmd_proxy(line) {
+        if (!this.proxy.allowed) {
+            this.respond(421, `PROXY not allowed from ${this.remote.ip}`)
+            return this.disconnect()
+        }
+
+        const proxy = parse_proxy_line(line)
+        if (!proxy) {
+            this.respond(421, 'Invalid PROXY format')
+            return this.disconnect()
+        }
+
+        this.apply_proxy(proxy)
     }
     /////////////////////////////////////////////////////////////////////////////
     // SMTP Commands
@@ -1858,6 +1894,9 @@ class Connection {
 }
 
 exports.Connection = Connection
+exports.is_haproxy_allowed = is_haproxy_allowed
+exports.normalize_ip = normalize_ip
+exports.parse_proxy_line = parse_proxy_line
 
 exports.createConnection = (client, server, cfg) => {
     return new Connection(client, server, cfg)

--- a/docs/CoreConfig.md
+++ b/docs/CoreConfig.md
@@ -48,6 +48,7 @@ Per-connection limits and behaviours. See inline comments in the shipped
 | `main.spool_after` | `-1` | Size (bytes) at which to spool the message to disk. `-1` never spools; `0` always spools. |
 | `main.strict_rfc1869` | `false` | Reject `MAIL FROM` / `RCPT TO` that violates RFC 1869/821 (spurious spaces, missing brackets). |
 | `main.smtputf8` | `true` | Advertise `SMTPUTF8` (RFC 6531). |
+| `haproxy.enabled` | `true` | Enable HAProxy PROXY protocol handling. Set `false` to bypass PROXY support. |
 | `haproxy.hosts` | empty | Array of IPs/CIDRs allowed to send the PROXY protocol. See [HAProxy.md](HAProxy.md). |
 | `headers.add_received` | `true` | Add a `Received:` header to incoming mail. |
 | `headers.clean_auth_results` | `true` | Strip inbound `Authentication-Results:` headers before plugins run. |

--- a/docs/HAProxy.md
+++ b/docs/HAProxy.md
@@ -6,14 +6,17 @@ The PROXY v2 binary header is not currently supported.
 
 ## Configuration
 
-PROXY support is disabled by default. To enable it, list the IPs (or CIDRs) of trusted proxies in `connection.ini`:
+PROXY support is enabled by default, but inactive until trusted proxy IPs or CIDRs are listed in `connection.ini`:
 
 ```ini
 [haproxy]
+enabled=true
 hosts[] = 192.0.2.4
 hosts[] = 192.0.2.5/30
 hosts[] = 2001:db8::1
 ```
+
+Set `enabled=false` to disable PROXY protocol handling entirely. On SMTPS listeners this bypasses pre-TLS PROXY parsing and uses the standard implicit TLS server.
 
 Connections from any other IP get a `DENYSOFTDISCONNECT` if they send a `PROXY` command. `DENYSOFT` is deliberate — it avoids permanently rejecting valid mail when a misconfiguration causes a legitimate proxy to fall outside the allow-list.
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "haraka-constants": "~1.0.7",
     "haraka-dsn": "~1.2.0",
     "haraka-email-message": "~1.3.3",
-    "haraka-net-utils": "~1.8.2",
+    "haraka-net-utils": "~1.8.3",
     "haraka-notes": "~1.1.3",
     "haraka-plugin-redis": "~2.0.11",
     "haraka-results": "~2.3.0",

--- a/server.js
+++ b/server.js
@@ -438,6 +438,7 @@ Server.create_smtps_server = (opts, onConnect) => {
 
         function cleanup() {
             clearTimeout(proxy_timer)
+            socket.pause()
             socket.removeListener('data', on_data)
             socket.removeListener('close', cleanup)
             socket.removeListener('error', cleanup)

--- a/server.js
+++ b/server.js
@@ -376,12 +376,15 @@ Server.create_smtps_server = (opts, onConnect) => {
         }
         if (proxy_checked) cleartext.haraka_proxy_checked = true
 
-        const handshake_timeout = setTimeout(() => {
-            const err = new Error('TLS handshake timeout')
-            err.code = 'ERR_TLS_HANDSHAKE_TIMEOUT'
-            server.emit('tlsClientError', err, cleartext)
-            cleartext.destroy()
-        }, tls_opts.handshakeTimeout || 120 * 1000)
+        const handshake_timeout = setTimeout(
+            () => {
+                const err = new Error('TLS handshake timeout')
+                err.code = 'ERR_TLS_HANDSHAKE_TIMEOUT'
+                server.emit('tlsClientError', err, cleartext)
+                cleartext.destroy()
+            },
+            tls_opts.handshakeTimeout || 120 * 1000,
+        )
 
         function clear_handshake_timeout() {
             clearTimeout(handshake_timeout)

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@
 const cluster = require('node:cluster')
 const { spawn } = require('node:child_process')
 const fs = require('node:fs')
+const net = require('node:net')
 const os = require('node:os')
 const path = require('node:path')
 const tls = require('node:tls')
@@ -351,6 +352,135 @@ Server.load_default_tls_config = (done) => {
     })
 }
 
+Server.create_smtps_server = (opts, onConnect) => {
+    let server
+    const proxyPrefix = Buffer.from('PROXY ')
+
+    function close_with_proxy_error(socket, timer, msg) {
+        clearTimeout(timer)
+        socket.removeAllListeners('data')
+        socket.end(`421 ${msg}\r\n`, () => {
+            socket.destroy()
+        })
+    }
+
+    function start_tls(socket, proxy, proxy_checked) {
+        const tls_opts = { ...opts, server }
+        const cleartext = new tls.TLSSocket(socket, tls_opts)
+
+        if (proxy) {
+            cleartext.haraka_proxy = {
+                ...proxy,
+                proxy_ip: conn.normalize_ip(socket.remoteAddress) || socket.remoteAddress,
+            }
+        }
+        if (proxy_checked) cleartext.haraka_proxy_checked = true
+
+        const handshake_timeout = setTimeout(() => {
+            const err = new Error('TLS handshake timeout')
+            err.code = 'ERR_TLS_HANDSHAKE_TIMEOUT'
+            server.emit('tlsClientError', err, cleartext)
+            cleartext.destroy()
+        }, tls_opts.handshakeTimeout || 120 * 1000)
+
+        function clear_handshake_timeout() {
+            clearTimeout(handshake_timeout)
+        }
+
+        function on_tls_error(err) {
+            clear_handshake_timeout()
+            err.source = 'tls'
+            server.emit('tlsClientError', err, cleartext)
+            cleartext.destroy()
+        }
+
+        cleartext.once('error', on_tls_error)
+        cleartext.once('close', clear_handshake_timeout)
+        cleartext.once('secure', () => {
+            clear_handshake_timeout()
+            cleartext.removeListener('error', on_tls_error)
+            server.emit('secureConnection', cleartext)
+            onConnect(cleartext)
+        })
+    }
+
+    function starts_with_proxy_prefix(data) {
+        if (!data.length) return true
+        if (data.length > proxyPrefix.length) return data.subarray(0, proxyPrefix.length).equals(proxyPrefix)
+
+        return proxyPrefix.subarray(0, data.length).equals(data)
+    }
+
+    function start_tls_with_buffer(socket, data, proxy, proxy_checked) {
+        socket.pause()
+        if (data?.length) socket.unshift(data)
+        setImmediate(() => {
+            start_tls(socket, proxy, proxy_checked)
+            socket.resume()
+        })
+    }
+
+    server = net.createServer((socket) => {
+        const remote_ip = conn.normalize_ip(socket.remoteAddress) || socket.remoteAddress
+
+        if (!conn.is_haproxy_allowed(remote_ip)) {
+            start_tls(socket)
+            return
+        }
+
+        let current_data = null
+        const proxy_timer = setTimeout(() => {
+            close_with_proxy_error(socket, proxy_timer, 'PROXY timeout')
+        }, 30 * 1000)
+
+        function cleanup() {
+            clearTimeout(proxy_timer)
+            socket.removeListener('data', on_data)
+            socket.removeListener('close', cleanup)
+            socket.removeListener('error', cleanup)
+        }
+
+        function on_data(data) {
+            current_data = current_data ? Buffer.concat([current_data, data]) : data
+
+            if (!starts_with_proxy_prefix(current_data)) {
+                cleanup()
+                start_tls_with_buffer(socket, current_data, null, true)
+                return
+            }
+
+            const offset = current_data.indexOf(0x0a)
+            if (offset === -1) {
+                if (current_data.length > 512) {
+                    close_with_proxy_error(socket, proxy_timer, 'Invalid PROXY format')
+                }
+                return
+            }
+            if (offset > 512) {
+                close_with_proxy_error(socket, proxy_timer, 'Invalid PROXY format')
+                return
+            }
+
+            cleanup()
+
+            const proxy = conn.parse_proxy_line(current_data.slice(0, offset + 1))
+            if (!proxy) {
+                close_with_proxy_error(socket, proxy_timer, 'Invalid PROXY format')
+                return
+            }
+
+            const rest = current_data.slice(offset + 1)
+            start_tls_with_buffer(socket, rest, proxy, true)
+        }
+
+        socket.once('close', cleanup)
+        socket.once('error', cleanup)
+        socket.on('data', on_data)
+    })
+
+    return server
+}
+
 Server.get_smtp_server = async (ep, inactivity_timeout) => {
     let server
 
@@ -358,17 +488,19 @@ Server.get_smtp_server = async (ep, inactivity_timeout) => {
         client.setTimeout(inactivity_timeout)
         const connection = conn.createConnection(client, server, Server.cfg)
 
-        if (!server.has_tls) return
+        if (server.has_tls) {
+            const cipher = client.getCipher()
+            cipher.version = client.getProtocol() // replace min with actual
 
-        const cipher = client.getCipher()
-        cipher.version = client.getProtocol() // replace min with actual
+            connection.setTLS({
+                cipher,
+                verified: client.authorized,
+                verifyError: client.authorizationError,
+                peerCertificate: client.getPeerCertificate(),
+            })
+        }
 
-        connection.setTLS({
-            cipher,
-            verified: client.authorized,
-            verifyError: client.authorizationError,
-            peerCertificate: client.getPeerCertificate(),
-        })
+        if (client.haraka_proxy) connection.apply_proxy(client.haraka_proxy)
     }
 
     if (ep.port === parseInt(Server.cfg.main.smtps_port, 10)) {
@@ -382,7 +514,7 @@ Server.get_smtp_server = async (ep, inactivity_timeout) => {
             tls_socket.cfg.main.requireAuthorized,
         )
 
-        server = tls.createServer(opts, onConnect)
+        server = Server.create_smtps_server(opts, onConnect)
         tls_socket.addOCSP(server)
         server.has_tls = true
         server.on('resumeSession', (id, rsDone) => {

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ const os = require('node:os')
 const path = require('node:path')
 const tls = require('node:tls')
 const constants = require('haraka-constants')
+const net_utils = require('haraka-net-utils')
 
 const tls_socket = require('./tls_socket')
 const conn = require('./connection')
@@ -65,8 +66,16 @@ Server.load_http_ini = () => {
     }).main
 }
 
+Server.load_connection_ini = () => {
+    Server.connection = {}
+    Server.connection.cfg = Server.config.get('connection.ini', {
+        booleans: ['+haproxy.enabled'],
+    })
+}
+
 Server.load_smtp_ini()
 Server.load_http_ini()
+Server.load_connection_ini()
 
 Server.daemonize = function () {
     const c = this.cfg.main
@@ -381,7 +390,7 @@ Server.create_smtps_server = (opts, onConnect) => {
             if (proxy) {
                 smtps_state.proxy = {
                     ...proxy,
-                    proxy_ip: conn.normalize_ip(socket.remoteAddress) || socket.remoteAddress,
+                    proxy_ip: net_utils.normalize_ip(socket.remoteAddress) || socket.remoteAddress,
                 }
             }
             socket_tls_state.set(socket, smtps_state)
@@ -418,9 +427,9 @@ Server.create_smtps_server = (opts, onConnect) => {
     }
 
     server = net.createServer((socket) => {
-        const remote_ip = conn.normalize_ip(socket.remoteAddress) || socket.remoteAddress
+        const remote_ip = net_utils.normalize_ip(socket.remoteAddress) || socket.remoteAddress
 
-        if (!conn.is_haproxy_allowed(remote_ip, conn.haproxy_enabled, conn.haproxy_hosts_ipv6, conn.haproxy_hosts_ipv4)) {
+        if (!net_utils.is_haproxy_allowed(remote_ip)) {
             start_tls(socket)
             return
         }
@@ -463,7 +472,7 @@ Server.create_smtps_server = (opts, onConnect) => {
 
             cleanup()
 
-            const proxy = conn.parse_proxy_line(current_data.slice(0, offset + 1))
+            const proxy = net_utils.parse_proxy_line(current_data.slice(0, offset + 1))
             if (!proxy) {
                 close_with_proxy_error(socket, proxy_timer, 'Invalid PROXY format')
                 return
@@ -516,7 +525,9 @@ Server.get_smtp_server = async (ep, inactivity_timeout) => {
             tls_socket.cfg.main.requireAuthorized,
         )
 
-        server = conn.is_haproxy_enabled() ? Server.create_smtps_server(opts, onConnect) : tls.createServer(opts, onConnect)
+        server = Server.connection.cfg.haproxy.enabled
+            ? Server.create_smtps_server(opts, onConnect)
+            : tls.createServer(opts, onConnect)
         const tls_event_server = server.tlsServer || server
         tls_socket.addOCSP(tls_event_server)
         server.has_tls = true

--- a/server.js
+++ b/server.js
@@ -363,15 +363,16 @@ Server.load_default_tls_config = (done) => {
 
 Server.create_smtps_server = (opts, onConnect) => {
     let server
-    const socket_tls_state = new WeakMap()
+    const socket_tls_state = new Map()
     const proxyPrefix = Buffer.from('PROXY ')
     // Defensive cap while waiting for a PROXY v1 line before TLS starts.
     const proxyLineReadLimit = 512
 
     const tlsServer = tls.createServer(opts, (cleartext) => {
-        const smtps_state = socket_tls_state.get(cleartext._parent)
+        const state_key = socket_tls_state_key(cleartext)
+        const smtps_state = socket_tls_state.get(state_key)
         if (smtps_state) cleartext.haraka_smtps = smtps_state
-        socket_tls_state.delete(cleartext._parent)
+        socket_tls_state.delete(state_key)
 
         onConnect(cleartext)
     })
@@ -384,6 +385,10 @@ Server.create_smtps_server = (opts, onConnect) => {
         })
     }
 
+    function socket_tls_state_key(socket) {
+        return JSON.stringify([socket.remoteAddress, socket.remotePort, socket.localAddress, socket.localPort])
+    }
+
     function start_tls(socket, proxy, peer_allowed) {
         if (proxy || peer_allowed) {
             const smtps_state = { peer_allowed }
@@ -393,14 +398,14 @@ Server.create_smtps_server = (opts, onConnect) => {
                     proxy_ip: net_utils.normalize_ip(socket.remoteAddress) || socket.remoteAddress,
                 }
             }
-            socket_tls_state.set(socket, smtps_state)
+            socket_tls_state.set(socket_tls_state_key(socket), smtps_state)
         }
 
         tlsServer.emit('connection', socket)
     }
 
     tlsServer.on('tlsClientError', (err, cleartext) => {
-        socket_tls_state.delete(cleartext?._parent)
+        if (cleartext) socket_tls_state.delete(socket_tls_state_key(cleartext))
         server.emit('tlsClientError', err, cleartext)
     })
 

--- a/server.js
+++ b/server.js
@@ -354,7 +354,18 @@ Server.load_default_tls_config = (done) => {
 
 Server.create_smtps_server = (opts, onConnect) => {
     let server
+    const socket_tls_state = new WeakMap()
     const proxyPrefix = Buffer.from('PROXY ')
+    // Defensive cap while waiting for a PROXY v1 line before TLS starts.
+    const proxyLineReadLimit = 512
+
+    const tlsServer = tls.createServer(opts, (cleartext) => {
+        const smtps_state = socket_tls_state.get(cleartext._parent)
+        if (smtps_state) cleartext.haraka_smtps = smtps_state
+        socket_tls_state.delete(cleartext._parent)
+
+        onConnect(cleartext)
+    })
 
     function close_with_proxy_error(socket, timer, msg) {
         clearTimeout(timer)
@@ -364,48 +375,29 @@ Server.create_smtps_server = (opts, onConnect) => {
         })
     }
 
-    function start_tls(socket, proxy, proxy_checked) {
-        const tls_opts = { ...opts, server }
-        const cleartext = new tls.TLSSocket(socket, tls_opts)
-
-        if (proxy) {
-            cleartext.haraka_proxy = {
-                ...proxy,
-                proxy_ip: conn.normalize_ip(socket.remoteAddress) || socket.remoteAddress,
+    function start_tls(socket, proxy, peer_allowed) {
+        if (proxy || peer_allowed) {
+            const smtps_state = { peer_allowed }
+            if (proxy) {
+                smtps_state.proxy = {
+                    ...proxy,
+                    proxy_ip: conn.normalize_ip(socket.remoteAddress) || socket.remoteAddress,
+                }
             }
-        }
-        if (proxy_checked) cleartext.haraka_proxy_checked = true
-
-        const handshake_timeout = setTimeout(
-            () => {
-                const err = new Error('TLS handshake timeout')
-                err.code = 'ERR_TLS_HANDSHAKE_TIMEOUT'
-                server.emit('tlsClientError', err, cleartext)
-                cleartext.destroy()
-            },
-            tls_opts.handshakeTimeout || 120 * 1000,
-        )
-
-        function clear_handshake_timeout() {
-            clearTimeout(handshake_timeout)
+            socket_tls_state.set(socket, smtps_state)
         }
 
-        function on_tls_error(err) {
-            clear_handshake_timeout()
-            err.source = 'tls'
-            server.emit('tlsClientError', err, cleartext)
-            cleartext.destroy()
-        }
-
-        cleartext.once('error', on_tls_error)
-        cleartext.once('close', clear_handshake_timeout)
-        cleartext.once('secure', () => {
-            clear_handshake_timeout()
-            cleartext.removeListener('error', on_tls_error)
-            server.emit('secureConnection', cleartext)
-            onConnect(cleartext)
-        })
+        tlsServer.emit('connection', socket)
     }
+
+    tlsServer.on('tlsClientError', (err, cleartext) => {
+        socket_tls_state.delete(cleartext?._parent)
+        server.emit('tlsClientError', err, cleartext)
+    })
+
+    tlsServer.on('secureConnection', (cleartext) => {
+        server.emit('secureConnection', cleartext)
+    })
 
     function starts_with_proxy_prefix(data) {
         if (!data.length) return true
@@ -414,11 +406,13 @@ Server.create_smtps_server = (opts, onConnect) => {
         return proxyPrefix.subarray(0, data.length).equals(data)
     }
 
-    function start_tls_with_buffer(socket, data, proxy, proxy_checked) {
+    function start_tls_with_buffer(socket, data, proxy, peer_allowed) {
+        // Preserve bytes already read by the PROXY pre-parser, then hand the
+        // paused socket to TLS before letting it read again.
         socket.pause()
         if (data?.length) socket.unshift(data)
         setImmediate(() => {
-            start_tls(socket, proxy, proxy_checked)
+            start_tls(socket, proxy, peer_allowed)
             socket.resume()
         })
     }
@@ -426,7 +420,7 @@ Server.create_smtps_server = (opts, onConnect) => {
     server = net.createServer((socket) => {
         const remote_ip = conn.normalize_ip(socket.remoteAddress) || socket.remoteAddress
 
-        if (!conn.is_haproxy_allowed(remote_ip)) {
+        if (!conn.is_haproxy_allowed(remote_ip, conn.haproxy_enabled, conn.haproxy_hosts_ipv6, conn.haproxy_hosts_ipv4)) {
             start_tls(socket)
             return
         }
@@ -438,6 +432,8 @@ Server.create_smtps_server = (opts, onConnect) => {
 
         function cleanup() {
             clearTimeout(proxy_timer)
+            // Stop flowing before removing the pre-parser listener so TLS bytes
+            // cannot arrive between listener removal and TLS attachment.
             socket.pause()
             socket.removeListener('data', on_data)
             socket.removeListener('close', cleanup)
@@ -455,12 +451,12 @@ Server.create_smtps_server = (opts, onConnect) => {
 
             const offset = current_data.indexOf(0x0a)
             if (offset === -1) {
-                if (current_data.length > 512) {
+                if (current_data.length > proxyLineReadLimit) {
                     close_with_proxy_error(socket, proxy_timer, 'Invalid PROXY format')
                 }
                 return
             }
-            if (offset > 512) {
+            if (offset > proxyLineReadLimit) {
                 close_with_proxy_error(socket, proxy_timer, 'Invalid PROXY format')
                 return
             }
@@ -481,6 +477,8 @@ Server.create_smtps_server = (opts, onConnect) => {
         socket.once('error', cleanup)
         socket.on('data', on_data)
     })
+
+    server.tlsServer = tlsServer
 
     return server
 }
@@ -504,7 +502,7 @@ Server.get_smtp_server = async (ep, inactivity_timeout) => {
             })
         }
 
-        if (client.haraka_proxy) connection.apply_proxy(client.haraka_proxy)
+        if (client.haraka_smtps?.proxy) connection.apply_proxy(client.haraka_smtps.proxy)
     }
 
     if (ep.port === parseInt(Server.cfg.main.smtps_port, 10)) {
@@ -518,10 +516,11 @@ Server.get_smtp_server = async (ep, inactivity_timeout) => {
             tls_socket.cfg.main.requireAuthorized,
         )
 
-        server = Server.create_smtps_server(opts, onConnect)
-        tls_socket.addOCSP(server)
+        server = conn.is_haproxy_enabled() ? Server.create_smtps_server(opts, onConnect) : tls.createServer(opts, onConnect)
+        const tls_event_server = server.tlsServer || server
+        tls_socket.addOCSP(tls_event_server)
         server.has_tls = true
-        server.on('resumeSession', (id, rsDone) => {
+        tls_event_server.on('resumeSession', (id, rsDone) => {
             Server.loginfo('client requested TLS resumeSession')
             rsDone(null, null)
         })

--- a/test/fixtures/haproxy_allowed/config/connection.ini
+++ b/test/fixtures/haproxy_allowed/config/connection.ini
@@ -1,0 +1,3 @@
+[haproxy]
+enabled=true
+hosts[] = 127.0.0.1

--- a/test/fixtures/haproxy_disabled/config/connection.ini
+++ b/test/fixtures/haproxy_disabled/config/connection.ini
@@ -1,0 +1,3 @@
+[haproxy]
+enabled=false
+hosts[] = 127.0.0.1

--- a/test/fixtures/haproxy_untrusted/config/connection.ini
+++ b/test/fixtures/haproxy_untrusted/config/connection.ini
@@ -1,0 +1,3 @@
+[haproxy]
+enabled=true
+hosts[] = 192.0.2.1

--- a/test/server.js
+++ b/test/server.js
@@ -8,6 +8,7 @@ const { once } = require('node:events')
 const path = require('node:path')
 const tls = require('node:tls')
 const constants = require('haraka-constants')
+const net_utils = require('haraka-net-utils')
 
 const endpoint = require('../endpoint')
 const message = require('haraka-email-message')
@@ -273,9 +274,8 @@ describe('server', () => {
         })
 
         it('accepts PROXY v1 before the SMTPS TLS handshake', async () => {
-            const connection = require('../connection')
-            const originalAllowed = connection.is_haproxy_allowed
-            connection.is_haproxy_allowed = () => true
+            const originalAllowed = net_utils.is_haproxy_allowed
+            net_utils.is_haproxy_allowed = () => true
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -323,7 +323,7 @@ describe('server', () => {
                 assert.match(banner.toString(), /^220 /)
                 assert.equal(tlsErrors.length, 0)
             } finally {
-                connection.is_haproxy_allowed = originalAllowed
+                net_utils.is_haproxy_allowed = originalAllowed
                 if (client) client.destroy()
                 else if (raw) raw.destroy()
                 await close(server)
@@ -331,9 +331,8 @@ describe('server', () => {
         })
 
         it('accepts direct SMTPS from a PROXY-allowed peer', async () => {
-            const connection = require('../connection')
-            const originalAllowed = connection.is_haproxy_allowed
-            connection.is_haproxy_allowed = () => true
+            const originalAllowed = net_utils.is_haproxy_allowed
+            net_utils.is_haproxy_allowed = () => true
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -368,7 +367,7 @@ describe('server', () => {
                 assert.match(banner.toString(), /^220 /)
                 assert.equal(tlsErrors.length, 0)
             } finally {
-                connection.is_haproxy_allowed = originalAllowed
+                net_utils.is_haproxy_allowed = originalAllowed
                 if (client) client.destroy()
                 await close(server)
             }
@@ -444,10 +443,9 @@ describe('server', () => {
         })
 
         it('uses direct TLS for SMTPS when HAProxy support is disabled', async () => {
-            const connection = require('../connection')
-            const originalEnabled = connection.is_haproxy_enabled
-            connection.is_haproxy_enabled = () => false
             this.server.cfg.main.smtps_port = 0
+            const originalEnabled = this.server.connection.cfg.haproxy.enabled
+            this.server.connection.cfg.haproxy.enabled = false
 
             let server
             let client
@@ -476,16 +474,15 @@ describe('server', () => {
                     'direct TLS fallback handshake timed out',
                 )
             } finally {
-                connection.is_haproxy_enabled = originalEnabled
+                this.server.connection.cfg.haproxy.enabled = originalEnabled
                 if (client) client.destroy()
                 if (server) await close(server)
             }
         })
 
         it('accepts direct SMTPS from an untrusted PROXY peer', async () => {
-            const connection = require('../connection')
-            const originalAllowed = connection.is_haproxy_allowed
-            connection.is_haproxy_allowed = () => false
+            const originalAllowed = net_utils.is_haproxy_allowed
+            net_utils.is_haproxy_allowed = () => false
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -512,16 +509,15 @@ describe('server', () => {
                     'untrusted direct SMTPS handshake timed out',
                 )
             } finally {
-                connection.is_haproxy_allowed = originalAllowed
+                net_utils.is_haproxy_allowed = originalAllowed
                 if (client) client.destroy()
                 await close(server)
             }
         })
 
         it('rejects malformed SMTPS PROXY lines before TLS', async () => {
-            const connection = require('../connection')
-            const originalAllowed = connection.is_haproxy_allowed
-            connection.is_haproxy_allowed = () => true
+            const originalAllowed = net_utils.is_haproxy_allowed
+            net_utils.is_haproxy_allowed = () => true
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -537,16 +533,15 @@ describe('server', () => {
                 const [response] = await withTimeout(once(raw, 'data'), 3000, 'malformed PROXY response timed out')
                 assert.match(response.toString(), /^421 Invalid PROXY format/)
             } finally {
-                connection.is_haproxy_allowed = originalAllowed
+                net_utils.is_haproxy_allowed = originalAllowed
                 if (raw) raw.destroy()
                 await close(server)
             }
         })
 
         it('rejects oversized SMTPS PROXY lines before TLS', async () => {
-            const connection = require('../connection')
-            const originalAllowed = connection.is_haproxy_allowed
-            connection.is_haproxy_allowed = () => true
+            const originalAllowed = net_utils.is_haproxy_allowed
+            net_utils.is_haproxy_allowed = () => true
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -562,17 +557,16 @@ describe('server', () => {
                 const [response] = await withTimeout(once(raw, 'data'), 3000, 'oversized PROXY response timed out')
                 assert.match(response.toString(), /^421 Invalid PROXY format/)
             } finally {
-                connection.is_haproxy_allowed = originalAllowed
+                net_utils.is_haproxy_allowed = originalAllowed
                 if (raw) raw.destroy()
                 await close(server)
             }
         })
 
         it('times out waiting for SMTPS PROXY from an allowed peer', async () => {
-            const connection = require('../connection')
-            const originalAllowed = connection.is_haproxy_allowed
+            const originalAllowed = net_utils.is_haproxy_allowed
             const originalSetTimeout = global.setTimeout
-            connection.is_haproxy_allowed = () => true
+            net_utils.is_haproxy_allowed = () => true
             global.setTimeout = (fn, ms, ...args) => originalSetTimeout(fn, ms === 30 * 1000 ? 20 : ms, ...args)
             this.server.cfg.main.smtps_port = 0
 
@@ -588,7 +582,7 @@ describe('server', () => {
                 const [response] = await withTimeout(once(raw, 'data'), 3000, 'PROXY timeout response timed out')
                 assert.match(response.toString(), /^421 PROXY timeout/)
             } finally {
-                connection.is_haproxy_allowed = originalAllowed
+                net_utils.is_haproxy_allowed = originalAllowed
                 global.setTimeout = originalSetTimeout
                 if (raw) raw.destroy()
                 await close(server)
@@ -596,9 +590,8 @@ describe('server', () => {
         })
 
         it('accepts byte-by-byte direct SMTPS from a PROXY-allowed peer', async () => {
-            const connection = require('../connection')
-            const originalAllowed = connection.is_haproxy_allowed
-            connection.is_haproxy_allowed = () => true
+            const originalAllowed = net_utils.is_haproxy_allowed
+            net_utils.is_haproxy_allowed = () => true
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -655,7 +648,7 @@ describe('server', () => {
                 )
                 assert.match(banner.toString(), /^220 /)
             } finally {
-                connection.is_haproxy_allowed = originalAllowed
+                net_utils.is_haproxy_allowed = originalAllowed
                 if (client) client.destroy()
                 else if (raw) raw.destroy()
                 await close(server)

--- a/test/server.js
+++ b/test/server.js
@@ -4,6 +4,7 @@ const { describe, it, beforeEach, afterEach } = require('node:test')
 const assert = require('node:assert/strict')
 const { createHmac } = require('node:crypto')
 const net = require('node:net')
+const { once } = require('node:events')
 const path = require('node:path')
 const tls = require('node:tls')
 const constants = require('haraka-constants')
@@ -124,6 +125,35 @@ const sendMessage = ({
         )
     })
 
+const listen = (server, host = '127.0.0.1') =>
+    new Promise((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, host, () => {
+            server.removeListener('error', reject)
+            resolve()
+        })
+    })
+
+const close = (server) =>
+    new Promise((resolve) => {
+        server.close(resolve)
+    })
+
+const withTimeout = (promise, ms, msg) =>
+    new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(msg)), ms)
+        promise.then(
+            (result) => {
+                clearTimeout(timer)
+                resolve(result)
+            },
+            (err) => {
+                clearTimeout(timer)
+                reject(err)
+            },
+        )
+    })
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('server', () => {
@@ -240,6 +270,108 @@ describe('server', () => {
             assert.equal(server.has_tls, true)
             const count = await new Promise((res) => server.getConnections((err, n) => res(n)))
             assert.equal(count, 0)
+        })
+
+        it('accepts PROXY v1 before the SMTPS TLS handshake', async () => {
+            const connection = require('../connection')
+            const originalAllowed = connection.is_haproxy_allowed
+            connection.is_haproxy_allowed = () => true
+            this.server.cfg.main.smtps_port = 0
+
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
+            const tlsErrors = []
+            let raw
+            let client
+
+            server.on('tlsClientError', (err) => {
+                tlsErrors.push(err)
+            })
+
+            try {
+                await listen(server)
+
+                raw = net.connect(server.address().port, '127.0.0.1')
+                await withTimeout(
+                    Promise.race([
+                        once(raw, 'connect'),
+                        once(raw, 'error').then(([err]) => {
+                            throw err
+                        }),
+                    ]),
+                    3000,
+                    'SMTPS TCP connection timed out',
+                )
+
+                raw.write('PROXY TCP4 127.0.0.1 127.0.0.1 42310 465\r\n')
+                client = tls.connect({
+                    socket: raw,
+                    rejectUnauthorized: false,
+                    servername: 'localhost',
+                })
+
+                await withTimeout(
+                    Promise.race([
+                        once(client, 'secureConnect'),
+                        once(client, 'error').then(([err]) => {
+                            throw err
+                        }),
+                    ]),
+                    3000,
+                    'SMTPS PROXY handshake timed out',
+                )
+                const [banner] = await withTimeout(once(client, 'data'), 3000, 'SMTPS PROXY banner timed out')
+                assert.match(banner.toString(), /^220 /)
+                assert.equal(tlsErrors.length, 0)
+            } finally {
+                connection.is_haproxy_allowed = originalAllowed
+                if (client) client.destroy()
+                else if (raw) raw.destroy()
+                await close(server)
+            }
+        })
+
+        it('accepts direct SMTPS from a PROXY-allowed peer', async () => {
+            const connection = require('../connection')
+            const originalAllowed = connection.is_haproxy_allowed
+            connection.is_haproxy_allowed = () => true
+            this.server.cfg.main.smtps_port = 0
+
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
+            const tlsErrors = []
+            let client
+
+            server.on('tlsClientError', (err) => {
+                tlsErrors.push(err)
+            })
+
+            try {
+                await listen(server)
+
+                client = tls.connect({
+                    port: server.address().port,
+                    host: '127.0.0.1',
+                    rejectUnauthorized: false,
+                    servername: 'localhost',
+                })
+
+                await withTimeout(
+                    Promise.race([
+                        once(client, 'secureConnect'),
+                        once(client, 'error').then(([err]) => {
+                            throw err
+                        }),
+                    ]),
+                    3000,
+                    'direct SMTPS handshake timed out',
+                )
+                const [banner] = await withTimeout(once(client, 'data'), 3000, 'direct SMTPS banner timed out')
+                assert.match(banner.toString(), /^220 /)
+                assert.equal(tlsErrors.length, 0)
+            } finally {
+                connection.is_haproxy_allowed = originalAllowed
+                if (client) client.destroy()
+                await close(server)
+            }
         })
     })
 

--- a/test/server.js
+++ b/test/server.js
@@ -14,6 +14,23 @@ const endpoint = require('../endpoint')
 const message = require('haraka-email-message')
 const { get_client } = require('../smtp_client')
 
+function fixtureConfig(name) {
+    const testRoot = path.resolve('test')
+    return require('haraka-config').module_config(testRoot, path.resolve('test/fixtures', name))
+}
+
+function useHaproxyFixture(server, name) {
+    const originalConfig = net_utils.config
+    const originalConnectionCfg = server.connection.cfg
+    const config = fixtureConfig(name)
+    net_utils.config = config
+    server.connection.cfg = config.get('connection.ini', { booleans: ['+haproxy.enabled'] })
+    return () => {
+        net_utils.config = originalConfig
+        server.connection.cfg = originalConnectionCfg
+    }
+}
+
 // ─── CRAM-MD5 helper ──────────────────────────────────────────────────────────
 
 /** Compute a CRAM-MD5 response to a server challenge. */
@@ -274,8 +291,7 @@ describe('server', () => {
         })
 
         it('accepts PROXY v1 before the SMTPS TLS handshake', async () => {
-            const originalAllowed = net_utils.is_haproxy_allowed
-            net_utils.is_haproxy_allowed = () => true
+            const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -323,16 +339,15 @@ describe('server', () => {
                 assert.match(banner.toString(), /^220 /)
                 assert.equal(tlsErrors.length, 0)
             } finally {
-                net_utils.is_haproxy_allowed = originalAllowed
                 if (client) client.destroy()
                 else if (raw) raw.destroy()
                 await close(server)
+                restoreHaproxyConfig()
             }
         })
 
         it('accepts direct SMTPS from a PROXY-allowed peer', async () => {
-            const originalAllowed = net_utils.is_haproxy_allowed
-            net_utils.is_haproxy_allowed = () => true
+            const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -367,9 +382,9 @@ describe('server', () => {
                 assert.match(banner.toString(), /^220 /)
                 assert.equal(tlsErrors.length, 0)
             } finally {
-                net_utils.is_haproxy_allowed = originalAllowed
                 if (client) client.destroy()
                 await close(server)
+                restoreHaproxyConfig()
             }
         })
 
@@ -443,9 +458,8 @@ describe('server', () => {
         })
 
         it('uses direct TLS for SMTPS when HAProxy support is disabled', async () => {
+            const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_disabled')
             this.server.cfg.main.smtps_port = 0
-            const originalEnabled = this.server.connection.cfg.haproxy.enabled
-            this.server.connection.cfg.haproxy.enabled = false
 
             let server
             let client
@@ -474,15 +488,14 @@ describe('server', () => {
                     'direct TLS fallback handshake timed out',
                 )
             } finally {
-                this.server.connection.cfg.haproxy.enabled = originalEnabled
                 if (client) client.destroy()
                 if (server) await close(server)
+                restoreHaproxyConfig()
             }
         })
 
         it('accepts direct SMTPS from an untrusted PROXY peer', async () => {
-            const originalAllowed = net_utils.is_haproxy_allowed
-            net_utils.is_haproxy_allowed = () => false
+            const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_untrusted')
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -509,15 +522,14 @@ describe('server', () => {
                     'untrusted direct SMTPS handshake timed out',
                 )
             } finally {
-                net_utils.is_haproxy_allowed = originalAllowed
                 if (client) client.destroy()
                 await close(server)
+                restoreHaproxyConfig()
             }
         })
 
         it('rejects malformed SMTPS PROXY lines before TLS', async () => {
-            const originalAllowed = net_utils.is_haproxy_allowed
-            net_utils.is_haproxy_allowed = () => true
+            const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -533,15 +545,14 @@ describe('server', () => {
                 const [response] = await withTimeout(once(raw, 'data'), 3000, 'malformed PROXY response timed out')
                 assert.match(response.toString(), /^421 Invalid PROXY format/)
             } finally {
-                net_utils.is_haproxy_allowed = originalAllowed
                 if (raw) raw.destroy()
                 await close(server)
+                restoreHaproxyConfig()
             }
         })
 
         it('rejects oversized SMTPS PROXY lines before TLS', async () => {
-            const originalAllowed = net_utils.is_haproxy_allowed
-            net_utils.is_haproxy_allowed = () => true
+            const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -557,16 +568,15 @@ describe('server', () => {
                 const [response] = await withTimeout(once(raw, 'data'), 3000, 'oversized PROXY response timed out')
                 assert.match(response.toString(), /^421 Invalid PROXY format/)
             } finally {
-                net_utils.is_haproxy_allowed = originalAllowed
                 if (raw) raw.destroy()
                 await close(server)
+                restoreHaproxyConfig()
             }
         })
 
         it('times out waiting for SMTPS PROXY from an allowed peer', async () => {
-            const originalAllowed = net_utils.is_haproxy_allowed
+            const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             const originalSetTimeout = global.setTimeout
-            net_utils.is_haproxy_allowed = () => true
             global.setTimeout = (fn, ms, ...args) => originalSetTimeout(fn, ms === 30 * 1000 ? 20 : ms, ...args)
             this.server.cfg.main.smtps_port = 0
 
@@ -582,16 +592,15 @@ describe('server', () => {
                 const [response] = await withTimeout(once(raw, 'data'), 3000, 'PROXY timeout response timed out')
                 assert.match(response.toString(), /^421 PROXY timeout/)
             } finally {
-                net_utils.is_haproxy_allowed = originalAllowed
                 global.setTimeout = originalSetTimeout
                 if (raw) raw.destroy()
                 await close(server)
+                restoreHaproxyConfig()
             }
         })
 
         it('accepts byte-by-byte direct SMTPS from a PROXY-allowed peer', async () => {
-            const originalAllowed = net_utils.is_haproxy_allowed
-            net_utils.is_haproxy_allowed = () => true
+            const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
             const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
@@ -648,10 +657,10 @@ describe('server', () => {
                 )
                 assert.match(banner.toString(), /^220 /)
             } finally {
-                net_utils.is_haproxy_allowed = originalAllowed
                 if (client) client.destroy()
                 else if (raw) raw.destroy()
                 await close(server)
+                restoreHaproxyConfig()
             }
         })
     })

--- a/test/server.js
+++ b/test/server.js
@@ -294,7 +294,9 @@ describe('server', () => {
             const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            // PROXY-before-TLS takes slightly longer than the default 10 ms timeout on Windows,
+            // use 50 ms timeout to avoid flaky tests (default is 300000 ms).
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 50)
             const tlsErrors = []
             let raw
             let client
@@ -350,7 +352,7 @@ describe('server', () => {
             const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
             const tlsErrors = []
             let client
 
@@ -391,7 +393,7 @@ describe('server', () => {
         it('preserves TLS server events for SMTPS connections', async () => {
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
             let ocspRequests = 0
             let first
             let second
@@ -465,7 +467,7 @@ describe('server', () => {
             let client
 
             try {
-                server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+                server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
                 assert.equal(server.tlsServer, undefined)
 
                 await listen(server)
@@ -498,7 +500,7 @@ describe('server', () => {
             const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_untrusted')
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
             let client
 
             try {
@@ -532,7 +534,7 @@ describe('server', () => {
             const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
             let raw
 
             try {
@@ -555,7 +557,7 @@ describe('server', () => {
             const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
             let raw
 
             try {
@@ -580,7 +582,7 @@ describe('server', () => {
             global.setTimeout = (fn, ms, ...args) => originalSetTimeout(fn, ms === 30 * 1000 ? 20 : ms, ...args)
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
             let raw
 
             try {
@@ -603,7 +605,7 @@ describe('server', () => {
             const restoreHaproxyConfig = useHaproxyFixture(this.server, 'haproxy_allowed')
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
             let raw
             let client
 

--- a/test/server.js
+++ b/test/server.js
@@ -278,7 +278,7 @@ describe('server', () => {
             connection.is_haproxy_allowed = () => true
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
             const tlsErrors = []
             let raw
             let client
@@ -336,7 +336,7 @@ describe('server', () => {
             connection.is_haproxy_allowed = () => true
             this.server.cfg.main.smtps_port = 0
 
-            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10)
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
             const tlsErrors = []
             let client
 
@@ -370,6 +370,294 @@ describe('server', () => {
             } finally {
                 connection.is_haproxy_allowed = originalAllowed
                 if (client) client.destroy()
+                await close(server)
+            }
+        })
+
+        it('preserves TLS server events for SMTPS connections', async () => {
+            this.server.cfg.main.smtps_port = 0
+
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            let ocspRequests = 0
+            let first
+            let second
+
+            server.tlsServer.on('OCSPRequest', (cert, issuer, cb) => {
+                ocspRequests++
+                cb()
+            })
+
+            try {
+                await listen(server)
+
+                first = tls.connect({
+                    port: server.address().port,
+                    host: '127.0.0.1',
+                    rejectUnauthorized: false,
+                    requestOCSP: true,
+                    servername: 'localhost',
+                    maxVersion: 'TLSv1.2',
+                })
+
+                await withTimeout(
+                    Promise.race([
+                        once(first, 'secureConnect'),
+                        once(first, 'error').then(([err]) => {
+                            throw err
+                        }),
+                    ]),
+                    3000,
+                    'first SMTPS handshake timed out',
+                )
+                const session = first.getSession()
+                first.destroy()
+                await withTimeout(once(first, 'close'), 3000, 'first SMTPS close timed out')
+
+                second = tls.connect({
+                    port: server.address().port,
+                    host: '127.0.0.1',
+                    rejectUnauthorized: false,
+                    requestOCSP: true,
+                    servername: 'localhost',
+                    maxVersion: 'TLSv1.2',
+                    session,
+                })
+
+                await withTimeout(
+                    Promise.race([
+                        once(second, 'secureConnect'),
+                        once(second, 'error').then(([err]) => {
+                            throw err
+                        }),
+                    ]),
+                    3000,
+                    'resumed SMTPS handshake timed out',
+                )
+
+                assert.equal(ocspRequests, 1)
+                assert.equal(second.isSessionReused(), true)
+            } finally {
+                if (second) second.destroy()
+                if (first) first.destroy()
+                await close(server)
+            }
+        })
+
+        it('uses direct TLS for SMTPS when HAProxy support is disabled', async () => {
+            const connection = require('../connection')
+            const originalEnabled = connection.is_haproxy_enabled
+            connection.is_haproxy_enabled = () => false
+            this.server.cfg.main.smtps_port = 0
+
+            let server
+            let client
+
+            try {
+                server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+                assert.equal(server.tlsServer, undefined)
+
+                await listen(server)
+
+                client = tls.connect({
+                    port: server.address().port,
+                    host: '127.0.0.1',
+                    rejectUnauthorized: false,
+                    servername: 'localhost',
+                })
+
+                await withTimeout(
+                    Promise.race([
+                        once(client, 'secureConnect'),
+                        once(client, 'error').then(([err]) => {
+                            throw err
+                        }),
+                    ]),
+                    3000,
+                    'direct TLS fallback handshake timed out',
+                )
+            } finally {
+                connection.is_haproxy_enabled = originalEnabled
+                if (client) client.destroy()
+                if (server) await close(server)
+            }
+        })
+
+        it('accepts direct SMTPS from an untrusted PROXY peer', async () => {
+            const connection = require('../connection')
+            const originalAllowed = connection.is_haproxy_allowed
+            connection.is_haproxy_allowed = () => false
+            this.server.cfg.main.smtps_port = 0
+
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            let client
+
+            try {
+                await listen(server)
+
+                client = tls.connect({
+                    port: server.address().port,
+                    host: '127.0.0.1',
+                    rejectUnauthorized: false,
+                    servername: 'localhost',
+                })
+
+                await withTimeout(
+                    Promise.race([
+                        once(client, 'secureConnect'),
+                        once(client, 'error').then(([err]) => {
+                            throw err
+                        }),
+                    ]),
+                    3000,
+                    'untrusted direct SMTPS handshake timed out',
+                )
+            } finally {
+                connection.is_haproxy_allowed = originalAllowed
+                if (client) client.destroy()
+                await close(server)
+            }
+        })
+
+        it('rejects malformed SMTPS PROXY lines before TLS', async () => {
+            const connection = require('../connection')
+            const originalAllowed = connection.is_haproxy_allowed
+            connection.is_haproxy_allowed = () => true
+            this.server.cfg.main.smtps_port = 0
+
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            let raw
+
+            try {
+                await listen(server)
+
+                raw = net.connect(server.address().port, '127.0.0.1')
+                await withTimeout(once(raw, 'connect'), 3000, 'malformed PROXY TCP connection timed out')
+                raw.write('PROXY TCP4 nope 127.0.0.1 42310 465\r\n')
+
+                const [response] = await withTimeout(once(raw, 'data'), 3000, 'malformed PROXY response timed out')
+                assert.match(response.toString(), /^421 Invalid PROXY format/)
+            } finally {
+                connection.is_haproxy_allowed = originalAllowed
+                if (raw) raw.destroy()
+                await close(server)
+            }
+        })
+
+        it('rejects oversized SMTPS PROXY lines before TLS', async () => {
+            const connection = require('../connection')
+            const originalAllowed = connection.is_haproxy_allowed
+            connection.is_haproxy_allowed = () => true
+            this.server.cfg.main.smtps_port = 0
+
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            let raw
+
+            try {
+                await listen(server)
+
+                raw = net.connect(server.address().port, '127.0.0.1')
+                await withTimeout(once(raw, 'connect'), 3000, 'oversized PROXY TCP connection timed out')
+                raw.write(`PROXY ${'x'.repeat(513)}`)
+
+                const [response] = await withTimeout(once(raw, 'data'), 3000, 'oversized PROXY response timed out')
+                assert.match(response.toString(), /^421 Invalid PROXY format/)
+            } finally {
+                connection.is_haproxy_allowed = originalAllowed
+                if (raw) raw.destroy()
+                await close(server)
+            }
+        })
+
+        it('times out waiting for SMTPS PROXY from an allowed peer', async () => {
+            const connection = require('../connection')
+            const originalAllowed = connection.is_haproxy_allowed
+            const originalSetTimeout = global.setTimeout
+            connection.is_haproxy_allowed = () => true
+            global.setTimeout = (fn, ms, ...args) => originalSetTimeout(fn, ms === 30 * 1000 ? 20 : ms, ...args)
+            this.server.cfg.main.smtps_port = 0
+
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            let raw
+
+            try {
+                await listen(server)
+
+                raw = net.connect(server.address().port, '127.0.0.1')
+                await withTimeout(once(raw, 'connect'), 3000, 'PROXY timeout TCP connection timed out')
+
+                const [response] = await withTimeout(once(raw, 'data'), 3000, 'PROXY timeout response timed out')
+                assert.match(response.toString(), /^421 PROXY timeout/)
+            } finally {
+                connection.is_haproxy_allowed = originalAllowed
+                global.setTimeout = originalSetTimeout
+                if (raw) raw.destroy()
+                await close(server)
+            }
+        })
+
+        it('accepts byte-by-byte direct SMTPS from a PROXY-allowed peer', async () => {
+            const connection = require('../connection')
+            const originalAllowed = connection.is_haproxy_allowed
+            connection.is_haproxy_allowed = () => true
+            this.server.cfg.main.smtps_port = 0
+
+            const server = await this.server.get_smtp_server(endpoint('127.0.0.1:0'), 10000)
+            let raw
+            let client
+
+            try {
+                await listen(server)
+
+                raw = net.connect(server.address().port, '127.0.0.1')
+                await withTimeout(once(raw, 'connect'), 3000, 'fragmented direct SMTPS TCP connection timed out')
+
+                const write = raw.write.bind(raw)
+                raw.write = (chunk, encoding, cb) => {
+                    if (typeof encoding === 'function') {
+                        cb = encoding
+                        encoding = undefined
+                    }
+                    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding)
+                    let pos = 0
+                    const write_next = () => {
+                        if (pos >= buffer.length) {
+                            if (cb) cb()
+                            return
+                        }
+                        write(buffer.subarray(pos, pos + 1))
+                        pos++
+                        setImmediate(write_next)
+                    }
+                    write_next()
+                    return true
+                }
+
+                client = tls.connect({
+                    socket: raw,
+                    rejectUnauthorized: false,
+                    servername: 'localhost',
+                })
+
+                await withTimeout(
+                    Promise.race([
+                        once(client, 'secureConnect'),
+                        once(client, 'error').then(([err]) => {
+                            throw err
+                        }),
+                    ]),
+                    3000,
+                    'fragmented direct SMTPS handshake timed out',
+                )
+                const [banner] = await withTimeout(
+                    once(client, 'data'),
+                    3000,
+                    'fragmented direct SMTPS banner timed out',
+                )
+                assert.match(banner.toString(), /^220 /)
+            } finally {
+                connection.is_haproxy_allowed = originalAllowed
+                if (client) client.destroy()
+                else if (raw) raw.destroy()
                 await close(server)
             }
         })


### PR DESCRIPTION
Previously, SMTPS used `tls.createServer`, so OpenSSL expected the first bytes on the connection to be a TLS ClientHello. When proxies sent a plaintext `PROXY` header first, OpenSSL interpreted that header as TLS and failed with errors like `wrong version number` or `packet length too long`, as mentioned in #3105.

This PR adds support for SMTPS behind proxies by pre-reading the `PROXY` line before starting the TLS handshake. That lets Haraka consume and validate the cleartext `PROXY` header before handing the remaining bytes to Node’s TLS layer.

Proxy parsing logic in `connection.js` was refactored through some reusable functions extracted from `Connection.cmd_proxy` so `Server.create_smtps_server` can parse and validate the `PROXY` line before starting the TLS handshake.

SMTPS now starts with a raw `net.createServer` for the initial TCP connection. If the peer is trusted and the first bytes begin with `PROXY` then the socket is wrapped in TLS with `start_tls_with_buffer`. If the connection started with a TLS handshake rather than `PROXY` or the IP is not a trusted peer, the socket is wrapped with TLS via `start_tls`, or `start_tls_with_buffer` (to unshift any bytes we inspected before starting TLS).

Fixes #3105

Verified:
- `node --test test/server.js test/connection.js`
- Manually tested SMTPS behind Traefik / Nginx / HAProxy with PROXY Protocol v1

Checklist:
- [ ] docs updated
- [x] tests updated
- [ ] [CHANGELOG](https://github.com/haraka/Haraka/blob/master/CHANGELOG.md) updated