### PR TITLE
meta: change .name from Haraka -> haraka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix: change package name from Haraka to haraka #3596
 - fix(haraka): wrap util.createFile in a try
 - fix(conn): update local and remote results after proxy #3593
 - feat(conn): add main.postel option #3592

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "author": "Matt Sergeant <helpme@gmail.com> (http://baudehlo.com/)",
-  "name": "Haraka",
+  "author": "Matt Sergeant <helpme@gmail.com>",
+  "name": "haraka",
   "license": "MIT",
   "description": "An SMTP Server project.",
   "keywords": [
@@ -77,8 +77,8 @@
     "url": "https://github.com/haraka/Haraka/issues"
   },
   "bin": {
-    "haraka": "./bin/haraka",
-    "haraka_grep": "./bin/haraka_grep"
+    "haraka": "bin/haraka",
+    "haraka_grep": "bin/haraka_grep"
   },
   "scripts": {
     "prepare": "git rev-parse --git-dir >/dev/null 2>&1 && git config core.hooksPath .githooks || true",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   "devDependencies": {
     "@haraka/eslint-config": "~3.0.0",
     "haraka-test-fixtures": "^1.7.1",
-    "mock-require": "~3.0.3"
+    "mock-require": "~3.0.3",
+    "toobusy-js": "^0.5.1"
   },
   "bugs": {
     "mail": "haraka.mail@gmail.com",

--- a/test/plugins/toobusy.js
+++ b/test/plugins/toobusy.js
@@ -1,21 +1,198 @@
 'use strict'
 
 const assert = require('node:assert/strict')
-const { describe, it } = require('node:test')
+const { beforeEach, describe, it } = require('node:test')
 
-const { makePlugin } = require('haraka-test-fixtures')
+const { makeConnection, makePlugin } = require('haraka-test-fixtures')
+require('haraka-constants').import(global)
 
 describe('toobusy', () => {
+    let plugin
+
+    beforeEach(() => {
+        plugin = makePlugin('toobusy', { register: false })
+    })
+
     describe('register', () => {
-        it('handles missing toobusy-js gracefully (does not throw)', () => {
-            const plugin = makePlugin('toobusy', { register: false })
-            // toobusy-js is not installed; register should catch the error and return
-            let registered = false
-            plugin.register_hook = () => {
-                registered = true
+        it('registers connect hook with correct priority', () => {
+            const hooks = []
+            plugin.register_hook = function (hook, name, priority) {
+                hooks.push({ hook, name, priority })
             }
+
+            plugin.register()
+
+            assert.equal(hooks.length, 1, 'should register one hook')
+            assert.equal(hooks[0].hook, 'connect')
+            assert.equal(hooks[0].name, 'check_busy')
+            assert.equal(hooks[0].priority, -100)
+        })
+
+        it('loads config on register', () => {
+            let loadConfigCalled = false
+            const originalLoadConfig = plugin.loadConfig
+            plugin.loadConfig = function () {
+                loadConfigCalled = true
+                return originalLoadConfig.call(this)
+            }
+
+            plugin.register()
+
+            assert.equal(loadConfigCalled, true, 'loadConfig should be called')
+        })
+
+        it('handles missing toobusy-js gracefully', () => {
             assert.doesNotThrow(() => plugin.register())
-            assert.equal(registered, false, 'hook should not be registered without toobusy-js')
+        })
+    })
+
+    describe('loadConfig', () => {
+        beforeEach(() => {
+            plugin.register()
+        })
+
+        it('gets toobusy.maxlag config value', () => {
+            let configArgs = []
+
+            plugin.config.get = function (key, type, callback) {
+                configArgs = [key, type]
+                return '70'
+            }
+
+            plugin.loadConfig()
+
+            assert.equal(configArgs[0], 'toobusy.maxlag')
+            assert.equal(configArgs[1], 'value')
+        })
+
+        it('passes callback to config.get for hot reload', () => {
+            let callbackProvided = false
+
+            plugin.config.get = function (key, type, callback) {
+                callbackProvided = typeof callback === 'function'
+                return '70'
+            }
+
+            plugin.loadConfig()
+
+            assert.equal(callbackProvided, true, 'callback should be provided for hot reload')
+        })
+
+        it('handles zero maxLag value', () => {
+            plugin.config.get = () => '0'
+
+            assert.doesNotThrow(() => {
+                plugin.loadConfig()
+            })
+        })
+
+        it('handles non-numeric maxLag value', () => {
+            plugin.config.get = () => 'notanumber'
+
+            assert.doesNotThrow(() => {
+                plugin.loadConfig()
+            })
+        })
+
+        it('handles empty string maxLag value', () => {
+            plugin.config.get = () => ''
+
+            assert.doesNotThrow(() => {
+                plugin.loadConfig()
+            })
+        })
+
+        it('parses numeric maxLag as integer', () => {
+            plugin.config.get = () => '100'
+
+            assert.doesNotThrow(() => {
+                plugin.loadConfig()
+            })
+        })
+
+        it('supports reload via callback', () => {
+            let callbackFn = null
+
+            plugin.config.get = function (key, type, callback) {
+                callbackFn = callback
+                return '70'
+            }
+
+            plugin.loadConfig()
+
+            assert.equal(typeof callbackFn, 'function', 'callback should be provided')
+            assert.doesNotThrow(() => {
+                if (callbackFn) callbackFn()
+            })
+        })
+    })
+
+    describe('check_busy', () => {
+        beforeEach(() => {
+            plugin.register()
+        })
+
+        it('calls next without args when not busy', (t, done) => {
+            plugin.config.get = () => '70'
+            plugin.loadConfig()
+
+            plugin.check_busy(function (...args) {
+                assert.equal(args.length, 0, 'should call next with no arguments')
+                done()
+            })
+        })
+
+        it('initializes was_busy state', (t, done) => {
+            plugin.config.get = () => '70'
+            plugin.loadConfig()
+
+            plugin.check_busy(function () {
+                done()
+            })
+        })
+
+        it('is a callable function', () => {
+            assert.equal(typeof plugin.check_busy, 'function')
+        })
+
+        it('does not log when not busy', (t, done) => {
+            plugin.config.get = () => '70'
+            plugin.loadConfig()
+
+            let logCount = 0
+            plugin.logcrit = function () {
+                logCount++
+            }
+
+            plugin.check_busy(function () {
+                plugin.check_busy(function () {
+                    assert.equal(logCount, 0, 'should not log when not busy')
+                    done()
+                })
+            })
+        })
+
+        it('accepts next callback', (t, done) => {
+            plugin.config.get = () => '70'
+            plugin.loadConfig()
+
+            const nextFn = function () {
+                done()
+            }
+
+            assert.doesNotThrow(() => {
+                plugin.check_busy(nextFn)
+            })
+        })
+
+        it('works with connection context', (t, done) => {
+            plugin.config.get = () => '70'
+            plugin.loadConfig()
+
+            const conn = makeConnection()
+            plugin.check_busy.call(conn, function () {
+                done()
+            })
         })
     })
 })


### PR DESCRIPTION
- `npm pkg fix`, strips the ./ from the bin entries
- remove baudehlo.com URL, it doesn't resolve

TL;DR

Haraka is old enough that we got a uppercase letter in our NPM package name before the restriction went into place. However, somer newer software isn't aware or doesn't care and assumes ONLY all-lower-case names are valid. We've skated by without complications for a long time, but the party is getting late and having an upper-case letter is becoming technical debt. I'm on a technical debt erasing binge.

Now that I've got publishing automated, Haraka will be dual published as 'haraka' and 'Haraka'. After a suitable period of mourning (and watching _Haraka_'s install stats fall while *haraka* install stats climb, I'll take 'Haraka' out back and put her down.
