### PR TITLE
fix(proxy): update local and remote results to new values after proxy header is parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix(proxy): update local and remote results to new values after proxy header is parsed
 - build: add qlty config and README badge
 - refactor: move rfc1869 to haraka-utils
 - refactor: move FsyncWriteStream to haraka-utils

--- a/connection.js
+++ b/connection.js
@@ -1172,6 +1172,8 @@ class Connection {
             this.set('remote.port', parseInt(src_port, 10))
             this.set('remote.host', null)
             this.set('hello.host', null)
+            this.results.add({name: 'local'},  this.local);
+            this.results.add({name: 'remote'}, this.remote);
             plugins.run_hooks('connect_init', this)
         })
     }


### PR DESCRIPTION
After the proxy header is parsed, Haraka updates `connection.local` and `connection.remote`, but the values in `connection.results` are not updated. This PR updates `results` accordingly.

> [!NOTE]  
> Should the `hello` result be updated as well?

Checklist:

- [ ] docs updated
- [ ] tests updated
- [x] [CHANGELOG](https://github.com/haraka/Haraka/blob/master/CHANGELOG.md) updated
