### PR TITLE
Release 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1895,4 +1895,4 @@ config files.
 [3.1.7]: https://github.com/haraka/Haraka/releases/tag/v3.1.7
 [3.2.0]: https://github.com/haraka/Haraka/releases/tag/v3.2.0
 [3.2.1]: https://github.com/haraka/Haraka/releases/tag/v3.2.1
-[3.3.0]: https://github.com/haraka/Haraka/releases/tag/v3.3.0
+[3.3.1]: https://github.com/haraka/Haraka/releases/tag/v3.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [3.3.0] - 2026-06-05
+
 - fix(conn): flag soft queue denials in results
 - feat: expose fetch to plugins
+- change: remove @haraka/email-address wrapper #3598
+- change: log when MFROM or RCPT fail to parse #3581
 - fix: change package name from Haraka to haraka #3596
-- fix(haraka): wrap util.createFile in a try
+- fix(haraka): wrap util.createFile in a try #3595
 - fix(conn): update local and remote results after proxy #3593
 - feat(conn): add main.postel option #3592
-- change: log when MFROM or RCPT fail to parse #3581
 - feat: proxy support for smtps (465) #3577
 - refactor(auth_proxy): use net_utils.endpoint #3584
 - refactor: move endpoint, HostPool, LineSocket to net-utils #3583
@@ -1892,3 +1895,4 @@ config files.
 [3.1.7]: https://github.com/haraka/Haraka/releases/tag/v3.1.7
 [3.2.0]: https://github.com/haraka/Haraka/releases/tag/v3.2.0
 [3.2.1]: https://github.com/haraka/Haraka/releases/tag/v3.2.1
+[3.3.0]: https://github.com/haraka/Haraka/releases/tag/v3.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
-### [3.3.0] - 2026-06-05
+### [3.3.1] - 2026-06-12
 
 - fix(conn): flag soft queue denials in results
 - feat: expose fetch to plugins

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "server",
     "email"
   ],
-  "version": "3.3.0",
+  "version": "3.3.1",
   "homepage": "http://haraka.github.io",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "server",
     "email"
   ],
-  "version": "3.2.1",
+  "version": "3.3.0",
   "homepage": "http://haraka.github.io",
   "repository": {
     "type": "git",

--- a/server.js
+++ b/server.js
@@ -11,10 +11,10 @@ const tls = require('node:tls')
 const constants = require('haraka-constants')
 const net_utils = require('haraka-net-utils')
 
+const { endpoint } = require('haraka-net-utils')
 const tls_socket = require('./tls_socket')
 const conn = require('./connection')
 const outbound = require('./outbound')
-const { endpoint } = net_utils
 
 const Server = exports
 Server.logger = require('./logger')

--- a/test/smtp_client.js
+++ b/test/smtp_client.js
@@ -340,8 +340,6 @@ describe('SMTPClient socket connect event', () => {
         socket.setTimeout = (ms) => {
             lastTimeout = ms
         }
-        // constructing the client is what registers the 'connect' handler on
-        // the socket; the binding is unused, but the side effect is required
         makeClient({ socket, idle_timeout: 120 })
         socket.emit('connect')
         assert.equal(lastTimeout, 120_000)


### PR DESCRIPTION
- feat(conn): add main.postel option #3592 
- change: log when MFROM or RCPT fail to parse #3581
- feat: proxy support for smtps (465) #3577
- refactor(auth_proxy): use net_utils.endpoint #3584
- refactor: move endpoint, HostPool, LineSocket to net-utils #3583
- refactor: move rfc1869, FsyncWriteStream, TimerQueue to haraka-utils #3585
- refactor: move cram_md5_response to haraka-utils #3585
- dep(many): bump to latest #3587
- dep(eslint): update @haraka/eslint-config to v3, #3586
- dep(haraka-utils): ~2.1.1 for position-aware MAIL/RCPT address errors
- build: add qlty config and README badge #3588
- test: update to test-fixtures 1.7.0 helpers #3589
